### PR TITLE
Update editor alignment to match front end

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -130,6 +130,15 @@ function twentynineteen_scripts() {
 add_action( 'wp_enqueue_scripts', 'twentynineteen_scripts' );
 
 /**
+ * Enqueue supplemental block editor styles
+ */
+function twentynineteen_editor_frame_styles() {
+    wp_enqueue_style( 'twentynineteen-editor-frame-styles', get_theme_file_uri( '/style-editor-frame.css' ), false, '1.0', 'all' );
+}
+
+add_action( 'enqueue_block_editor_assets', 'twentynineteen_editor_frame_styles' );
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class.twentynineteen-svg-icons.php';

--- a/style-editor-frame.css
+++ b/style-editor-frame.css
@@ -28,3 +28,24 @@ body.gutenberg-editor-page .gutenberg .editor-post-title__block .editor-post-tit
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 2.8125em;
 }
+
+/** === Off-Center Content === */
+@media all and (min-width: 768px) {
+  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-writing-flow {
+    display: grid;
+    grid-template-columns: 10% 80% 10%;
+  }
+  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-writing-flow > div {
+    grid-column-start: 2;
+  }
+  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-post-title__block,
+  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-block-list__block {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-block-list__block[data-align="full"] {
+    width: 136%;
+    position: relative;
+    left: -18%;
+  }
+}

--- a/style-editor-frame.css
+++ b/style-editor-frame.css
@@ -1,0 +1,30 @@
+/*!
+Twenty Nineteen Editor Frame Styles
+*/
+/** === Includes === */
+/* If we add the border using a regular CSS border, it won't look good on non-retina devices,
+ * since its edges can look jagged due to lack of antialiasing. In this case, we are several
+ * layers of box-shadow to add the border visually, which will render the border smoother. */
+/** === Title === */
+body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
+  background: #919191;
+  content: "\020";
+  display: block;
+  height: 2px;
+  margin: 1rem 0;
+  width: 1em;
+}
+
+body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
+  width: 2.8125em;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 1em;
+  position: relative;
+  top: 0.5em;
+}
+
+body.gutenberg-editor-page .gutenberg .editor-post-title__block .editor-post-title__input {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 2.8125em;
+}

--- a/style-editor-frame.scss
+++ b/style-editor-frame.scss
@@ -27,3 +27,31 @@ body.gutenberg-editor-page .gutenberg .editor-post-title__block {
 		font-size: $font__size-xxl;
 	}
 }
+
+/** === Off-Center Content === */
+
+body.gutenberg-editor-page .gutenberg .edit-post-layout {
+
+	@media all and (min-width: $tablet_width ) {
+		.editor-writing-flow {
+			display: grid;
+			grid-template-columns: 10% 80% 10%;
+
+			> div {
+				grid-column-start: 2;
+			}
+		}
+
+		.editor-post-title__block,
+		.editor-block-list__block {
+			margin-left: 0;
+			margin-right: 0;
+		}
+
+		.editor-block-list__block[data-align="full"] {
+			width: 136%;
+			position: relative;
+			left: -18%;
+		}
+	}
+}

--- a/style-editor-frame.scss
+++ b/style-editor-frame.scss
@@ -1,0 +1,29 @@
+/*!
+Twenty Nineteen Editor Frame Styles
+*/
+
+/** === Includes === */
+
+@import "sass/variables-site/variables-site";
+@import "sass/variables-site/colors";
+@import "sass/mixins/mixins-master";
+
+/** === Title === */
+
+body.gutenberg-editor-page .gutenberg .editor-post-title__block {
+	@include post-section-dash;
+
+	&:before {
+		width: $font__size-xxl;
+		margin-top: 0;
+		margin-bottom: 0;
+		margin-left: 1em;
+		position: relative;
+		top: 0.5em;
+	}
+
+	.editor-post-title__input {
+		font-family: $font__heading;
+		font-size: $font__size-xxl;
+	}
+}


### PR DESCRIPTION
The front end of the theme left-aligns all content, and lets wide width blocks extend beyond the text column on the right. We need to match the front end to the back end as much as possible, so this PR is a rough first stab at getting that alignment in place. 

- Gutenberg currently auto-prefixes editor block stylesheets. That won't work for us here since these styles need to effect the frame of the page, not just individual blocks. Until a solution for that it sorted out, this introduces a second editor stylesheet. (This also allows us to customize the page title.)
- So far, this doesn't effect any items that are aligned to the right. Those should end up hanging off the right of the text column too. 
- Once we have this working on the back end, we'll likely want to post the markup over to the frontend so it matches. 

_Before:_ 
![screen shot 2018-10-16 at 10 41 00 am](https://user-images.githubusercontent.com/1202812/47024607-0ce88300-d130-11e8-90ee-55807f93647d.png)

_After:_
![screen shot 2018-10-16 at 10 40 30 am](https://user-images.githubusercontent.com/1202812/47024612-0eb24680-d130-11e8-96d4-4e26ae53726d.png)
