### PR TITLE
Adds async/defer capability to JavaScript loading

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -117,7 +117,8 @@ add_action( 'after_setup_theme', 'twentynineteen_content_width', 0 );
 function twentynineteen_scripts() {
 	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri() );
 
-	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
+	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', false );
+	wp_script_add_data( 'twentynineteen-skip-link-focus-fix', 'defer', true );
 
 	if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) {
 		wp_add_inline_style( 'twentynineteen-style', twentynineteen_header_featured_image_css() );

--- a/functions.php
+++ b/functions.php
@@ -118,7 +118,6 @@ function twentynineteen_scripts() {
 	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri() );
 
 	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', false );
-	wp_script_add_data( 'twentynineteen-skip-link-focus-fix', 'defer', true );
 
 	if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) {
 		wp_add_inline_style( 'twentynineteen-style', twentynineteen_header_featured_image_css() );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -32,6 +32,37 @@ function twentynineteen_body_classes( $classes ) {
 add_filter( 'body_class', 'twentynineteen_body_classes' );
 
 /**
+ * Adds async/defer attributes to enqueued / registered scripts.
+ *
+ * If #12009 lands in WordPress, this function can no-op since it would be handled in core.
+ *
+ * @link https://core.trac.wordpress.org/ticket/12009
+ * @param string $tag    The script tag.
+ * @param string $handle The script handle.
+ * @return array
+ */
+function twentynineteen_filter_script_loader_tag( $tag, $handle ) {
+
+	foreach ( array( 'async', 'defer' ) as $attr ) {
+		if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
+			continue;
+		}
+
+		// Prevent adding attribute when already added in #12009.
+		if ( ! preg_match( ":\s$attr(=|>|\s):", $tag ) ) {
+			$tag = preg_replace( ':(?=></script>):', " $attr", $tag, 1 );
+		}
+
+		// Only allow async or defer, not both.
+		break;
+	}
+
+	return $tag;
+}
+
+add_filter( 'script_loader_tag', 'twentynineteen_filter_script_loader_tag', 10, 2 );
+
+/**
  * Add a pingback url auto-discovery header for single posts, pages, or attachments.
  */
 function twentynineteen_pingback_header() {


### PR DESCRIPTION
- Adds `async`/`defer` capability to JavaScript loading.
- Defers loading of `twentynineteen-skip-link-focus-fix` to improve performance.

`async`/`defer` is [new best practice for JS loading](https://developers.google.com/speed/docs/insights/BlockingJS) and should be used for all enqueued JS on the front end in place of loading in footer. This feature allows control of JS loading by adding the following code to any enqueued script:

```php
wp_script_add_data( '[label]', '[async/defer]', true );
```

Corresponds with https://core.trac.wordpress.org/ticket/12009 and gracefully falls back if/when this feature is added to core.

Code by @westonruter, originally contributed to [WP Rig](https://github.com/wprig/wprig)