### PR TITLE
Add Travis config modified from Twenty Seventeen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Files to exclude when creating archive.
+
+*.git export-ignore
+*.gitignore export-ignore
+*.gitattributes export-ignore
+.travis.yml export-ignore
+CONTRIBUTING.md export-ignore
+CONTRIBUTORS.md export-ignore
+phpcs.xml.dist export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,13 +59,16 @@ before_script:
     - sed -i "s/yourpasswordhere//" wp-tests-config.php
     # Create WordPress database.
     - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
-    # Install CodeSniffer for WordPress Coding Standards checks.
-    - wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-    # Install WordPress Coding Standards.
-    - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
-    # Set install path for WordPress Coding Standards
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - php phpcs.phar --config-set installed_paths wordpress-coding-standards
+    - |
+      if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]] && [[ ${TRAVIS_PHP_VERSION:0:3} != "5.3" ]]; then
+        # Install CodeSniffer for WordPress Coding Standards checks.
+        wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+        # Install WordPress Coding Standards.
+        mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
+        # Set install path for WordPress Coding Standards
+        # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+        php phpcs.phar --config-set installed_paths $(pwd)/wordpress-coding-standards
+      fi
     # Hop into themes directory.
     - cd $theme_dir
     # After CodeSniffer install you should refresh your path.
@@ -92,4 +95,4 @@ script:
     # -n flag: Do not print warnings (shortcut for --warning-severity=0)
     # --standard: Use WordPress as the standard.
     # --extensions: Only sniff PHP files.
-    - php $WP_DEVELOP_DIR/phpcs.phar -p -s -v -n . --extensions=php
+    - if [ -e $WP_DEVELOP_DIR/phpcs.phar ]; then php $WP_DEVELOP_DIR/phpcs.phar -p -s -v -n . --extensions=php; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 # Travis CI configuration file.
 # @link https://travis-ci.org/
 
-# For use with the Twenty Seventeen WordPress theme
-# @link https://github.com/WordPress/twentyseventeen/
+# For use with the Twenty Nineteen WordPress theme
+# @link https://github.com/WordPress/twentynineteen/
 
 # Declare project language and PHP versions to test against.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
+
+# Newer versions like trusty don't have PHP 5.2 or 5.3
+# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+dist: precise
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
@@ -41,7 +45,7 @@ before_script:
     - mkdir -p $WP_DEVELOP_DIR
     # Use the Git mirror of WordPress.
     - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
-    # Set up Twenty Seventeen theme information.
+    # Set up Twenty Nineteen theme information.
     - theme_slug=$(basename $(pwd))
     - theme_dir=$WP_DEVELOP_DIR/src/wp-content/themes/$theme_slug
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ dist: precise
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
+    - "7.3"
     - "7.2"
     - "7.1"
     - "7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,93 @@
+# Travis CI configuration file.
+# @link https://travis-ci.org/
+
+# For use with the Twenty Seventeen WordPress theme
+# @link https://github.com/WordPress/twentyseventeen/
+
+# Declare project language and PHP versions to test against.
+# @link http://about.travis-ci.org/docs/user/languages/php/
+language: php
+
+# Declare versions of PHP to use. Use one decimal max.
+php:
+    - "7.2"
+    - "7.1"
+    - "7.0"
+    - "5.6"
+    - "5.5"
+    - "5.4"
+    - "5.3"
+    # Current $required_php_version for WordPress: 5.2.4
+    - "5.2"
+
+# Ditch sudo and use containers.
+# @link http://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F
+# @link http://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure
+sudo: false
+
+# Declare which versions of WordPress to test against.
+# Also declare whether or not to test in Multisite.
+env:
+    # Current version in development is 5.0.
+    # @link https://github.com/WordPress/WordPress
+    - WP_VERSION=5.0 WP_MULTISITE=0
+
+# Use this to prepare your build for testing.
+# e.g. copy database configurations, environment variables, etc.
+# Failures in this section will result in build status 'errored'.
+before_script:
+    # Set up WordPress installation.
+    - export WP_DEVELOP_DIR=/tmp/wordpress/
+    - mkdir -p $WP_DEVELOP_DIR
+    # Use the Git mirror of WordPress.
+    - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
+    # Set up Twenty Seventeen theme information.
+    - theme_slug=$(basename $(pwd))
+    - theme_dir=$WP_DEVELOP_DIR/src/wp-content/themes/$theme_slug
+    - cd ..
+    - mv $theme_slug $theme_dir
+    # Set up WordPress configuration.
+    - cd $WP_DEVELOP_DIR
+    - echo $WP_DEVELOP_DIR
+    - cp wp-tests-config-sample.php wp-tests-config.php
+    - sed -i "s/youremptytestdbnamehere/wordpress_test/" wp-tests-config.php
+    - sed -i "s/yourusernamehere/root/" wp-tests-config.php
+    - sed -i "s/yourpasswordhere//" wp-tests-config.php
+    # Create WordPress database.
+    - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    - mkdir php-codesniffer && curl -L https://github.com/squizlabs/PHP_CodeSniffer/archive/master.tar.gz | tar xz --strip-components=1 -C php-codesniffer
+    # Install WordPress Coding Standards.
+    - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
+    # Hop into CodeSniffer directory.
+    - cd php-codesniffer
+    # Set install path for WordPress Coding Standards
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards
+    # Hop into themes directory.
+    - cd $theme_dir
+    # After CodeSniffer install you should refresh your path.
+    - phpenv rehash
+    # Install JSHint, a JavaScript Code Quality Tool
+    # @link http://jshint.com/docs/
+    - npm install -g jshint
+    - wget https://develop.svn.wordpress.org/trunk/.jshintrc
+
+# Run test script commands.
+# Default is specific to project language.
+# All commands must exit with code 0 on success. Anything else is considered failure.
+script:
+    # Search theme for PHP syntax errors.
+    - find . \( -name '*.php' \) -exec php -lf {} \;
+    # Run the theme through JSHint
+    - jshint .
+    # WordPress Coding Standards
+    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link http://pear.php.net/package/PHP_CodeSniffer/
+    # -p flag: Show progress of the run.
+    # -s flag: Show sniff codes in all reports.
+    # -v flag: Print verbose output.
+    # -n flag: Do not print warnings (shortcut for --warning-severity=0)
+    # --standard: Use WordPress as the standard.
+    # --extensions: Only sniff PHP files.
+    - $WP_DEVELOP_DIR/php-codesniffer/scripts/phpcs -p -s -v -n . --extensions=php

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,12 @@ before_script:
     # Create WordPress database.
     - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
     # Install CodeSniffer for WordPress Coding Standards checks.
-    - mkdir php-codesniffer && curl -L https://github.com/squizlabs/PHP_CodeSniffer/archive/master.tar.gz | tar xz --strip-components=1 -C php-codesniffer
+    - wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
     # Install WordPress Coding Standards.
     - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
-    # Hop into CodeSniffer directory.
-    - cd php-codesniffer
     # Set install path for WordPress Coding Standards
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards
+    - php phpcs.phar --config-set installed_paths wordpress-coding-standards
     # Hop into themes directory.
     - cd $theme_dir
     # After CodeSniffer install you should refresh your path.
@@ -94,4 +92,4 @@ script:
     # -n flag: Do not print warnings (shortcut for --warning-severity=0)
     # --standard: Use WordPress as the standard.
     # --extensions: Only sniff PHP files.
-    - $WP_DEVELOP_DIR/php-codesniffer/scripts/phpcs -p -s -v -n . --extensions=php
+    - php $WP_DEVELOP_DIR/phpcs.phar -p -s -v -n . --extensions=php

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+
+	<!-- Set a description for this ruleset. -->
+	<description>A custom set of code standard rules to check for WordPress themes.</description>
+
+	<!-- Include the WordPress ruleset, with space for exclusions if necessary. -->
+	<rule ref="WordPress-Core">
+		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.InlineComment.NotCapital" />
+	</rule>
+	<rule ref="WordPress-Docs">
+
+	</rule>
+
+	<rule ref="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing">
+		<severity>0</severity>
+	</rule>
+</ruleset>


### PR DESCRIPTION
This adapts the `.travis.yml` file and PHPCS config from Twenty Seventeen.

Having this in place will prevent issues from being introduced, such as being fixed in these PRs:

* https://github.com/WordPress/twentynineteen/pull/52
* https://github.com/WordPress/twentynineteen/pull/51
* https://github.com/WordPress/twentynineteen/pull/49
* https://github.com/WordPress/twentynineteen/pull/16