### PR TITLE
🐛 FIX: Missing calc Bracket

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -349,7 +349,7 @@
 			@include media(tablet) {
 
 				margin: $size__spacing-unit calc(2 * (100vw / 12));
-				max-width: calc(6 * (100vw / 12);
+				max-width: calc(6 * (100vw / 12));
 
 				p {
 					font-size: $font__size-lg;


### PR DESCRIPTION
Added a missing `calc` bracket that caused an error during a SASS compile test.

WP.org username: mrasharirfan