### PR TITLE
Switching pagination labels to reflect order of posts

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -290,8 +290,8 @@ if ( ! function_exists( 'twentynineteen_the_posts_navigation' ) ) :
 		$next_icon = twentynineteen_get_icon_svg( 'chevron_right', 22 );
 		the_posts_pagination( array(
 			'mid_size'  => 2,
-			'prev_text' => sprintf( '%s <span class="nav-prev-text">%s</span>', $prev_icon, __( 'Older posts', 'twentynineteen' ) ),
-			'next_text' => sprintf( '<span class="nav-next-text">%s</span> %s', __( 'Newer posts', 'twentynineteen' ), $next_icon ),
+			'prev_text' => sprintf( '%s <span class="nav-prev-text">%s</span>', $prev_icon, __( 'Newer posts', 'twentynineteen' ) ),
+			'next_text' => sprintf( '<span class="nav-next-text">%s</span> %s', __( 'Older posts', 'twentynineteen' ), $next_icon ),
 		) );
 	}
 endif;


### PR DESCRIPTION
Switching "Older posts" and "Newer posts" labels in pagination function to properly reflect post order going from newest posts (page 1) to older posts (page 2+).

Related issue: https://github.com/WordPress/twentynineteen/issues/53

WordPress.org username: yingling017