### PR TITLE
Update text colors to pass WCAG AA

### DIFF
--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -12,7 +12,7 @@ $color__background_selection: mix( $color__background-body, $color__background-b
 
 // Text
 $color__text-main: #111;
-$color__text-light: lighten( #111, 50% );
+$color__text-light: #767676;
 $color__text-hover: lighten( #111, 22.5% );
 $color__text-screen: #21759b;
 $color__text-input: #666;

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -21,11 +21,11 @@ $color__text-input-focus: #111;
 // Links
 $color__link: #0073aa;
 $color__link-visited: #0073aa;
-$color__link-hover: #00a0d2;
+$color__link-hover: darken( $color__link, 10% );
 
 // Borders
 $color__border-link: #0073aa;
-$color__border-link-hover: #00a0d2;
+$color__border-link-hover: darken( $color__link, 10% );
 $color__border-button: #ccc #ccc #bbb;
 $color__border-button-hover: #ccc #bbb #aaa;
 $color__border-button-focus: #aaa #bbb #bbb;

--- a/style-editor.css
+++ b/style-editor.css
@@ -51,7 +51,7 @@ h1 {
 }
 
 h1:before {
-  background: #919191;
+  background: #767676;
   content: "\020";
   display: block;
   height: 2px;
@@ -64,7 +64,7 @@ h2 {
 }
 
 h2:before {
-  background: #919191;
+  background: #767676;
   content: "\020";
   display: block;
   height: 2px;
@@ -108,7 +108,7 @@ figcaption {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.7111111111em;
   line-height: 1.6;
-  color: #919191;
+  color: #767676;
 }
 
 /** === Paragraph === */
@@ -243,7 +243,7 @@ body[data-type="core/cover-image"][data-align="full"] .wp-block-cover-image-text
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.7111111111em;
   line-height: 1.6;
-  color: #919191;
+  color: #767676;
 }
 
 /** === Pullquote === */
@@ -301,7 +301,7 @@ body[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citati
   font-size: 0.7111111111em;
   line-height: 1.6;
   text-transform: none;
-  color: #919191;
+  color: #767676;
 }
 
 body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit,
@@ -363,12 +363,12 @@ body[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citati
 
 /** === Table === */
 .wp-block-table td, .wp-block-table th {
-  border-color: #919191;
+  border-color: #767676;
 }
 
 /** === Separator === */
 .wp-block-separator:not(.is-style-dots) {
-  border-bottom: 2px solid #919191;
+  border-bottom: 2px solid #767676;
 }
 
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
@@ -377,7 +377,7 @@ body[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citati
 }
 
 .wp-block-separator.is-style-dots:before {
-  color: #919191;
+  color: #767676;
   font-size: 1.6875em;
   letter-spacing: 0.8888888889em;
 }
@@ -415,14 +415,14 @@ ul.wp-block-archives li a,
 ul.wp-block-archives li a:after,
 .wp-block-categories li a:after,
 .wp-block-latest-posts li a:after {
-  color: #919191;
+  color: #767676;
   content: ",";
 }
 
 ul.wp-block-archives li:last-child a:after,
 .wp-block-categories li:last-child a:after,
 .wp-block-latest-posts li:last-child a:after {
-  color: #919191;
+  color: #767676;
   content: ".";
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -94,7 +94,7 @@ a {
 }
 
 a:hover, a:active {
-  color: #00a0d2;
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }

--- a/style.css
+++ b/style.css
@@ -630,7 +630,7 @@ a {
 
 a:hover,
 a:active {
-  color: #00a0d2;
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -873,7 +873,7 @@ a:visited {
 }
 
 a:hover, a:active {
-  color: #00a0d2;
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -916,7 +916,7 @@ body.page .main-navigation {
 }
 
 .main-navigation ul.main-menu > li > a:hover {
-  color: #00a0d2;
+  color: #005177;
 }
 
 .main-navigation ul.main-menu > li > a:after {
@@ -1038,7 +1038,7 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #00a0d2;
+  color: #005177;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -1998,7 +1998,7 @@ body.page .main-navigation {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #00a0d2;
+  color: #005177;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2102,7 +2102,7 @@ body.page .main-navigation {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #00a0d2;
+  color: #005177;
 }
 
 .discussion-avatar-list {
@@ -2882,7 +2882,7 @@ body.page .main-navigation {
 }
 
 .author-description p.author-bio a.author-link:hover {
-  color: #00a0d2;
+  color: #005177;
   text-decoration: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -646,7 +646,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1:not(.site-title):before, h2:before {
-  background: #919191;
+  background: #767676;
   content: "\020";
   display: block;
   height: 2px;
@@ -655,7 +655,7 @@ h1:not(.site-title):before, h2:before {
 }
 
 hr {
-  background-color: #919191;
+  background-color: #767676;
   border: 0;
   height: 2px;
 }
@@ -741,7 +741,7 @@ blockquote > p {
 }
 
 blockquote cite {
-  color: #919191;
+  color: #767676;
 }
 
 table {
@@ -750,7 +750,7 @@ table {
 }
 
 table td, table th {
-  border-color: #919191;
+  border-color: #767676;
 }
 
 /* Forms */
@@ -922,7 +922,7 @@ body.page .main-navigation {
 .main-navigation ul.main-menu > li > a:after {
   content: ",";
   display: inline;
-  color: #919191;
+  color: #767676;
 }
 
 .main-navigation ul.main-menu > li:last-child > a:after {
@@ -1021,7 +1021,7 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a .meta-nav {
-  color: #919191;
+  color: #767676;
   user-select: none;
 }
 
@@ -1029,7 +1029,7 @@ body.page .main-navigation {
   display: none;
   content: "—";
   width: 2em;
-  color: #919191;
+  color: #767676;
   height: 1em;
 }
 
@@ -1284,7 +1284,7 @@ body.page .main-navigation {
 }
 
 .site-branding {
-  color: #919191;
+  color: #767676;
   position: relative;
 }
 
@@ -1374,7 +1374,7 @@ body.page .main-navigation {
 
 .site-description {
   display: inline;
-  color: #919191;
+  color: #767676;
   font-weight: normal;
   margin: 0;
 }
@@ -1601,7 +1601,7 @@ body.page .main-navigation {
 }
 
 .hentry .entry-title:before {
-  background: #919191;
+  background: #767676;
   content: "\020";
   display: block;
   height: 2px;
@@ -1619,7 +1619,7 @@ body.page .main-navigation {
 
 .hentry .entry-meta,
 .hentry .entry-footer {
-  color: #919191;
+  color: #767676;
   font-weight: 500;
 }
 
@@ -1826,7 +1826,7 @@ body.page .main-navigation {
 }
 
 .comments-area .comments-title-wrap .comments-title:before {
-  background: #919191;
+  background: #767676;
   content: "\020";
   display: block;
   height: 2px;
@@ -2033,7 +2033,7 @@ body.page .main-navigation {
 .comment .comment-metadata .comment-edit-link {
   display: inline-block;
   font-weight: 500;
-  color: #919191;
+  color: #767676;
   vertical-align: baseline;
 }
 
@@ -2053,7 +2053,7 @@ body.page .main-navigation {
 }
 
 .comment .comment-metadata .edit-link-sep {
-  color: #919191;
+  color: #767676;
   margin: 0 0.2em;
   opacity: 0;
   transition: opacity 200ms ease-in-out;
@@ -2061,7 +2061,7 @@ body.page .main-navigation {
 }
 
 .comment .comment-metadata .edit-link {
-  color: #919191;
+  color: #767676;
   transition: opacity 200ms ease-in-out;
   opacity: 0;
 }
@@ -2181,7 +2181,7 @@ body.page .main-navigation {
 
 .archive .page-header .page-title,
 .search .page-header .page-title {
-  color: #919191;
+  color: #767676;
   display: inline;
   letter-spacing: normal;
 }
@@ -2205,7 +2205,7 @@ body.page .main-navigation {
 .search .page-header .page-description:after {
   content: ".";
   font-weight: bold;
-  color: #919191;
+  color: #767676;
 }
 
 @media only screen and (min-width: 768px) {
@@ -2227,7 +2227,7 @@ body.page .main-navigation {
 --------------------------------------------------------------*/
 /* Site footer */
 .site-footer {
-  color: #919191;
+  color: #767676;
 }
 
 .site-footer .site-info {
@@ -2459,7 +2459,7 @@ body.page .main-navigation {
 .entry-content .wp-block-archives li,
 .entry-content .wp-block-categories li,
 .entry-content .wp-block-latest-posts li {
-  color: #919191;
+  color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.6875);
   font-weight: bold;
@@ -2469,14 +2469,14 @@ body.page .main-navigation {
 .entry-content .wp-block-archives li a:after,
 .entry-content .wp-block-categories li a:after,
 .entry-content .wp-block-latest-posts li a:after {
-  color: #919191;
+  color: #767676;
   content: ",";
 }
 
 .entry-content .wp-block-archives li:last-child a:after,
 .entry-content .wp-block-categories li:last-child a:after,
 .entry-content .wp-block-latest-posts li:last-child a:after {
-  color: #919191;
+  color: #767676;
   content: ".";
 }
 
@@ -2525,7 +2525,7 @@ body.page .main-navigation {
   font-size: 0.7111111111em;
   line-height: 1.6;
   text-transform: none;
-  color: #919191;
+  color: #767676;
 }
 
 .entry-content .wp-block-pullquote.alignleft blockquote, .entry-content .wp-block-pullquote.alignright blockquote {
@@ -2718,7 +2718,7 @@ body.page .main-navigation {
 
 .entry-content .wp-block-separator:not(.is-style-dots),
 .entry-content hr:not(.is-style-dots) {
-  background-color: #919191;
+  background-color: #767676;
   border: 0;
   height: 2px;
 }
@@ -2737,7 +2737,7 @@ body.page .main-navigation {
 
 .entry-content .wp-block-separator.is-style-dots:before,
 .entry-content hr.is-style-dots:before {
-  color: #919191;
+  color: #767676;
   font-size: 1.6875em;
   letter-spacing: 0.8888888889em;
   padding-left: 0.8888888889em;
@@ -2748,7 +2748,7 @@ body.page .main-navigation {
 }
 
 .entry-content .wp-block-table td, .entry-content .wp-block-table th {
-  border-color: #919191;
+  border-color: #767676;
 }
 
 .entry-content .wp-block-file {
@@ -2837,7 +2837,7 @@ body.page .main-navigation {
 }
 
 .author-description:before {
-  background: #919191;
+  background: #767676;
   content: "\020";
   display: block;
   height: 2px;
@@ -2852,7 +2852,7 @@ body.page .main-navigation {
 .author-description p.author-bio {
   word-spacing: -0.05em;
   display: inline;
-  color: #919191;
+  color: #767676;
   line-height: 1.3;
 }
 


### PR DESCRIPTION
In response to #41 

> Color issues:
>  #919191 on #ffffff – Found in post and page meta. On search pages.
>  #00a0d2 on #ffffff – The hover color found on some links.

Changes `#919191` to `#767676` ([thanks](
https://github.com/WordPress/twentynineteen/issues/41#issuecomment-430323473), @melchoyce)
Changes `#00a0d2` to `#005177`