### PR TITLE
Remove unnecessary and redundant ARIA roles [a11y]

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -11,7 +11,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 		<?php if ( have_posts() ) : ?>
 

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ get_header();
 ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 <?php
 	if ( have_posts() ) {

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 			
 			<?php
 			

--- a/single.php
+++ b/single.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 			<?php
 

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -19,7 +19,7 @@
 		<span class="separator">&mdash;</span> <?php echo $description; ?>
 	</p>
 	<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
-		<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'twentynineteen' ); ?>">
+		<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'twentynineteen' ); ?>">
 			<?php 
 			wp_nav_menu( array(
 				'theme_location' => 'menu-1',
@@ -29,7 +29,7 @@
 		</nav><!-- #site-navigation -->
 	<?php endif; ?>
 	<?php if ( has_nav_menu( 'social' ) ) : ?>
-		<nav class="social-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Footer Social Links Menu', 'twentynineteen' ); ?>">
+		<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Footer Social Links Menu', 'twentynineteen' ); ?>">
 			<?php 
 			wp_nav_menu( array(
 				'theme_location' => 'social',


### PR DESCRIPTION
Related: #41

>  Recommended: You don't need the explicit roles on the main navigation, role="navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'twentynineteen' ); ?> or on the <main> element. They can be removed.

Cheers,
Jb

(audrasjb on w.org)