### PR TITLE
Replace the_content with the_excerpt when not in a singular post/page

### DIFF
--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -25,18 +25,22 @@
 
 	<div class="entry-content">
 		<?php
-		the_content( sprintf(
-			wp_kses(
-				/* translators: %s: Name of current post. Only visible to screen readers */
-				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentynineteen' ),
-				array(
-					'span' => array(
-						'class' => array(),
-					),
-				)
-			),
-			get_the_title()
-		) );
+		if ( is_singular() ) :
+			the_content( sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentynineteen' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			) );
+		else : 
+			the_excerpt();
+		endif;
 
 		wp_link_pages( array(
 			'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentynineteen' ),


### PR DESCRIPTION
Fixes #89 
Indeed, when we are not on a singular post/page, we should avoid to display the full post content.