### PR TITLE
Remove unnecessary use of alt text in image ::after (CSS/SASS)

### DIFF
--- a/rtl.css
+++ b/rtl.css
@@ -9,5 +9,4 @@ https://codex.wordpress.org/Right-to-Left_Language_Support
 */
 body {
   direction: rtl;
-  unicode-bidi: embed;
-}
+  unicode-bidi: embed; }

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -78,7 +78,7 @@ img {
 
 	&:after {
 		color: $color__text-input;
-		content: "This image is broken :-/ ( "attr(alt)" )";
+		content: " ";
 		display: block;
 		left: 50%;
 		position: absolute;

--- a/style-editor.css
+++ b/style-editor.css
@@ -11,31 +11,22 @@ when Gutenberg supports styling those variations more intuitively.
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /** === Content Width === */
 .wp-block {
-  width: calc(100vw - (2 * 1rem));
-}
-
-@media only screen and (min-width: 768px) {
-  .wp-block {
-    width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .wp-block {
-    width: calc(6 * (100vw / 12 ));
-  }
-}
+  width: calc(100vw - (2 * 1rem)); }
+  @media only screen and (min-width: 768px) {
+    .wp-block {
+      width: calc(8 * (100vw / 12)); } }
+  @media only screen and (min-width: 1168px) {
+    .wp-block {
+      width: calc(6 * (100vw / 12 )); } }
 
 /** === Base Typography === */
 body {
   font-size: 22px;
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  color: #111;
-}
+  color: #111; }
 
 p {
-  font-size: 22px;
-}
+  font-size: 22px; }
 
 h1,
 h2,
@@ -43,73 +34,57 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
 
 h1 {
-  font-size: 2.8125em;
-}
-
-h1:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
+  font-size: 2.8125em; }
+  h1:before {
+    background: #767676;
+    content: "\020";
+    display: block;
+    height: 2px;
+    margin: 1rem 0;
+    width: 1em; }
 
 h2 {
-  font-size: 2.25em;
-}
-
-h2:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
+  font-size: 2.25em; }
+  h2:before {
+    background: #767676;
+    content: "\020";
+    display: block;
+    height: 2px;
+    margin: 1rem 0;
+    width: 1em; }
 
 h3 {
-  font-size: 1.6875em;
-}
+  font-size: 1.6875em; }
 
 h4 {
-  font-size: 1.125em;
-}
+  font-size: 1.125em; }
 
 h5 {
-  font-size: 0.8888888889em;
-}
+  font-size: 0.88889em; }
 
 h6 {
-  font-size: 0.7111111111em;
-}
+  font-size: 0.71111em; }
 
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
-}
-
-a:hover, a:active {
-  color: #005177;
-  outline: 0;
-  text-decoration: none;
-}
-
-a:focus {
-  outline: 0;
-  text-decoration: underline;
-}
+  color: #0073aa; }
+  a:hover,
+  a:active {
+    color: #005177;
+    outline: 0;
+    text-decoration: none; }
+  a:focus {
+    outline: 0;
+    text-decoration: underline; }
 
 figcaption {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   line-height: 1.6;
-  color: #767676;
-}
+  color: #767676; }
 
 /** === Paragraph === */
 .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
@@ -117,8 +92,7 @@ figcaption {
   font-size: 3.375em;
   line-height: 1;
   font-weight: bold;
-  margin: 0 0.25em 0 0;
-}
+  margin: 0 0.25em 0 0; }
 
 /** === Cover Image === */
 .wp-block-cover-image h2,
@@ -128,154 +102,116 @@ figcaption {
   font-weight: bold;
   line-height: 1.4;
   width: calc(100vw - (2 * 1rem));
-  max-width: calc(100vw - (2 * 1rem));
-}
-
-@media only screen and (min-width: 768px) {
-  .wp-block-cover-image h2,
-  .wp-block-cover-image .wp-block-cover-image-text {
-    width: calc(8 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .wp-block-cover-image h2,
-  .wp-block-cover-image .wp-block-cover-image-text {
-    width: calc(6 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
-  }
-}
+  max-width: calc(100vw - (2 * 1rem)); }
+  @media only screen and (min-width: 768px) {
+    .wp-block-cover-image h2,
+    .wp-block-cover-image .wp-block-cover-image-text {
+      width: calc(8 * (100vw / 12));
+      max-width: calc(8 * (100vw / 12)); } }
+  @media only screen and (min-width: 1168px) {
+    .wp-block-cover-image h2,
+    .wp-block-cover-image .wp-block-cover-image-text {
+      width: calc(6 * (100vw / 12));
+      max-width: calc(6 * (100vw / 12)); } }
 
 .wp-block-cover-image.has-left-content {
-  justify-content: center;
-}
-
-.wp-block-cover-image.has-left-content h2,
-.wp-block-cover-image.has-left-content .wp-block-cover-image-text {
-  padding: 1em;
-}
+  justify-content: center; }
+  .wp-block-cover-image.has-left-content h2,
+  .wp-block-cover-image.has-left-content .wp-block-cover-image-text {
+    padding: 1em; }
 
 .wp-block-cover-image.has-right-content {
-  justify-content: center;
-}
-
-.wp-block-cover-image.has-right-content h2,
-.wp-block-cover-image.has-right-content .wp-block-cover-image-text {
-  padding: 1em;
-}
+  justify-content: center; }
+  .wp-block-cover-image.has-right-content h2,
+  .wp-block-cover-image.has-right-content .wp-block-cover-image-text {
+    padding: 1em; }
 
 body[data-type="core/cover-image"][data-align="left"] h2,
 body[data-type="core/cover-image"][data-align="left"] .wp-block-cover-image-text,
 body[data-type="core/cover-image"][data-align="right"] h2,
 body[data-type="core/cover-image"][data-align="right"] .wp-block-cover-image-text {
   width: 100%;
-  max-width: 305px;
-}
+  max-width: 305px; }
 
 body[data-type="core/cover-image"][data-align="wide"] h2,
 body[data-type="core/cover-image"][data-align="wide"] .wp-block-cover-image-text,
 body[data-type="core/cover-image"][data-align="full"] h2,
 body[data-type="core/cover-image"][data-align="full"] .wp-block-cover-image-text {
-  padding: 0;
-}
+  padding: 0; }
 
 /** === Gallery === */
 .wp-block-gallery .blocks-gallery-image figcaption,
 .wp-block-gallery .blocks-gallery-item figcaption {
-  font-size: 0.7111111111em;
-  line-height: 1.6;
-}
+  font-size: 0.71111em;
+  line-height: 1.6; }
 
 /** === Button === */
 .wp-block-button .wp-block-button__link {
   line-height: 1.8;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.8888888889em;
-  font-weight: bold;
-}
+  font-size: 0.88889em;
+  font-weight: bold; }
 
 .wp-block-button .wp-block-button__link:not(.has-background),
 .wp-block-button .wp-block-button__link:not(.has-background) {
-  background: #0073aa;
-}
+  background: #0073aa; }
 
 .wp-block-button:not(.is-style-squared) .wp-block-button__link {
-  border-radius: 5px;
-}
+  border-radius: 5px; }
 
 .wp-block-button.is-style-outline .wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link:hover,
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link:active {
   background: transparent;
-  border-color: #0073aa;
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-text-color),
-.wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
-  color: #0073aa;
-}
+  border-color: #0073aa; }
+  .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+  .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-text-color),
+  .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+  .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+    color: #0073aa; }
 
 /** === Blockquote === */
 .wp-block-quote:not(.is-large):not(.is-style-large) {
-  border-left: 2px solid #0073aa;
-}
+  border-left: 2px solid #0073aa; }
 
-.wp-block-quote.is-large, .wp-block-quote.is-style-large {
+.wp-block-quote.is-large,
+.wp-block-quote.is-style-large {
   margin-top: 2.8125em;
-  margin-bottom: 2.8125em;
-}
+  margin-bottom: 2.8125em; }
 
 .wp-block-quote.is-large p,
 .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
-  margin-top: 0.5em;
-}
+  margin-top: 0.5em; }
 
 .wp-block-quote cite,
 .wp-block-quote footer,
 .wp-block-quote .wp-block-quote__citation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   line-height: 1.6;
-  color: #767676;
-}
+  color: #767676; }
 
 /** === Pullquote === */
 .wp-block-pullquote {
-  border: none;
-}
-
-.wp-block-pullquote.is-style-solid-color blockquote {
-  width: calc(100vw - (2 * 1rem));
-  max-width: 80%;
-}
-
-@media only screen and (min-width: 768px) {
+  border: none; }
   .wp-block-pullquote.is-style-solid-color blockquote {
-    width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .wp-block-pullquote.is-style-solid-color blockquote {
-    width: calc(6 * (100vw / 12));
-  }
-}
-
-.wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) p,
-.wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation {
-  color: white;
-}
-
-.wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
-  background-color: #0073aa;
-}
+    width: calc(100vw - (2 * 1rem));
+    max-width: 80%; }
+    @media only screen and (min-width: 768px) {
+      .wp-block-pullquote.is-style-solid-color blockquote {
+        width: calc(8 * (100vw / 12)); } }
+    @media only screen and (min-width: 1168px) {
+      .wp-block-pullquote.is-style-solid-color blockquote {
+        width: calc(6 * (100vw / 12)); } }
+  .wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) p,
+  .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation {
+    color: white; }
+  .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
+    background-color: #0073aa; }
 
 body[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 body[data-type="core/pullquote"] blockquote > .editor-rich-text p,
@@ -291,40 +227,31 @@ body[data-type="core/pullquote"][data-align="right"] p {
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
-  color: #111;
-}
+  color: #111; }
 
 body[data-type="core/pullquote"] .wp-block-pullquote__citation,
 body[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation,
 body[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   line-height: 1.6;
   text-transform: none;
-  color: #767676;
-}
+  color: #767676; }
 
 body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit,
 body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit {
-  max-width: 50%;
-}
-
-body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color),
-body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color) {
-  padding: 0;
-}
-
-body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color,
-body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color {
-  padding: 1em;
-}
-
-body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color p,
-body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation,
-body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color p,
-body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation {
-  color: white;
-}
+  max-width: 50%; }
+  body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color),
+  body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color) {
+    padding: 0; }
+  body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color,
+  body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color {
+    padding: 1em; }
+    body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color p,
+    body[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation,
+    body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color p,
+    body[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color .wp-block-pullquote__citation {
+      color: white; }
 
 body[data-type="core/pullquote"][data-align="left"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 body[data-type="core/pullquote"][data-align="left"] blockquote > .editor-rich-text p,
@@ -334,114 +261,88 @@ body[data-type="core/pullquote"][data-align="right"] blockquote > .block-library
 body[data-type="core/pullquote"][data-align="right"] blockquote > .editor-rich-text p,
 body[data-type="core/pullquote"][data-align="right"] p,
 body[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation {
-  text-align: left;
-}
+  text-align: left; }
 
 /** === File === */
 .wp-block-file {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.wp-block-file .wp-block-file__button {
-  line-height: 1.8;
-  font-size: 0.8888888889em;
-  font-weight: bold;
-  background-color: #0073aa;
-  border-radius: 5px;
-}
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
+  .wp-block-file .wp-block-file__button {
+    line-height: 1.8;
+    font-size: 0.88889em;
+    font-weight: bold;
+    background-color: #0073aa;
+    border-radius: 5px; }
 
 /** === Verse === */
 .wp-block-verse,
 .wp-block-verse pre {
-  padding: 0;
-}
+  padding: 0; }
 
 /** === Code === */
 .wp-block-code {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
 /** === Table === */
 .wp-block-table td, .wp-block-table th {
-  border-color: #767676;
-}
+  border-color: #767676; }
 
 /** === Separator === */
 .wp-block-separator:not(.is-style-dots) {
-  border-bottom: 2px solid #767676;
-}
+  border-bottom: 2px solid #767676; }
 
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
   width: 2.25em;
-  margin-left: 0;
-}
+  margin-left: 0; }
 
 .wp-block-separator.is-style-dots:before {
   color: #767676;
   font-size: 1.6875em;
-  letter-spacing: 0.8888888889em;
-}
+  letter-spacing: 0.88889em; }
 
 /** === Latest Posts, Archives, Categories === */
 ul.wp-block-archives,
 .wp-block-categories,
 .wp-block-latest-posts {
   padding: 0;
-  list-style-type: none;
-}
-
-ul.wp-block-archives ul,
-.wp-block-categories ul,
-.wp-block-latest-posts ul {
-  padding: 0;
-  list-style-type: none;
-}
-
-ul.wp-block-archives li,
-.wp-block-categories li,
-.wp-block-latest-posts li {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1.6875em;
-  font-weight: bold;
-  line-height: 1.2;
-}
-
-ul.wp-block-archives li a,
-.wp-block-categories li a,
-.wp-block-latest-posts li a {
-  text-decoration: none;
-}
-
-ul.wp-block-archives li a:after,
-.wp-block-categories li a:after,
-.wp-block-latest-posts li a:after {
-  color: #767676;
-  content: ",";
-}
-
-ul.wp-block-archives li:last-child a:after,
-.wp-block-categories li:last-child a:after,
-.wp-block-latest-posts li:last-child a:after {
-  color: #767676;
-  content: ".";
-}
+  list-style-type: none; }
+  ul.wp-block-archives ul,
+  .wp-block-categories ul,
+  .wp-block-latest-posts ul {
+    padding: 0;
+    list-style-type: none; }
+  ul.wp-block-archives li,
+  .wp-block-categories li,
+  .wp-block-latest-posts li {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-size: 1.6875em;
+    font-weight: bold;
+    line-height: 1.2; }
+    ul.wp-block-archives li a,
+    .wp-block-categories li a,
+    .wp-block-latest-posts li a {
+      text-decoration: none; }
+      ul.wp-block-archives li a:after,
+      .wp-block-categories li a:after,
+      .wp-block-latest-posts li a:after {
+        color: #767676;
+        content: ","; }
+    ul.wp-block-archives li:last-child a:after,
+    .wp-block-categories li:last-child a:after,
+    .wp-block-latest-posts li:last-child a:after {
+      color: #767676;
+      content: "."; }
 
 /** === Latest Comments === */
 .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-weight: bold;
-}
-
-.wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
-  font-weight: normal;
-}
+  font-weight: bold; }
+  .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+    font-weight: normal; }
 
 .wp-block-latest-comments .wp-block-latest-comments__comment,
 .wp-block-latest-comments .wp-block-latest-comments__comment-date,
 .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
-  font-size: inherit;
-}
+  font-size: inherit; }
 
 .wp-block-latest-comments .wp-block-latest-comments__comment-date {
-  font-size: 0.7111111111em;
-}
+  font-size: 0.71111em; }

--- a/style.css
+++ b/style.css
@@ -49,7 +49,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Comments
 # Blocks
 # Jetpack
-# Infinite scroll
 # Media
 	## Captions
 	## Galleries
@@ -69,8 +68,7 @@ html {
   line-height: 1.15;
   /* 1 */
   -webkit-text-size-adjust: 100%;
-  /* 2 */
-}
+  /* 2 */ }
 
 /* Sections
 	 ========================================================================== */
@@ -78,8 +76,7 @@ html {
  * Remove the margin in all browsers.
  */
 body {
-  margin: 0;
-}
+  margin: 0; }
 
 /**
  * Correct the font size and margin on `h1` elements within `section` and
@@ -87,8 +84,7 @@ body {
  */
 h1 {
   font-size: 2em;
-  margin: 0.67em 0;
-}
+  margin: 0.67em 0; }
 
 /* Grouping content
 	 ========================================================================== */
@@ -102,8 +98,7 @@ hr {
   height: 0;
   /* 1 */
   overflow: visible;
-  /* 2 */
-}
+  /* 2 */ }
 
 /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
@@ -113,8 +108,7 @@ pre {
   font-family: monospace, monospace;
   /* 1 */
   font-size: 1em;
-  /* 2 */
-}
+  /* 2 */ }
 
 /* Text-level semantics
 	 ========================================================================== */
@@ -122,8 +116,7 @@ pre {
  * Remove the gray background on active links in IE 10.
  */
 a {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
 /**
  * 1. Remove the bottom border in Chrome 57-
@@ -135,16 +128,14 @@ abbr[title] {
   text-decoration: underline;
   /* 2 */
   text-decoration: underline dotted;
-  /* 2 */
-}
+  /* 2 */ }
 
 /**
  * Add the correct font weight in Chrome, Edge, and Safari.
  */
 b,
 strong {
-  font-weight: bolder;
-}
+  font-weight: bolder; }
 
 /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
@@ -156,15 +147,13 @@ samp {
   font-family: monospace, monospace;
   /* 1 */
   font-size: 1em;
-  /* 2 */
-}
+  /* 2 */ }
 
 /**
  * Add the correct font size in all browsers.
  */
 small {
-  font-size: 80%;
-}
+  font-size: 80%; }
 
 /**
  * Prevent `sub` and `sup` elements from affecting the line height in
@@ -175,16 +164,13 @@ sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
-  vertical-align: baseline;
-}
+  vertical-align: baseline; }
 
 sub {
-  bottom: -0.25em;
-}
+  bottom: -0.25em; }
 
 sup {
-  top: -0.5em;
-}
+  top: -0.5em; }
 
 /* Embedded content
 	 ========================================================================== */
@@ -192,8 +178,7 @@ sup {
  * Remove the border on images inside links in IE 10.
  */
 img {
-  border-style: none;
-}
+  border-style: none; }
 
 /* Forms
 	 ========================================================================== */
@@ -213,8 +198,7 @@ textarea {
   line-height: 1.15;
   /* 1 */
   margin: 0;
-  /* 2 */
-}
+  /* 2 */ }
 
 /**
  * Show the overflow in IE.
@@ -223,8 +207,7 @@ textarea {
 button,
 input {
   /* 1 */
-  overflow: visible;
-}
+  overflow: visible; }
 
 /**
  * Remove the inheritance of text transform in Edge, Firefox, and IE.
@@ -233,8 +216,7 @@ input {
 button,
 select {
   /* 1 */
-  text-transform: none;
-}
+  text-transform: none; }
 
 /**
  * Correct the inability to style clickable types in iOS and Safari.
@@ -243,8 +225,7 @@ button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button;
-}
+  -webkit-appearance: button; }
 
 /**
  * Remove the inner border and padding in Firefox.
@@ -254,8 +235,7 @@ button::-moz-focus-inner,
 [type="reset"]::-moz-focus-inner,
 [type="submit"]::-moz-focus-inner {
   border-style: none;
-  padding: 0;
-}
+  padding: 0; }
 
 /**
  * Restore the focus styles unset by the previous rule.
@@ -264,15 +244,13 @@ button:-moz-focusring,
 [type="button"]:-moz-focusring,
 [type="reset"]:-moz-focusring,
 [type="submit"]:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
+  outline: 1px dotted ButtonText; }
 
 /**
  * Correct the padding in Firefox.
  */
 fieldset {
-  padding: 0.35em 0.75em 0.625em;
-}
+  padding: 0.35em 0.75em 0.625em; }
 
 /**
  * 1. Correct the text wrapping in Edge and IE.
@@ -292,22 +270,19 @@ legend {
   padding: 0;
   /* 3 */
   white-space: normal;
-  /* 1 */
-}
+  /* 1 */ }
 
 /**
  * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 progress {
-  vertical-align: baseline;
-}
+  vertical-align: baseline; }
 
 /**
  * Remove the default vertical scrollbar in IE 10+.
  */
 textarea {
-  overflow: auto;
-}
+  overflow: auto; }
 
 /**
  * 1. Add the correct box sizing in IE 10.
@@ -318,16 +293,14 @@ textarea {
   box-sizing: border-box;
   /* 1 */
   padding: 0;
-  /* 2 */
-}
+  /* 2 */ }
 
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
 [type="number"]::-webkit-inner-spin-button,
 [type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
+  height: auto; }
 
 /**
  * 1. Correct the odd appearance in Chrome and Safari.
@@ -337,15 +310,13 @@ textarea {
   -webkit-appearance: textfield;
   /* 1 */
   outline-offset: -2px;
-  /* 2 */
-}
+  /* 2 */ }
 
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
 [type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
+  -webkit-appearance: none; }
 
 /**
  * 1. Correct the inability to style clickable types in iOS and Safari.
@@ -355,8 +326,7 @@ textarea {
   -webkit-appearance: button;
   /* 1 */
   font: inherit;
-  /* 2 */
-}
+  /* 2 */ }
 
 /* Interactive
 	 ========================================================================== */
@@ -364,15 +334,13 @@ textarea {
  * Add the correct display in Edge, IE 10+, and Firefox.
  */
 details {
-  display: block;
-}
+  display: block; }
 
 /*
  * Add the correct display in all browsers.
  */
 summary {
-  display: list-item;
-}
+  display: list-item; }
 
 /* Misc
 	 ========================================================================== */
@@ -380,20 +348,17 @@ summary {
  * Add the correct display in IE 10+.
  */
 template {
-  display: none;
-}
+  display: none; }
 
 /**
  * Add the correct display in IE 10.
  */
 [hidden] {
-  display: none;
-}
+  display: none; }
 
 /* Typography */
 html {
-  font-size: 22px;
-}
+  font-size: 22px; }
 
 body {
   -webkit-font-smoothing: antialiased;
@@ -404,8 +369,7 @@ body {
   font-size: 1em;
   line-height: 1.8;
   margin: 0;
-  text-rendering: optimizeLegibility;
-}
+  text-rendering: optimizeLegibility; }
 
 button,
 input,
@@ -416,8 +380,7 @@ textarea {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: 400;
   line-height: 1.8;
-  text-rendering: optimizeLegibility;
-}
+  text-rendering: optimizeLegibility; }
 
 .main-navigation,
 .page-description,
@@ -433,8 +396,7 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: -0.02em;
   line-height: 1.2;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+  -moz-osx-font-smoothing: grayscale; }
 
 .site-info,
 .page-description,
@@ -447,30 +409,25 @@ h1, h2, h3, h4, h5, h6 {
 #cancel-comment-reply-link,
 img:after,
 .page-links {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
 
 .page-title {
-  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-}
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif; }
 
 .site-branding,
 .main-navigation ul.main-menu > li,
 .social-navigation,
 .author-description p.author-bio,
 .nav-links {
-  line-height: 1.25;
-}
+  line-height: 1.25; }
 
 h1 {
-  font-size: 2.8125em;
-}
+  font-size: 2.8125em; }
 
 .entry-title,
 .has-larger-font-size,
 h2 {
-  font-size: 2.25em;
-}
+  font-size: 2.25em; }
 
 .has-regular-font-size,
 .has-large-font-size,
@@ -478,8 +435,7 @@ h2.author-title,
 p.author-bio,
 .comments-title,
 h3 {
-  font-size: 1.6875em;
-}
+  font-size: 1.6875em; }
 
 .site-title,
 .site-description,
@@ -490,14 +446,12 @@ h3 {
 .comment-author .fn,
 .no-comments,
 h4 {
-  font-size: 1.125em;
-}
+  font-size: 1.125em; }
 
 .pagination .nav-links,
 .comment-content,
 h5 {
-  font-size: 0.8888888889em;
-}
+  font-size: 0.88889em; }
 
 .entry-meta,
 .entry-footer,
@@ -510,140 +464,110 @@ h5 {
 #cancel-comment-reply-link,
 img:after,
 h6 {
-  font-size: 0.7111111111em;
-}
+  font-size: 0.71111em; }
 
 .site-title,
 .page-title {
-  font-weight: normal;
-}
+  font-weight: normal; }
 
 .page-description,
 .page-links a {
-  font-weight: bold;
-}
+  font-weight: bold; }
 
 .site-description {
-  letter-spacing: -0.01em;
-}
+  letter-spacing: -0.01em; }
 
 .post-navigation .post-title,
 .entry-title,
 .comments-title {
   hyphens: auto;
-  word-break: break-word;
-}
+  word-break: break-word; }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    hyphens: none;
-  }
-}
+    hyphens: none; } }
 
 p {
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+  -moz-osx-font-smoothing: grayscale; }
 
 dfn, cite, em, i {
-  font-style: italic;
-}
+  font-style: italic; }
 
 blockquote > p {
   font-size: 1.6875em;
   font-style: italic;
-  line-height: 1.2;
-}
+  line-height: 1.2; }
 
 blockquote cite {
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-style: normal;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
 
 pre {
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-family: "Courier 10 Pitch", Courier, monospace;
   line-height: 1.8;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 code, kbd, tt, var {
-  font-size: 0.8888888889em;
-  font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
-}
+  font-size: 0.88889em;
+  font-family: Menlo, monaco, Consolas, Lucida Console, monospace; }
 
 abbr, acronym {
   border-bottom: 1px dotted #666;
-  cursor: help;
-}
+  cursor: help; }
 
 mark, ins {
   background: #fff9c0;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
 big {
-  font-size: 3.375em;
-}
+  font-size: 3.375em; }
 
 a {
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: none;
-}
-
-a:focus {
-  text-decoration: underline;
-}
+  text-decoration: none; }
+  a:hover {
+    text-decoration: none; }
+  a:focus {
+    text-decoration: underline; }
 
 /* Elements */
 html {
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 ::-moz-selection {
-  background: #bfdcea;
-}
+  background: #bfdcea; }
 
 ::selection {
-  background: #bfdcea;
-}
+  background: #bfdcea; }
 
 *,
 *:before,
 *:after {
-  box-sizing: inherit;
-}
+  box-sizing: inherit; }
 
 body {
-  background: #fff;
-}
+  background: #fff; }
 
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
-}
+  color: #0073aa; }
 
 a:hover,
 a:active {
   color: #005177;
   outline: 0;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
 a:focus {
   outline: 0;
-  text-decoration: underline;
-}
+  text-decoration: underline; }
 
 h1, h2, h3, h4, h5, h6 {
   clear: both;
-  margin: 1rem 0;
-}
+  margin: 1rem 0; }
 
 h1:not(.site-title):before, h2:before {
   background: #767676;
@@ -651,107 +575,82 @@ h1:not(.site-title):before, h2:before {
   display: block;
   height: 2px;
   margin: 1rem 0;
-  width: 1em;
-}
+  width: 1em; }
 
 hr {
   background-color: #767676;
   border: 0;
-  height: 2px;
-}
+  height: 2px; }
 
 ul,
 ol {
-  padding-left: 1rem;
-}
+  padding-left: 1rem; }
 
 ul {
-  list-style: disc;
-}
-
-ul ul {
-  list-style-type: circle;
-}
+  list-style: disc; }
+  ul ul {
+    list-style-type: circle; }
 
 ol {
-  list-style: decimal;
-}
+  list-style: decimal; }
 
 li {
-  line-height: 1.8;
-}
+  line-height: 1.8; }
 
 li > ul,
 li > ol {
-  padding-left: 2rem;
-}
+  padding-left: 2rem; }
 
 dt {
-  font-weight: bold;
-}
+  font-weight: bold; }
 
 dd {
-  margin: 0 1rem 1rem;
-}
+  margin: 0 1rem 1rem; }
 
 img {
   height: auto;
   max-width: 100%;
   min-height: calc(3 * 1rem);
-  position: relative;
-}
-
-img:before {
-  background-color: #eee;
-  border: 1px dashed #ccc;
-  border-radius: 3px;
-  content: " ";
-  display: block;
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-img:after {
-  color: #666;
-  content: "This image is broken :-/ ( " attr(alt) " )";
-  display: block;
-  left: 50%;
-  position: absolute;
-  text-align: center;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 100%;
-}
+  position: relative; }
+  img:before {
+    background-color: #eee;
+    border: 1px dashed #ccc;
+    border-radius: 3px;
+    content: " ";
+    display: block;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%; }
+  img:after {
+    color: #666;
+    content: " ";
+    display: block;
+    left: 50%;
+    position: absolute;
+    text-align: center;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%; }
 
 figure {
-  margin: 0;
-}
+  margin: 0; }
 
 blockquote {
   border-left: 2px solid #0073aa;
   margin-left: -2rem;
-  padding: 1rem 0 0.5rem 2rem;
-}
-
-blockquote > p {
-  margin: 0 0 1rem;
-}
-
-blockquote cite {
-  color: #767676;
-}
+  padding: 1rem 0 0.5rem 2rem; }
+  blockquote > p {
+    margin: 0 0 1rem; }
+  blockquote cite {
+    color: #767676; }
 
 table {
   margin: 0 0 1rem;
-  width: 100%;
-}
-
-table td, table th {
-  border-color: #767676;
-}
+  width: 100%; }
+  table td, table th {
+    border-color: #767676; }
 
 /* Forms */
 .button,
@@ -766,41 +665,35 @@ input[type="submit"] {
   box-sizing: border-box;
   color: white;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-weight: 600;
   line-height: 1.2;
   outline: none;
-  padding: 0.66rem 1rem;
-}
-
-.button:hover,
-button:hover,
-input[type="button"]:hover,
-input[type="reset"]:hover,
-input[type="submit"]:hover {
-  cursor: pointer;
-}
-
-.button:hover, .button:focus,
-button:hover,
-button:focus,
-input[type="button"]:hover,
-input[type="button"]:focus,
-input[type="reset"]:hover,
-input[type="reset"]:focus,
-input[type="submit"]:hover,
-input[type="submit"]:focus {
-  background: #111;
-}
-
-.button:focus,
-button:focus,
-input[type="button"]:focus,
-input[type="reset"]:focus,
-input[type="submit"]:focus {
-  outline: thin dotted;
-  outline-offset: -4px;
-}
+  padding: 0.66rem 1rem; }
+  .button:hover,
+  button:hover,
+  input[type="button"]:hover,
+  input[type="reset"]:hover,
+  input[type="submit"]:hover {
+    cursor: pointer; }
+  .button:hover,
+  .button:focus,
+  button:hover,
+  button:focus,
+  input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="reset"]:hover,
+  input[type="reset"]:focus,
+  input[type="submit"]:hover,
+  input[type="submit"]:focus {
+    background: #111; }
+  .button:focus,
+  button:focus,
+  input[type="button"]:focus,
+  input[type="reset"]:focus,
+  input[type="submit"]:focus {
+    outline: thin dotted;
+    outline-offset: -4px; }
 
 input[type="text"],
 input[type="email"],
@@ -823,41 +716,36 @@ textarea {
   border: solid 1px #ccc;
   box-sizing: border-box;
   outline: none;
-  padding: 0.5rem 0.66rem;
-}
-
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="url"]:focus,
-input[type="password"]:focus,
-input[type="search"]:focus,
-input[type="number"]:focus,
-input[type="tel"]:focus,
-input[type="range"]:focus,
-input[type="date"]:focus,
-input[type="month"]:focus,
-input[type="week"]:focus,
-input[type="time"]:focus,
-input[type="datetime"]:focus,
-input[type="datetime-local"]:focus,
-input[type="color"]:focus,
-textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
-  outline-offset: -4px;
-}
+  padding: 0.5rem 0.66rem; }
+  input[type="text"]:focus,
+  input[type="email"]:focus,
+  input[type="url"]:focus,
+  input[type="password"]:focus,
+  input[type="search"]:focus,
+  input[type="number"]:focus,
+  input[type="tel"]:focus,
+  input[type="range"]:focus,
+  input[type="date"]:focus,
+  input[type="month"]:focus,
+  input[type="week"]:focus,
+  input[type="time"]:focus,
+  input[type="datetime"]:focus,
+  input[type="datetime-local"]:focus,
+  input[type="color"]:focus,
+  textarea:focus {
+    border-color: #0073aa;
+    outline: thin solid rgba(0, 115, 170, 0.15);
+    outline-offset: -4px; }
 
 textarea {
   box-sizing: border-box;
   display: block;
   width: 100%;
   max-width: 100%;
-  resize: vertical;
-}
+  resize: vertical; }
 
 form p {
-  margin: 1rem 0;
-}
+  margin: 1rem 0; }
 
 /* Navigation */
 /*--------------------------------------------------------------
@@ -865,298 +753,196 @@ form p {
 --------------------------------------------------------------*/
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
-}
-
-a:visited {
-  color: #0073aa;
-}
-
-a:hover, a:active {
-  color: #005177;
-  outline: 0;
-  text-decoration: none;
-}
-
-a:focus {
-  outline: 0;
-  text-decoration: underline;
-}
+  color: #0073aa; }
+  a:visited {
+    color: #0073aa; }
+  a:hover,
+  a:active {
+    color: #005177;
+    outline: 0;
+    text-decoration: none; }
+  a:focus {
+    outline: 0;
+    text-decoration: underline; }
 
 /*--------------------------------------------------------------
 ## Menus
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  display: inline;
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation {
-    display: block;
-  }
-}
-
-body.page .main-navigation {
-  display: block;
-}
-
-.main-navigation > div {
-  display: inline;
-}
-
-.main-navigation ul.main-menu {
-  display: inline;
-  margin: 0;
-  padding: 0;
-}
-
-.main-navigation ul.main-menu > li {
-  display: inline;
-}
-
-.main-navigation ul.main-menu > li > a:hover {
-  color: #005177;
-}
-
-.main-navigation ul.main-menu > li > a:after {
-  content: ",";
-  display: inline;
-  color: #767676;
-}
-
-.main-navigation ul.main-menu > li:last-child > a:after {
-  content: ".";
-}
-
-.main-navigation ul.main-menu > li > a {
-  font-weight: 700;
-  color: #0073aa;
-}
-
-.main-navigation ul.main-menu > li:last-child > a {
-  margin-right: 0;
-}
-
-.main-navigation ul.sub-menu {
-  display: none;
-}
+  display: inline; }
+  @media only screen and (min-width: 768px) {
+    .main-navigation {
+      display: block; } }
+  body.page .main-navigation {
+    display: block; }
+  .main-navigation > div {
+    display: inline; }
+  .main-navigation ul.main-menu {
+    display: inline;
+    margin: 0;
+    padding: 0; }
+    .main-navigation ul.main-menu > li {
+      display: inline; }
+      .main-navigation ul.main-menu > li > a:hover {
+        color: #005177; }
+      .main-navigation ul.main-menu > li > a:after {
+        content: ",";
+        display: inline;
+        color: #767676; }
+      .main-navigation ul.main-menu > li:last-child > a:after {
+        content: "."; }
+      .main-navigation ul.main-menu > li > a {
+        font-weight: 700;
+        color: #0073aa; }
+      .main-navigation ul.main-menu > li:last-child > a {
+        margin-right: 0; }
+  .main-navigation ul.sub-menu {
+    display: none; }
 
 /* Social menu */
 .social-navigation {
-  margin-top: calc(1rem / 2);
-  text-align: left;
-}
-
-.social-navigation ul.social-links-menu {
-  content: "";
-  display: table;
-  table-layout: fixed;
-  display: inline-block;
-  margin: 0;
-  padding: 0;
-}
-
-.social-navigation ul.social-links-menu li {
-  display: inline-block;
-  vertical-align: bottom;
-  vertical-align: -webkit-baseline-middle;
-  list-style: none;
-}
-
-.social-navigation ul.social-links-menu li:nth-child(n+2) {
-  margin-left: 0.1em;
-}
-
-.social-navigation ul.social-links-menu li a {
-  border-bottom: 1px solid transparent;
-  display: block;
-  color: #111;
-  margin-bottom: -1px;
-  transition: opacity 110ms ease-in-out;
-}
-
-.social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
-  color: #111;
-  opacity: 0.6;
-}
-
-.social-navigation ul.social-links-menu li a:focus {
-  color: #111;
-  opacity: 1;
-  border-bottom: 1px solid #111;
-}
-
-.social-navigation ul.social-links-menu li a svg {
-  display: block;
-  width: 32px;
-  height: 32px;
-}
-
-.social-navigation ul.social-links-menu li a svg#ui-icon-link {
-  transform: rotate(-45deg);
-}
+  margin-top: calc(1rem / 2 );
+  text-align: left; }
+  .social-navigation ul.social-links-menu {
+    content: "";
+    display: table;
+    table-layout: fixed;
+    display: inline-block;
+    margin: 0;
+    padding: 0; }
+    .social-navigation ul.social-links-menu li {
+      display: inline-block;
+      vertical-align: bottom;
+      vertical-align: -webkit-baseline-middle;
+      list-style: none; }
+      .social-navigation ul.social-links-menu li:nth-child(n+2) {
+        margin-left: 0.1em; }
+      .social-navigation ul.social-links-menu li a {
+        border-bottom: 1px solid transparent;
+        display: block;
+        color: #111;
+        margin-bottom: -1px;
+        transition: opacity 110ms ease-in-out; }
+        .social-navigation ul.social-links-menu li a:hover,
+        .social-navigation ul.social-links-menu li a:active {
+          color: #111;
+          opacity: 0.6; }
+        .social-navigation ul.social-links-menu li a:focus {
+          color: #111;
+          opacity: 1;
+          border-bottom: 1px solid #111; }
+        .social-navigation ul.social-links-menu li a svg {
+          display: block;
+          width: 32px;
+          height: 32px; }
+          .social-navigation ul.social-links-menu li a svg#ui-icon-link {
+            transform: rotate(-45deg); }
 
 /*--------------------------------------------------------------
 ## Next / Previous
 --------------------------------------------------------------*/
 /* Next/Previous navigation */
 .post-navigation {
-  margin: calc(3 * 1rem) 0;
-}
-
-.post-navigation .nav-links {
-  margin: 0 1rem;
-  max-width: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-@media only screen and (min-width: 1168px) {
+  margin: calc(3 * 1rem) 0; }
   .post-navigation .nav-links {
-    flex-direction: row;
-    margin: 0 calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-.post-navigation .nav-links a .meta-nav {
-  color: #767676;
-  user-select: none;
-}
-
-.post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
-  display: none;
-  content: "—";
-  width: 2em;
-  color: #767676;
-  height: 1em;
-}
-
-.post-navigation .nav-links a .post-title {
-  hyphens: auto;
-}
-
-.post-navigation .nav-links a:hover {
-  color: #005177;
-}
-
-@media only screen and (min-width: 1168px) {
-  .post-navigation .nav-links .nav-previous,
-  .post-navigation .nav-links .nav-next {
-    min-width: calc(50% - 2 * 1rem);
-  }
-}
-
-.post-navigation .nav-links .nav-previous {
-  order: 2;
-}
-
-@media only screen and (min-width: 1168px) {
-  .post-navigation .nav-links .nav-previous {
-    order: 1;
-  }
-}
-
-.post-navigation .nav-links .nav-previous + .nav-next {
-  margin-bottom: 1rem;
-}
-
-.post-navigation .nav-links .nav-previous .meta-nav:before {
-  display: inline;
-}
-
-.post-navigation .nav-links .nav-next {
-  order: 1;
-}
-
-@media only screen and (min-width: 1168px) {
-  .post-navigation .nav-links .nav-next {
-    order: 2;
-  }
-}
-
-.post-navigation .nav-links .nav-next .meta-nav:after {
-  display: inline;
-}
+    margin: 0 1rem;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column; }
+    @media only screen and (min-width: 1168px) {
+      .post-navigation .nav-links {
+        flex-direction: row;
+        margin: 0 calc(2 * (100vw / 12));
+        max-width: calc(8 * (100vw / 12)); } }
+    .post-navigation .nav-links a .meta-nav {
+      color: #767676;
+      user-select: none; }
+      .post-navigation .nav-links a .meta-nav:before,
+      .post-navigation .nav-links a .meta-nav:after {
+        display: none;
+        content: "—";
+        width: 2em;
+        color: #767676;
+        height: 1em; }
+    .post-navigation .nav-links a .post-title {
+      hyphens: auto; }
+    .post-navigation .nav-links a:hover {
+      color: #005177; }
+    @media only screen and (min-width: 1168px) {
+      .post-navigation .nav-links .nav-previous,
+      .post-navigation .nav-links .nav-next {
+        min-width: calc(50% - 2 * 1rem); } }
+    .post-navigation .nav-links .nav-previous {
+      order: 2; }
+      @media only screen and (min-width: 1168px) {
+        .post-navigation .nav-links .nav-previous {
+          order: 1; } }
+      .post-navigation .nav-links .nav-previous + .nav-next {
+        margin-bottom: 1rem; }
+      .post-navigation .nav-links .nav-previous .meta-nav:before {
+        display: inline; }
+    .post-navigation .nav-links .nav-next {
+      order: 1; }
+      @media only screen and (min-width: 1168px) {
+        .post-navigation .nav-links .nav-next {
+          order: 2; } }
+      .post-navigation .nav-links .nav-next .meta-nav:after {
+        display: inline; }
 
 .pagination .nav-links {
   display: flex;
   flex-wrap: wrap;
-  padding: 0 calc(.5 * 1rem);
-}
-
-.pagination .nav-links > * {
-  padding: calc(.5 * 1rem);
-}
-
-.pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
-  padding-left: 0;
-}
-
-.pagination .nav-links > *.dots, .pagination .nav-links > *.next {
-  padding-right: 0;
-}
-
-.pagination .nav-links .nav-next-text,
-.pagination .nav-links .nav-prev-text {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .pagination .nav-links {
-    margin-left: calc(2 * (100vw / 12));
-    padding: 0;
-  }
-  .pagination .nav-links .prev > *,
-  .pagination .nav-links .next > * {
-    display: inline-block;
-    vertical-align: text-bottom;
-  }
+  padding: 0 calc(.5 * 1rem); }
   .pagination .nav-links > * {
-    padding: 1rem;
-  }
-}
+    padding: calc(.5 * 1rem); }
+    .pagination .nav-links > *.dots,
+    .pagination .nav-links > *.prev {
+      padding-left: 0; }
+    .pagination .nav-links > *.dots,
+    .pagination .nav-links > *.next {
+      padding-right: 0; }
+  .pagination .nav-links .nav-next-text,
+  .pagination .nav-links .nav-prev-text {
+    display: none; }
+  @media only screen and (min-width: 768px) {
+    .pagination .nav-links {
+      margin-left: calc(2 * (100vw / 12) );
+      padding: 0; }
+      .pagination .nav-links .prev > *,
+      .pagination .nav-links .next > * {
+        display: inline-block;
+        vertical-align: text-bottom; }
+      .pagination .nav-links > * {
+        padding: 1rem; } }
 
 .comment-navigation .nav-links {
   display: flex;
-  flex-direction: row;
-}
+  flex-direction: row; }
 
 .comment-navigation .nav-previous,
 .comment-navigation .nav-next {
   min-width: 50%;
-  width: 100%;
-}
-
-.comment-navigation .nav-previous .secondary-text,
-.comment-navigation .nav-next .secondary-text {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
+  width: 100%; }
   .comment-navigation .nav-previous .secondary-text,
   .comment-navigation .nav-next .secondary-text {
-    display: inline;
-  }
-}
-
-.comment-navigation .nav-previous svg,
-.comment-navigation .nav-next svg {
-  vertical-align: middle;
-  position: relative;
-  margin: 0 -0.35em;
-  top: -1px;
-}
-
-.comment-navigation .nav-previous a:hover,
-.comment-navigation .nav-next a:hover {
-  color: #0073aa;
-}
+    display: none; }
+    @media only screen and (min-width: 768px) {
+      .comment-navigation .nav-previous .secondary-text,
+      .comment-navigation .nav-next .secondary-text {
+        display: inline; } }
+  .comment-navigation .nav-previous svg,
+  .comment-navigation .nav-next svg {
+    vertical-align: middle;
+    position: relative;
+    margin: 0 -0.35em;
+    top: -1px; }
+  .comment-navigation .nav-previous a:hover,
+  .comment-navigation .nav-next a:hover {
+    color: #0073aa; }
 
 .comment-navigation .nav-next {
-  text-align: right;
-}
+  text-align: right; }
 
 /* Accessibility */
 /* Text meant only for screen readers. */
@@ -1171,55 +957,48 @@ body.page .main-navigation {
   position: absolute !important;
   width: 1px;
   word-wrap: normal !important;
-  /* Many screen reader and browser combinations announce broken words as they would appear visually. */
-}
-
-.screen-reader-text:focus {
-  background-color: #f1f1f1;
-  border-radius: 3px;
-  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
-  clip: auto !important;
-  clip-path: none;
-  color: #21759b;
-  display: block;
-  font-size: 14px;
-  font-size: 0.875rem;
-  font-weight: bold;
-  height: auto;
-  left: 5px;
-  line-height: normal;
-  padding: 15px 23px 14px;
-  text-decoration: none;
-  top: 5px;
-  width: auto;
-  z-index: 100000;
-  /* Above WP toolbar. */
-}
+  /* Many screen reader and browser combinations announce broken words as they would appear visually. */ }
+  .screen-reader-text:focus {
+    background-color: #f1f1f1;
+    border-radius: 3px;
+    box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+    clip: auto !important;
+    clip-path: none;
+    color: #21759b;
+    display: block;
+    font-size: 14px;
+    font-size: 0.875rem;
+    font-weight: bold;
+    height: auto;
+    left: 5px;
+    line-height: normal;
+    padding: 15px 23px 14px;
+    text-decoration: none;
+    top: 5px;
+    width: auto;
+    z-index: 100000;
+    /* Above WP toolbar. */ }
 
 /* Do not show the outline on the skip link target. */
 #content[tabindex="-1"]:focus {
-  outline: 0;
-}
+  outline: 0; }
 
 /* Alignments */
 .alignleft {
   display: inline;
   float: left;
-  margin-right: 1rem;
-}
+  margin-right: 1rem; }
 
 .alignright {
   display: inline;
   float: right;
-  margin-left: 1rem;
-}
+  margin-left: 1rem; }
 
 .aligncenter {
   clear: both;
   display: block;
   margin-left: auto;
-  margin-right: auto;
-}
+  margin-right: auto; }
 
 /* Clearings */
 .clear:before,
@@ -1236,8 +1015,7 @@ body.page .main-navigation {
 .site-footer:after {
   content: "";
   display: table;
-  table-layout: fixed;
-}
+  table-layout: fixed; }
 
 .clear:after,
 .entry-content:after,
@@ -1245,143 +1023,101 @@ body.page .main-navigation {
 .site-header:after,
 .site-content:after,
 .site-footer:after {
-  clear: both;
-}
+  clear: both; }
 
 /* Layout */
 /** === Layout === */
 #page {
-  width: 100%;
-}
+  width: 100%; }
 
 .site-content {
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 /* Content */
 /*--------------------------------------------------------------
 ## Header
 --------------------------------------------------------------*/
 .site-header {
-  padding: 1em;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-header {
-    margin: 0;
-    padding: 3rem 0;
-  }
-  .site-header.featured-image {
-    display: flex;
-    min-height: 100vh;
-    flex-direction: column;
-    justify-content: space-between;
-    margin-bottom: 3rem;
-  }
-  .site-header.featured-image .site-branding-container {
-    margin-bottom: auto;
-  }
-}
+  padding: 1em; }
+  @media only screen and (min-width: 768px) {
+    .site-header {
+      margin: 0;
+      padding: 3rem 0; }
+      .site-header.featured-image {
+        display: flex;
+        min-height: 100vh;
+        flex-direction: column;
+        justify-content: space-between;
+        margin-bottom: 3rem; }
+        .site-header.featured-image .site-branding-container {
+          margin-bottom: auto; } }
 
 .site-branding {
   color: #767676;
-  position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    margin: 0 calc(2 * (100vw / 12));
-    max-width: 22em;
-  }
-}
+  position: relative; }
+  @media only screen and (min-width: 768px) {
+    .site-branding {
+      margin: 0 calc(2 * (100vw / 12));
+      max-width: 22em; } }
 
 .site-logo {
   position: relative;
   z-index: 999;
-  margin-bottom: calc(.66 * 1rem);
-}
-
-@media only screen and (min-width: 768px) {
-  .site-logo {
-    margin-bottom: 0;
-    position: absolute;
-    right: calc(100% + (0.5 * calc(100vw / 12)));
-    top: 4px;
-    z-index: 999;
-  }
-}
-
-.site-logo .custom-logo-link {
-  border-radius: 100%;
-  box-sizing: content-box;
-  box-shadow: 0 0 0 0 transparent;
-  display: block;
-  width: 32px;
-  height: 32px;
-  overflow: hidden;
-  transition: box-shadow 200ms ease-in-out;
-}
-
-.site-logo .custom-logo-link .custom-logo {
-  min-height: inherit;
-}
-
-.site-logo .custom-logo-link:hover, .site-logo .custom-logo-link:active, .site-logo .custom-logo-link:focus {
-  box-shadow: 0 0 0 2px black;
-}
-
-@media only screen and (min-width: 768px) {
+  margin-bottom: calc(.66 * 1rem); }
+  @media only screen and (min-width: 768px) {
+    .site-logo {
+      margin-bottom: 0;
+      position: absolute;
+      right: calc(100% + (0.5 * calc(100vw / 12)));
+      top: 4px;
+      z-index: 999; } }
   .site-logo .custom-logo-link {
-    width: 64px;
-    height: 64px;
-  }
-}
+    border-radius: 100%;
+    box-sizing: content-box;
+    box-shadow: 0 0 0 0 transparent;
+    display: block;
+    width: 32px;
+    height: 32px;
+    overflow: hidden;
+    transition: box-shadow 200ms ease-in-out; }
+    .site-logo .custom-logo-link .custom-logo {
+      min-height: inherit; }
+    .site-logo .custom-logo-link:hover,
+    .site-logo .custom-logo-link:active,
+    .site-logo .custom-logo-link:focus {
+      box-shadow: 0 0 0 2px black; }
+    @media only screen and (min-width: 768px) {
+      .site-logo .custom-logo-link {
+        width: 64px;
+        height: 64px; } }
 
 .site-title {
   margin: auto;
   display: inline;
   color: #111;
-  /* When there is no description set, make sure navigation appears below title. */
-}
-
-.featured-image .site-title {
-  margin: 0;
-}
-
-@media only screen and (min-width: 768px) {
+  /* When there is no description set, make sure navigation appears below title. */ }
   .featured-image .site-title {
-    display: inline-block;
-  }
-}
-
-.site-title + .main-navigation {
-  display: block;
-}
-
-.site-title a {
-  color: inherit;
-}
-
-.site-title a:hover {
-  color: #4a4a4a;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-title {
-    display: inline;
-  }
-}
+    margin: 0; }
+    @media only screen and (min-width: 768px) {
+      .featured-image .site-title {
+        display: inline-block; } }
+  .site-title + .main-navigation {
+    display: block; }
+  .site-title a {
+    color: inherit; }
+    .site-title a:hover {
+      color: #4a4a4a; }
+  @media only screen and (min-width: 768px) {
+    .site-title {
+      display: inline; } }
 
 .site-description {
   display: inline;
   color: #767676;
   font-weight: normal;
-  margin: 0;
-}
-
-.site-description .separator {
-  margin: 0 .2em;
-}
+  margin: 0; }
+  .site-description .separator {
+    margin: 0 0.2em; }
 
 .site-header.featured-image {
   /* Need relative positioning to properly align layers. */
@@ -1403,862 +1139,585 @@ body.page .main-navigation {
   /* Second layer: screen. */
   /* Third layer: multiply. */
   /* Fourth layer: overlay. */
-  /* Fifth layer: readability overlay */
-}
-
-.site-header.featured-image .site-branding .site-title,
-.site-header.featured-image .site-branding .site-description,
-.site-header.featured-image .main-navigation a:after,
-.site-header.featured-image .main-navigation li,
-.site-header.featured-image .social-navigation li,
-.site-header.featured-image .entry-meta,
-.site-header.featured-image .entry-title {
-  color: white;
-}
-
-.site-header.featured-image .main-navigation a,
-.site-header.featured-image .social-navigation a,
-.site-header.featured-image .site-title a,
-.site-header.featured-image .hentry a {
-  color: white;
-  transition: opacity 110ms ease-in-out;
-}
-
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active,
-.site-header.featured-image .social-navigation a:hover,
-.site-header.featured-image .social-navigation a:active,
-.site-header.featured-image .site-title a:hover,
-.site-header.featured-image .site-title a:active,
-.site-header.featured-image .hentry a:hover,
-.site-header.featured-image .hentry a:active {
-  color: white;
-  opacity: 0.6;
-}
-
-.site-header.featured-image .main-navigation a:focus,
-.site-header.featured-image .social-navigation a:focus,
-.site-header.featured-image .site-title a:focus,
-.site-header.featured-image .hentry a:focus {
-  color: white;
-}
-
-.site-header.featured-image .social-navigation a:focus {
-  color: white;
-  opacity: 1;
-  border-bottom: 1px solid white;
-}
-
-.site-header.featured-image .social-navigation svg,
-.site-header.featured-image .hentry svg {
-  /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
-  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
-}
-
-.site-header.featured-image .hentry .entry-header {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-@media only screen and (min-width: 768px) {
+  /* Fifth layer: readability overlay */ }
+  .site-header.featured-image .site-branding .site-title,
+  .site-header.featured-image .site-branding .site-description,
+  .site-header.featured-image .main-navigation a:after,
+  .site-header.featured-image .main-navigation li,
+  .site-header.featured-image .social-navigation li,
+  .site-header.featured-image .entry-meta,
+  .site-header.featured-image .entry-title {
+    color: white; }
+  .site-header.featured-image .main-navigation a,
+  .site-header.featured-image .social-navigation a,
+  .site-header.featured-image .site-title a,
+  .site-header.featured-image .hentry a {
+    color: white;
+    transition: opacity 110ms ease-in-out; }
+    .site-header.featured-image .main-navigation a:hover,
+    .site-header.featured-image .main-navigation a:active,
+    .site-header.featured-image .social-navigation a:hover,
+    .site-header.featured-image .social-navigation a:active,
+    .site-header.featured-image .site-title a:hover,
+    .site-header.featured-image .site-title a:active,
+    .site-header.featured-image .hentry a:hover,
+    .site-header.featured-image .hentry a:active {
+      color: white;
+      opacity: 0.6; }
+    .site-header.featured-image .main-navigation a:focus,
+    .site-header.featured-image .social-navigation a:focus,
+    .site-header.featured-image .site-title a:focus,
+    .site-header.featured-image .hentry a:focus {
+      color: white; }
+  .site-header.featured-image .social-navigation a:focus {
+    color: white;
+    opacity: 1;
+    border-bottom: 1px solid white; }
+  .site-header.featured-image .social-navigation svg,
+  .site-header.featured-image .hentry svg {
+    /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
+    -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35)); }
   .site-header.featured-image .hentry .entry-header {
-    margin-left: calc(2 * (100vw / 12));
-    margin-right: calc(2 * (100vw / 12));
-  }
-}
-
-.site-header.featured-image .hentry .entry-header .entry-title:before {
-  background: white;
-}
-
-.site-header.featured-image .custom-logo-link {
-  background: white;
-  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
-}
-
-.site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
-  box-shadow: 0 0 0 2px white;
-}
-
-.site-header.featured-image .site-branding,
-.site-header.featured-image .hentry .entry-header {
-  z-index: 10;
-}
-
-.site-header.featured-image .site-branding-container:before,
-.site-header.featured-image .site-branding-container:after,
-.site-header.featured-image .hentry:before,
-.site-header.featured-image .hentry:after, .site-header.featured-image:after {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  content: "\020";
-  width: 100%;
-  height: 100%;
-}
-
-.site-header.featured-image .site-branding-container:before {
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  filter: grayscale(100%);
-  z-index: 1;
-}
-
-.site-header.featured-image .hentry:before {
-  background: #0073aa;
-  mix-blend-mode: screen;
-  opacity: 0.1;
-  z-index: 2;
-}
-
-.site-header.featured-image .hentry:after {
-  background: #0073aa;
-  mix-blend-mode: multiply;
-  opacity: 1;
-  z-index: 3;
-}
-
-.site-header.featured-image .site-branding-container:after {
-  background: rgba(255, 255, 255, 0.35);
-  mix-blend-mode: overlay;
-  opacity: 0.5;
-  z-index: 4;
-}
-
-.site-header.featured-image:after {
-  background: #000e14;
-  /**
+    margin-left: 0;
+    margin-right: 0; }
+    @media only screen and (min-width: 768px) {
+      .site-header.featured-image .hentry .entry-header {
+        margin-left: calc(2 * (100vw / 12));
+        margin-right: calc(2 * (100vw / 12)); } }
+    .site-header.featured-image .hentry .entry-header .entry-title:before {
+      background: white; }
+  .site-header.featured-image .custom-logo-link {
+    background: white;
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
+    .site-header.featured-image .custom-logo-link:hover,
+    .site-header.featured-image .custom-logo-link:active,
+    .site-header.featured-image .custom-logo-link:focus {
+      box-shadow: 0 0 0 2px white; }
+  .site-header.featured-image .site-branding,
+  .site-header.featured-image .hentry .entry-header {
+    z-index: 10; }
+  .site-header.featured-image .site-branding-container:before,
+  .site-header.featured-image .site-branding-container:after,
+  .site-header.featured-image .hentry:before,
+  .site-header.featured-image .hentry:after,
+  .site-header.featured-image:after {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    content: "\020";
+    width: 100%;
+    height: 100%; }
+  .site-header.featured-image .site-branding-container:before {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    filter: grayscale(100%);
+    z-index: 1; }
+  .site-header.featured-image .hentry:before {
+    background: #0073aa;
+    mix-blend-mode: screen;
+    opacity: 0.1;
+    z-index: 2; }
+  .site-header.featured-image .hentry:after {
+    background: #0073aa;
+    mix-blend-mode: multiply;
+    opacity: 1;
+    z-index: 3; }
+  .site-header.featured-image .site-branding-container:after {
+    background: rgba(255, 255, 255, 0.35);
+    mix-blend-mode: overlay;
+    opacity: 0.5;
+    z-index: 4; }
+  .site-header.featured-image:after {
+    background: #000e14;
+    /**
 		 * Add a transition to the readability overlay, to add a subtle
 		 * but smooth effect when resizing the screen.
 		 */
-  transition: opacity 1200ms ease-in-out;
-  z-index: 5;
-  opacity: 0.38;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-header.featured-image:after {
-    opacity: 0.18;
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .site-header.featured-image:after {
-    opacity: 0.1;
-  }
-}
-
-.site-header.featured-image ::-moz-selection {
-  background: rgba(255, 255, 255, 0.17);
-}
-
-.site-header.featured-image ::selection {
-  background: rgba(255, 255, 255, 0.17);
-}
+    transition: opacity 1200ms ease-in-out;
+    z-index: 5;
+    opacity: 0.38; }
+    @media only screen and (min-width: 768px) {
+      .site-header.featured-image:after {
+        opacity: 0.18; } }
+    @media only screen and (min-width: 1168px) {
+      .site-header.featured-image:after {
+        opacity: 0.1; } }
+  .site-header.featured-image ::-moz-selection {
+    background: rgba(255, 255, 255, 0.17); }
+  .site-header.featured-image ::selection {
+    background: rgba(255, 255, 255, 0.17); }
 
 /*--------------------------------------------------------------
 ## Posts and pages
 --------------------------------------------------------------*/
 .sticky {
-  display: block;
-}
+  display: block; }
 
 .updated:not(.published) {
-  display: none;
-}
+  display: none; }
 
 .page-links {
   clear: both;
-  margin: 0 0 calc(1.5 * 1rem);
-}
+  margin: 0 0 calc(1.5 * 1rem); }
 
 .hentry {
-  margin-top: calc(6 * 1rem);
-}
-
-.hentry:first-of-type {
-  margin-top: 0;
-}
-
-.hentry .entry-header {
-  margin: calc(3 * 1rem) 1rem 1rem;
-  position: relative;
-}
-
-@media only screen and (min-width: 768px) {
+  margin-top: calc(6 * 1rem); }
+  .hentry:first-of-type {
+    margin-top: 0; }
   .hentry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12 )) 1rem;
-  }
-  .featured-image .hentry .entry-header {
-    margin-bottom: 0;
-  }
-}
-
-.hentry .entry-title {
-  margin: 0;
-}
-
-.hentry .entry-title:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
-
-.hentry .entry-title a {
-  color: inherit;
-}
-
-.hentry .entry-title a:hover {
-  color: #4a4a4a;
-}
-
-.hentry .entry-meta,
-.hentry .entry-footer {
-  color: #767676;
-  font-weight: 500;
-}
-
-.hentry .entry-meta > span,
-.hentry .entry-footer > span {
-  margin-right: 1rem;
-}
-
-.hentry .entry-meta > span:last-child,
-.hentry .entry-footer > span:last-child {
-  margin-right: 0;
-}
-
-.hentry .entry-meta a,
-.hentry .entry-footer a {
-  transition: color 110ms ease-in-out;
-  color: currentColor;
-}
-
-.hentry .entry-meta a:hover,
-.hentry .entry-footer a:hover {
-  text-decoration: none;
-  color: #0073aa;
-}
-
-.hentry .entry-meta .svg-icon,
-.hentry .entry-footer .svg-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 0.5em;
-}
-
-.hentry .entry-meta {
-  margin: 1rem 0;
-}
-
-@media only screen and (min-width: 1168px) {
-  .hentry .entry-meta.has-discussion .comment-count {
-    float: right;
-    position: relative;
-  }
-}
-
-.hentry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 1168px) {
-  .hentry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
-    bottom: 100%;
-    display: block;
-    position: absolute;
-  }
-}
-
-.hentry .entry-footer {
-  margin: calc(2 * 1rem) 1rem 1rem;
-}
-
-@media only screen and (min-width: 768px) {
+    margin: calc(3 * 1rem) 1rem 1rem;
+    position: relative; }
+    @media only screen and (min-width: 768px) {
+      .hentry .entry-header {
+        margin: calc(3 * 1rem) calc(2 * (100vw / 12 ) ) 1rem; }
+        .featured-image .hentry .entry-header {
+          margin-bottom: 0; } }
+  .hentry .entry-title {
+    margin: 0; }
+    .hentry .entry-title:before {
+      background: #767676;
+      content: "\020";
+      display: block;
+      height: 2px;
+      margin: 1rem 0;
+      width: 1em; }
+    .hentry .entry-title a {
+      color: inherit; }
+      .hentry .entry-title a:hover {
+        color: #4a4a4a; }
+  .hentry .entry-meta,
   .hentry .entry-footer {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 768px) {
+    color: #767676;
+    font-weight: 500; }
+    .hentry .entry-meta > span,
+    .hentry .entry-footer > span {
+      margin-right: 1rem; }
+      .hentry .entry-meta > span:last-child,
+      .hentry .entry-footer > span:last-child {
+        margin-right: 0; }
+    .hentry .entry-meta a,
+    .hentry .entry-footer a {
+      transition: color 110ms ease-in-out;
+      color: currentColor; }
+      .hentry .entry-meta a:hover,
+      .hentry .entry-footer a:hover {
+        text-decoration: none;
+        color: #0073aa; }
+    .hentry .entry-meta .svg-icon,
+    .hentry .entry-footer .svg-icon {
+      position: relative;
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 0.5em; }
+  .hentry .entry-meta {
+    margin: 1rem 0; }
+    @media only screen and (min-width: 1168px) {
+      .hentry .entry-meta.has-discussion .comment-count {
+        float: right;
+        position: relative; } }
+    .hentry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
+      display: none; }
+      @media only screen and (min-width: 1168px) {
+        .hentry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
+          bottom: 100%;
+          display: block;
+          position: absolute; } }
   .hentry .entry-footer {
-    max-width: calc(6 * (100vw / 12));
-  }
-}
-
-.hentry .post-thumbnail {
-  margin: 1rem;
-}
-
-@media only screen and (min-width: 768px) {
+    margin: calc(2 * 1rem) 1rem 1rem; }
+    @media only screen and (min-width: 768px) {
+      .hentry .entry-footer {
+        margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+        max-width: calc(8 * (100vw / 12)); } }
+    @media only screen and (min-width: 768px) {
+      .hentry .entry-footer {
+        max-width: calc(6 * (100vw / 12)); } }
   .hentry .post-thumbnail {
-    margin: 1rem calc(2 * (100vw / 12));
-  }
-}
-
-.hentry .post-thumbnail:focus {
-  outline: none;
-}
-
-.hentry .post-thumbnail .post-thumbnail-inner {
-  display: block;
-}
-
-.hentry .post-thumbnail .post-thumbnail-inner img {
-  position: relative;
-  display: block;
-  width: 100%;
-}
-
-.image-filters-enabled .hentry .post-thumbnail {
-  position: relative;
-  display: block;
-}
-
-.image-filters-enabled .hentry .post-thumbnail .post-thumbnail-inner {
-  position: relative;
-  filter: grayscale(100%);
-  z-index: 1;
-}
-
-.image-filters-enabled .hentry .post-thumbnail .post-thumbnail-inner:after {
-  display: block;
-  width: 100%;
-  height: 100%;
-  z-index: 10;
-}
-
-.image-filters-enabled .hentry .post-thumbnail:before, .image-filters-enabled .hentry .post-thumbnail:after {
-  position: absolute;
-  display: block;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  content: "\020";
-  display: block;
-}
-
-.image-filters-enabled .hentry .post-thumbnail:before {
-  background: #0073aa;
-  mix-blend-mode: screen;
-  opacity: 0.1;
-  z-index: 2;
-}
-
-.image-filters-enabled .hentry .post-thumbnail:after {
-  background: #0073aa;
-  mix-blend-mode: multiply;
-  opacity: 1;
-  z-index: 3;
-}
-
-.hentry .entry-content .more-link {
-  transition: color 110ms ease-in-out;
-  display: inline;
-  color: inherit;
-}
-
-.hentry .entry-content .more-link:after {
-  content: "»";
-  margin-left: 0.5em;
-}
-
-.hentry .entry-content .more-link:hover {
-  color: #0073aa;
-  text-decoration: none;
-}
+    margin: 1rem; }
+    @media only screen and (min-width: 768px) {
+      .hentry .post-thumbnail {
+        margin: 1rem calc(2 * (100vw / 12)); } }
+    .hentry .post-thumbnail:focus {
+      outline: none; }
+    .hentry .post-thumbnail .post-thumbnail-inner {
+      display: block; }
+      .hentry .post-thumbnail .post-thumbnail-inner img {
+        position: relative;
+        display: block;
+        width: 100%; }
+  .image-filters-enabled .hentry .post-thumbnail {
+    position: relative;
+    display: block; }
+    .image-filters-enabled .hentry .post-thumbnail .post-thumbnail-inner {
+      position: relative;
+      filter: grayscale(100%);
+      z-index: 1; }
+      .image-filters-enabled .hentry .post-thumbnail .post-thumbnail-inner:after {
+        display: block;
+        width: 100%;
+        height: 100%;
+        z-index: 10; }
+    .image-filters-enabled .hentry .post-thumbnail:before, .image-filters-enabled .hentry .post-thumbnail:after {
+      position: absolute;
+      display: block;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      content: "\020";
+      display: block; }
+    .image-filters-enabled .hentry .post-thumbnail:before {
+      background: #0073aa;
+      mix-blend-mode: screen;
+      opacity: 0.1;
+      z-index: 2; }
+    .image-filters-enabled .hentry .post-thumbnail:after {
+      background: #0073aa;
+      mix-blend-mode: multiply;
+      opacity: 1;
+      z-index: 3; }
+  .hentry .entry-content .more-link {
+    transition: color 110ms ease-in-out;
+    display: inline;
+    color: inherit; }
+    .hentry .entry-content .more-link:after {
+      content: "»";
+      margin-left: 0.5em; }
+    .hentry .entry-content .more-link:hover {
+      color: #0073aa;
+      text-decoration: none; }
 
 /*--------------------------------------------------------------
 ## Comments
 --------------------------------------------------------------*/
 .comment-content a {
-  word-wrap: break-word;
-}
+  word-wrap: break-word; }
 
 .bypostauthor {
-  display: block;
-}
+  display: block; }
 
 .comments-area {
   /* Add extra margin when the comments section is located immediately after the
-	 * post itself (this happens on pages). */
-}
-
-.hentry + .comments-area {
-  margin-top: calc(3 * 1rem);
-}
-
-.comments-area .comments-title-wrap,
-.comments-area .comment-list,
-.comments-area > .comment-respond,
-.comments-area .comment-form-flex,
-.comments-area .no-comments {
-  margin: calc(2 * 1rem) 1rem;
-}
-
-@media only screen and (min-width: 768px) {
+	 * post itself (this happens on pages). */ }
+  .hentry + .comments-area {
+    margin-top: calc(3 * 1rem); }
   .comments-area .comments-title-wrap,
   .comments-area .comment-list,
   .comments-area > .comment-respond,
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
-  }
-}
-
-.comments-area .comments-title-wrap {
-  align-items: baseline;
-  display: flex;
-  justify-content: space-between;
-}
-
-.comments-area .comments-title-wrap .comments-title {
-  margin: 0;
-}
-
-.comments-area .comments-title-wrap .comments-title:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
+    margin: calc(2 * 1rem) 1rem; }
+    @media only screen and (min-width: 768px) {
+      .comments-area .comments-title-wrap,
+      .comments-area .comment-list,
+      .comments-area > .comment-respond,
+      .comments-area .comment-form-flex,
+      .comments-area .no-comments {
+        margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+        max-width: calc(6 * (100vw / 12)); } }
+  .comments-area .comments-title-wrap {
+    align-items: baseline;
+    display: flex;
+    justify-content: space-between; }
+    .comments-area .comments-title-wrap .comments-title {
+      margin: 0; }
+      .comments-area .comments-title-wrap .comments-title:before {
+        background: #767676;
+        content: "\020";
+        display: block;
+        height: 2px;
+        margin: 1rem 0;
+        width: 1em; }
 
 #comment {
   max-width: 100%;
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 #respond {
-  position: relative;
-}
-
-#respond .comment-user-avatar {
-  display: none;
-}
-
-#respond .comment-form {
-  padding-left: calc(1rem + calc(.5 * (100vw / 12)));
-}
-
-.comment #respond .comment-form {
-  padding-left: 0;
-}
-
-#respond .comment-form-comment label[for="comment"]:first-child {
-  display: none;
-}
-
-#respond > small {
-  display: block;
-  font-size: 22px;
-  position: absolute;
-  left: calc(1rem + 100%);
-  top: calc(-3.5 * 1rem);
-  width: calc(100vw / 12);
-}
+  position: relative; }
+  #respond .comment-user-avatar {
+    display: none; }
+  #respond .comment-form {
+    padding-left: calc(1rem + calc(.5 * (100vw / 12))); }
+    .comment #respond .comment-form {
+      padding-left: 0; }
+  #respond .comment-form-comment label[for="comment"]:first-child {
+    display: none; }
+  #respond > small {
+    display: block;
+    font-size: 22px;
+    position: absolute;
+    left: calc(1rem + 100%);
+    top: calc(-3.5 * 1rem);
+    width: calc(100vw / 12 ); }
 
 #comments > .comments-title:last-child {
-  display: none;
-}
+  display: none; }
 
 @media only screen and (min-width: 1168px) {
   #comments > #respond .comment-user-avatar {
     position: absolute;
     display: block;
     top: 0;
-    left: 0;
-  }
-  #comments > #respond .comment-user-avatar .avatar {
-    display: block;
-  }
-}
+    left: 0; }
+    #comments > #respond .comment-user-avatar .avatar {
+      display: block; } }
 
 .comment-form-flex {
   display: flex;
-  flex-direction: column;
-}
-
-.comment-form-flex .comments-title {
-  display: none;
-  margin: 0;
-  order: 1;
-}
-
-.comment-form-flex #respond {
-  order: 2;
-}
-
-.comment-form-flex #respond + .comments-title {
-  display: block;
-}
+  flex-direction: column; }
+  .comment-form-flex .comments-title {
+    display: none;
+    margin: 0;
+    order: 1; }
+  .comment-form-flex #respond {
+    order: 2; }
+    .comment-form-flex #respond + .comments-title {
+      display: block; }
 
 .comment-list {
   list-style: none;
-  padding: 0;
-}
-
-.comment-list .children {
-  margin: 0;
-  padding: 0 0 0 1rem;
-}
-
-.comment-list > .comment:first-child {
-  margin-top: 0;
-}
+  padding: 0; }
+  .comment-list .children {
+    margin: 0;
+    padding: 0 0 0 1rem; }
+  .comment-list > .comment:first-child {
+    margin-top: 0; }
 
 .comment-reply {
   left: calc(1rem + 100%);
   bottom: 0;
-  position: absolute;
-}
-
-#respond + .comment-reply {
-  display: none;
-}
-
-.comment-reply .comment-reply-link {
-  display: inline-block;
-}
+  position: absolute; }
+  #respond + .comment-reply {
+    display: none; }
+  .comment-reply .comment-reply-link {
+    display: inline-block; }
 
 .comment {
   list-style: none;
-  position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .comment {
-    padding-left: calc(.5 * (1rem + calc(100vw / 12 )));
-  }
-  .comment .children {
-    padding-left: 0;
-  }
-}
-
-.comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link-sep,
-.comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link {
-  opacity: 1;
-}
-
-.comment .comment-body {
-  margin: calc(2 * 1rem) 0;
-}
-
-.comment .comment-meta {
-  position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-author {
-    display: inline-block;
-    vertical-align: baseline;
-  }
-}
-
-.comment .comment-author .avatar {
-  float: left;
-  margin-right: 1rem;
-  position: relative;
-}
-
-@media only screen and (min-width: 768px) {
+  position: relative; }
+  @media only screen and (min-width: 768px) {
+    .comment {
+      padding-left: calc(.5 * (1rem + calc(100vw / 12 ))); }
+      .comment .children {
+        padding-left: 0; } }
+  .comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link-sep,
+  .comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link {
+    opacity: 1; }
+  .comment .comment-body {
+    margin: calc(2 * 1rem) 0; }
+  .comment .comment-meta {
+    position: relative; }
+  @media only screen and (min-width: 768px) {
+    .comment .comment-author {
+      display: inline-block;
+      vertical-align: baseline; } }
   .comment .comment-author .avatar {
-    float: inherit;
-    margin-right: inherit;
-    position: absolute;
-    top: 0;
-    right: calc(100% + 1rem);
-  }
-}
-
-.comment .comment-author .fn {
-  position: relative;
-  display: block;
-}
-
-@media only screen and (min-width: 768px) {
+    float: left;
+    margin-right: 1rem;
+    position: relative; }
+    @media only screen and (min-width: 768px) {
+      .comment .comment-author .avatar {
+        float: inherit;
+        margin-right: inherit;
+        position: absolute;
+        top: 0;
+        right: calc(100% + 1rem); } }
   .comment .comment-author .fn {
-    display: inline-block;
-    vertical-align: baseline;
-  }
-}
-
-.comment .comment-author .fn a {
-  color: inherit;
-}
-
-.comment .comment-author .fn a:hover {
-  color: #005177;
-}
-
-.comment .comment-author .post-author-badge {
-  border-radius: 100%;
-  display: block;
-  height: 18px;
-  position: absolute;
-  background: #008fd3;
-  right: calc(100% + 0.25rem);
-  top: -3px;
-  width: 18px;
-}
-
-.comment .comment-author .post-author-badge svg {
-  width: inherit;
-  height: inherit;
-  display: block;
-  fill: white;
-  transform: scale(0.875);
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-metadata {
-    display: inline-block;
-    margin-left: 1rem;
     position: relative;
-    vertical-align: baseline;
-  }
-}
-
-.comment .comment-metadata > a,
-.comment .comment-metadata .comment-edit-link {
-  display: inline-block;
-  font-weight: 500;
-  color: #767676;
-  vertical-align: baseline;
-}
-
-.comment .comment-metadata > a time,
-.comment .comment-metadata .comment-edit-link time {
-  vertical-align: baseline;
-}
-
-.comment .comment-metadata > a:hover,
-.comment .comment-metadata .comment-edit-link:hover {
-  color: #4a4a4a;
-  text-decoration: none;
-}
-
-.comment .comment-metadata > * {
-  display: inline-block;
-}
-
-.comment .comment-metadata .edit-link-sep {
-  color: #767676;
-  margin: 0 0.2em;
-  opacity: 0;
-  transition: opacity 200ms ease-in-out;
-  vertical-align: baseline;
-}
-
-.comment .comment-metadata .edit-link {
-  color: #767676;
-  transition: opacity 200ms ease-in-out;
-  opacity: 0;
-}
-
-.comment .comment-metadata .edit-link svg {
-  transform: scale(0.8);
-  vertical-align: baseline;
-  margin-right: 0.1em;
-}
-
-.comment .comment-metadata .comment-edit-link {
-  position: relative;
-  padding-left: 1rem;
-  margin-left: -1rem;
-  z-index: 1;
-}
-
-.comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
-}
-
-.comment .comment-content {
-  margin: 1rem 0;
-}
-
-.comment .comment-content > *:first-child {
-  margin-top: 0;
-}
-
-.comment .comment-content > *:last-child {
-  margin-bottom: 0;
-}
+    display: block; }
+    @media only screen and (min-width: 768px) {
+      .comment .comment-author .fn {
+        display: inline-block;
+        vertical-align: baseline; } }
+    .comment .comment-author .fn a {
+      color: inherit; }
+      .comment .comment-author .fn a:hover {
+        color: #005177; }
+  .comment .comment-author .post-author-badge {
+    border-radius: 100%;
+    display: block;
+    height: 18px;
+    position: absolute;
+    background: #008fd3;
+    right: calc(100% + 0.25rem);
+    top: -3px;
+    width: 18px; }
+    .comment .comment-author .post-author-badge svg {
+      width: inherit;
+      height: inherit;
+      display: block;
+      fill: white;
+      transform: scale(0.875); }
+  @media only screen and (min-width: 768px) {
+    .comment .comment-metadata {
+      display: inline-block;
+      margin-left: 1rem;
+      position: relative;
+      vertical-align: baseline; } }
+  .comment .comment-metadata > a,
+  .comment .comment-metadata .comment-edit-link {
+    display: inline-block;
+    font-weight: 500;
+    color: #767676;
+    vertical-align: baseline; }
+    .comment .comment-metadata > a time,
+    .comment .comment-metadata .comment-edit-link time {
+      vertical-align: baseline; }
+    .comment .comment-metadata > a:hover,
+    .comment .comment-metadata .comment-edit-link:hover {
+      color: #4a4a4a;
+      text-decoration: none; }
+  .comment .comment-metadata > * {
+    display: inline-block; }
+  .comment .comment-metadata .edit-link-sep {
+    color: #767676;
+    margin: 0 0.2em;
+    opacity: 0;
+    transition: opacity 200ms ease-in-out;
+    vertical-align: baseline; }
+  .comment .comment-metadata .edit-link {
+    color: #767676;
+    transition: opacity 200ms ease-in-out;
+    opacity: 0; }
+    .comment .comment-metadata .edit-link svg {
+      transform: scale(0.8);
+      vertical-align: baseline;
+      margin-right: 0.1em; }
+  .comment .comment-metadata .comment-edit-link {
+    position: relative;
+    padding-left: 1rem;
+    margin-left: -1rem;
+    z-index: 1; }
+    .comment .comment-metadata .comment-edit-link:hover {
+      color: #0073aa; }
+  .comment .comment-content {
+    margin: 1rem 0; }
+    .comment .comment-content > *:first-child {
+      margin-top: 0; }
+    .comment .comment-content > *:last-child {
+      margin-bottom: 0; }
 
 .comment-reply-link,
 #cancel-comment-reply-link {
-  font-weight: 500;
-}
-
-.comment-reply-link:hover,
-#cancel-comment-reply-link:hover {
-  color: #005177;
-}
+  font-weight: 500; }
+  .comment-reply-link:hover,
+  #cancel-comment-reply-link:hover {
+    color: #005177; }
 
 .discussion-avatar-list {
   content: "";
   display: table;
   table-layout: fixed;
   margin: 0;
-  padding: 0;
-}
-
-.discussion-avatar-list li {
-  position: relative;
-  list-style: none;
-  margin: 0 -8px 0 0;
-  padding: 0;
-  float: left;
-}
-
-.discussion-avatar-list .comment-user-avatar img {
-  height: calc(1.5 * 1rem);
-  width: calc(1.5 * 1rem);
-}
+  padding: 0; }
+  .discussion-avatar-list li {
+    position: relative;
+    list-style: none;
+    margin: 0 -8px 0 0;
+    padding: 0;
+    float: left; }
+  .discussion-avatar-list .comment-user-avatar img {
+    height: calc(1.5 * 1rem);
+    width: calc(1.5 * 1rem); }
 
 .discussion-meta .discussion-avatar-list {
   display: inline-block;
-  margin-right: 8px;
-}
+  margin-right: 8px; }
 
 .discussion-meta .discussion-meta-info {
-  margin: 0;
-}
-
-.discussion-meta .discussion-meta-info .svg-icon {
-  vertical-align: middle;
-  fill: currentColor;
-  transform: scale(0.6) scaleX(-1) translateY(-0.1em);
-  margin-left: -0.25rem;
-}
+  margin: 0; }
+  .discussion-meta .discussion-meta-info .svg-icon {
+    vertical-align: middle;
+    fill: currentColor;
+    transform: scale(0.6) scaleX(-1) translateY(-0.1em);
+    margin-left: -0.25rem; }
 
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-author,
   .comment-form .comment-form-email {
     width: calc(50% - 0.5rem);
-    float: left;
-  }
-}
+    float: left; } }
 
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-email {
-    margin-left: 1rem;
-  }
-}
+    margin-left: 1rem; } }
 
 .comment-form input[name="author"],
 .comment-form input[name="email"],
 .comment-form input[name="url"] {
   display: block;
-  width: 100%;
-}
+  width: 100%; }
 
 /*--------------------------------------------------------------
 ## Archives
 --------------------------------------------------------------*/
 .archive .page-header,
 .search .page-header {
-  margin: 1rem 1rem calc(3 * 1rem);
-}
-
-@media only screen and (min-width: 768px) {
-  .archive .page-header,
-  .search .page-header {
-    margin: 0 calc(2 * (100vw / 12)) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-.archive .page-header .page-title,
-.search .page-header .page-title {
-  color: #767676;
-  display: inline;
-  letter-spacing: normal;
-}
-
-.archive .page-header .page-title:before,
-.search .page-header .page-title:before {
-  display: none;
-}
-
-.archive .page-header .search-term,
-.archive .page-header .page-description,
-.search .page-header .search-term,
-.search .page-header .page-description {
-  display: inherit;
-  clear: both;
-}
-
-.archive .page-header .search-term:after,
-.archive .page-header .page-description:after,
-.search .page-header .search-term:after,
-.search .page-header .page-description:after {
-  content: ".";
-  font-weight: bold;
-  color: #767676;
-}
+  margin: 1rem 1rem calc(3 * 1rem); }
+  @media only screen and (min-width: 768px) {
+    .archive .page-header,
+    .search .page-header {
+      margin: 0 calc(2 * (100vw / 12)) calc(3 * 1rem);
+      max-width: calc(8 * (100vw / 12)); } }
+  .archive .page-header .page-title,
+  .search .page-header .page-title {
+    color: #767676;
+    display: inline;
+    letter-spacing: normal; }
+    .archive .page-header .page-title:before,
+    .search .page-header .page-title:before {
+      display: none; }
+  .archive .page-header .search-term,
+  .archive .page-header .page-description,
+  .search .page-header .search-term,
+  .search .page-header .page-description {
+    display: inherit;
+    clear: both; }
+    .archive .page-header .search-term:after,
+    .archive .page-header .page-description:after,
+    .search .page-header .search-term:after,
+    .search .page-header .page-description:after {
+      content: ".";
+      font-weight: bold;
+      color: #767676; }
 
 @media only screen and (min-width: 768px) {
   .hfeed .hentry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2);
-  }
-}
+    margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2); } }
 
 .not-found .search-submit {
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
 .not-found .search-field {
-  width: 100%;
-}
+  width: 100%; }
 
 /*--------------------------------------------------------------
 ## Footer
 --------------------------------------------------------------*/
 /* Site footer */
 .site-footer {
-  color: #767676;
-}
-
-.site-footer .site-info {
-  margin: calc(2 * 1rem) 1rem;
-}
-
-@media only screen and (min-width: 768px) {
+  color: #767676; }
   .site-footer .site-info {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-.site-footer a {
-  color: inherit;
-}
-
-.site-footer a:hover {
-  text-decoration: none;
-  color: #0073aa;
-}
+    margin: calc(2 * 1rem) 1rem; }
+    @media only screen and (min-width: 768px) {
+      .site-footer .site-info {
+        margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+        max-width: calc(8 * (100vw / 12)); } }
+  .site-footer a {
+    color: inherit; }
+    .site-footer a:hover {
+      text-decoration: none;
+      color: #0073aa; }
 
 /* Widgets */
 .widget {
   margin: 0 0 1rem;
-  /* Make sure select elements fit in widgets. */
-}
-
-.widget select {
-  max-width: 100%;
-}
+  /* Make sure select elements fit in widgets. */ }
+  .widget select {
+    max-width: 100%; }
 
 /* Blocks */
 /* !Block styles */
@@ -2276,133 +1735,90 @@ body.page .main-navigation {
 	& + h6 {
 		margin-top: calc(4 * 1rem);
 	}
-*/
-}
-
-@media only screen and (min-width: 768px) {
-  .entry-content > *,
-  .entry-summary > * {
-    margin: 32px calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry-content > *,
-  .entry-summary > * {
-    max-width: calc(6 * (100vw / 12));
-  }
-}
-
-.entry-content > * > *:first-child,
-.entry-summary > * > *:first-child {
-  margin-top: 0;
-}
-
-.entry-content > * > *:last-child,
-.entry-summary > * > *:last-child {
-  margin-bottom: 0;
-}
-
-.entry-content > *.alignwide,
-.entry-summary > *.alignwide {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-@media only screen and (min-width: 768px) {
+*/ }
+  @media only screen and (min-width: 768px) {
+    .entry-content > *,
+    .entry-summary > * {
+      margin: 32px calc(2 * (100vw / 12));
+      max-width: calc(8 * (100vw / 12)); } }
+  @media only screen and (min-width: 1168px) {
+    .entry-content > *,
+    .entry-summary > * {
+      max-width: calc(6 * (100vw / 12)); } }
+  .entry-content > * > *:first-child,
+  .entry-summary > * > *:first-child {
+    margin-top: 0; }
+  .entry-content > * > *:last-child,
+  .entry-summary > * > *:last-child {
+    margin-bottom: 0; }
   .entry-content > *.alignwide,
   .entry-summary > *.alignwide {
-    margin-left: calc(1 * (100vw / 12));
-    margin-right: calc(1 * (100vw / 12));
-    max-width: calc(10 * (100vw / 12));
-  }
-}
-
-.entry-content > *.alignfull,
-.entry-summary > *.alignfull {
-  margin-top: calc(2 * 1rem);
-  margin-right: 0;
-  margin-bottom: calc(2 * 1rem);
-  margin-left: 0;
-  max-width: 100%;
-}
-
-.entry-content > *.alignleft,
-.entry-summary > *.alignleft {
-  float: left;
-  max-width: calc(5 * (100vw / 12));
-  margin-top: 0;
-  margin-right: calc(2 * 1rem);
-}
-
-@media only screen and (min-width: 768px) {
+    margin-left: auto;
+    margin-right: auto; }
+    @media only screen and (min-width: 768px) {
+      .entry-content > *.alignwide,
+      .entry-summary > *.alignwide {
+        margin-left: calc(1 * (100vw / 12));
+        margin-right: calc(1 * (100vw / 12));
+        max-width: calc(10 * (100vw / 12)); } }
+  .entry-content > *.alignfull,
+  .entry-summary > *.alignfull {
+    margin-top: calc(2 * 1rem);
+    margin-right: 0;
+    margin-bottom: calc(2 * 1rem);
+    margin-left: 0;
+    max-width: 100%; }
   .entry-content > *.alignleft,
   .entry-summary > *.alignleft {
-    max-width: calc(4 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry-content > *.alignleft,
-  .entry-summary > *.alignleft {
-    max-width: calc(3 * (100vw / 12));
-  }
-}
-
-.entry-content > *.alignright,
-.entry-summary > *.alignright {
-  float: right;
-  max-width: calc(5 * (100vw / 12));
-  margin-top: 0;
-  margin-left: 1rem;
-  margin-right: 1rem;
-}
-
-@media only screen and (min-width: 768px) {
+    float: left;
+    max-width: calc(5 * (100vw / 12));
+    margin-top: 0;
+    margin-right: calc(2 * 1rem); }
+    @media only screen and (min-width: 768px) {
+      .entry-content > *.alignleft,
+      .entry-summary > *.alignleft {
+        max-width: calc(4 * (100vw / 12)); } }
+    @media only screen and (min-width: 1168px) {
+      .entry-content > *.alignleft,
+      .entry-summary > *.alignleft {
+        max-width: calc(3 * (100vw / 12)); } }
   .entry-content > *.alignright,
   .entry-summary > *.alignright {
-    max-width: calc(4 * (100vw / 12));
-    margin-right: calc(2 * (100vw / 12));
-  }
-}
+    float: right;
+    max-width: calc(5 * (100vw / 12));
+    margin-top: 0;
+    margin-left: 1rem;
+    margin-right: 1rem; }
+    @media only screen and (min-width: 768px) {
+      .entry-content > *.alignright,
+      .entry-summary > *.alignright {
+        max-width: calc(4 * (100vw / 12));
+        margin-right: calc(2 * (100vw / 12)); } }
 
 .entry-content .wp-block-audio {
-  width: 100%;
-}
-
-.entry-content .wp-block-audio audio {
-  width: 100%;
-}
-
-.entry-content .wp-block-audio.alignleft audio,
-.entry-content .wp-block-audio.alignright audio {
-  max-width: 190px;
-}
-
-@media only screen and (min-width: 768px) {
+  width: 100%; }
+  .entry-content .wp-block-audio audio {
+    width: 100%; }
   .entry-content .wp-block-audio.alignleft audio,
   .entry-content .wp-block-audio.alignright audio {
-    max-width: 384px;
-  }
-}
-
-@media only screen and (min-width: 1379px) {
-  .entry-content .wp-block-audio.alignleft audio,
-  .entry-content .wp-block-audio.alignright audio {
-    max-width: 385.44px;
-  }
-}
+    max-width: 190px; }
+    @media only screen and (min-width: 768px) {
+      .entry-content .wp-block-audio.alignleft audio,
+      .entry-content .wp-block-audio.alignright audio {
+        max-width: 384px; } }
+    @media only screen and (min-width: 1379px) {
+      .entry-content .wp-block-audio.alignleft audio,
+      .entry-content .wp-block-audio.alignright audio {
+        max-width: 385.44px; } }
 
 .entry-content .wp-block-video video {
-  width: 100%;
-}
+  width: 100%; }
 
 .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   background: #0073aa;
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.2;
   box-sizing: border-box;
@@ -2410,230 +1826,177 @@ body.page .main-navigation {
   padding: 0.66rem 1rem;
   outline: none;
   color: white;
-  outline: none;
-}
-
-.entry-content .wp-block-button .wp-block-button__link:hover {
-  cursor: pointer;
-}
-
-.entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:focus {
-  background: #111;
-}
-
-.entry-content .wp-block-button .wp-block-button__link:focus {
-  outline: thin dotted;
-  outline-offset: -4px;
-}
+  outline: none; }
+  .entry-content .wp-block-button .wp-block-button__link:hover {
+    cursor: pointer; }
+  .entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:focus {
+    background: #111; }
+  .entry-content .wp-block-button .wp-block-button__link:focus {
+    outline: thin dotted;
+    outline-offset: -4px; }
 
 .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
-  border-radius: 5px;
-}
+  border-radius: 5px; }
 
 .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   background: transparent;
-  border: 2px solid #0073aa;
-}
-
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
-  color: #0073aa;
-}
+  border: 2px solid #0073aa; }
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+    color: #0073aa; }
 
 .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   border-color: #111;
-  color: #111;
-}
+  color: #111; }
 
 .entry-content .wp-block-archives,
 .entry-content .wp-block-categories,
 .entry-content .wp-block-latest-posts {
   padding: 0;
-  list-style: none;
-}
-
-.entry-content .wp-block-archives li,
-.entry-content .wp-block-categories li,
-.entry-content .wp-block-latest-posts li {
-  color: #767676;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.6875);
-  font-weight: bold;
-  line-height: 1.2;
-}
-
-.entry-content .wp-block-archives li a:after,
-.entry-content .wp-block-categories li a:after,
-.entry-content .wp-block-latest-posts li a:after {
-  color: #767676;
-  content: ",";
-}
-
-.entry-content .wp-block-archives li:last-child a:after,
-.entry-content .wp-block-categories li:last-child a:after,
-.entry-content .wp-block-latest-posts li:last-child a:after {
-  color: #767676;
-  content: ".";
-}
+  list-style: none; }
+  .entry-content .wp-block-archives li,
+  .entry-content .wp-block-categories li,
+  .entry-content .wp-block-latest-posts li {
+    color: #767676;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-size: calc(22px * 1.6875 );
+    font-weight: bold;
+    line-height: 1.2; }
+    .entry-content .wp-block-archives li a:after,
+    .entry-content .wp-block-categories li a:after,
+    .entry-content .wp-block-latest-posts li a:after {
+      color: #767676;
+      content: ","; }
+    .entry-content .wp-block-archives li:last-child a:after,
+    .entry-content .wp-block-categories li:last-child a:after,
+    .entry-content .wp-block-latest-posts li:last-child a:after {
+      color: #767676;
+      content: "."; }
 
 .entry-content .wp-block-preformatted {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   line-height: 1.8;
-  padding: 1rem;
-}
+  padding: 1rem; }
 
 .entry-content .wp-block-verse {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-size: 22px;
-  line-height: 1.8;
-}
+  line-height: 1.8; }
 
 .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
   font-weight: bold;
-  margin: 0 0.25em 0 0;
-}
+  margin: 0 0.25em 0 0; }
 
 .entry-content .wp-block-pullquote {
   border: none;
-  padding: 1rem;
-}
+  padding: 1rem; }
+  .entry-content .wp-block-pullquote blockquote {
+    border: none;
+    padding-bottom: calc(2 * 1rem);
+    margin-right: 0; }
+  .entry-content .wp-block-pullquote p {
+    font-size: 2.25em;
+    font-style: italic;
+    line-height: 1.3;
+    margin-bottom: 0.5em;
+    margin-top: 0.5em;
+    color: #111; }
+  .entry-content .wp-block-pullquote cite {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-size: 0.71111em;
+    line-height: 1.6;
+    text-transform: none;
+    color: #767676; }
+  .entry-content .wp-block-pullquote.alignleft blockquote,
+  .entry-content .wp-block-pullquote.alignright blockquote {
+    padding-right: 1rem;
+    margin-left: 0;
+    text-align: left;
+    max-width: 100%; }
+  .entry-content .wp-block-pullquote.alignleft.is-style-solid-color,
+  .entry-content .wp-block-pullquote.alignright.is-style-solid-color {
+    padding: calc(2 * 1rem); }
+  .entry-content .wp-block-pullquote.alignleft:not(.is-style-solid-color) {
+    padding: 0 calc(2 * 1rem) 0 0; }
+  .entry-content .wp-block-pullquote.alignright:not(.is-style-solid-color) {
+    padding: 0 0 0 calc(2 * 1rem); }
+  .entry-content .wp-block-pullquote.is-style-solid-color p {
+    font-size: 2.25em;
+    line-height: 1.3;
+    margin-bottom: 0.5em;
+    margin-top: 0.5em; }
+  .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+    margin: 0 auto; }
+  .entry-content .wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) p,
+  .entry-content .wp-block-pullquote.is-style-solid-color cite {
+    color: white; }
+  .entry-content .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
+    background-color: #0073aa; }
+  .entry-content .wp-block-pullquote.is-style-solid-color.alignleft,
+  .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
+    padding-bottom: 1rem; }
+    .entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote,
+    .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
+      padding: 0 0 calc(2 * 1rem);
+      margin-left: 0;
+      margin-top: 0; }
 
-.entry-content .wp-block-pullquote blockquote {
-  border: none;
-  padding-bottom: calc(2 * 1rem);
-  margin-right: 0;
-}
-
-.entry-content .wp-block-pullquote p {
-  font-size: 2.25em;
-  font-style: italic;
-  line-height: 1.3;
-  margin-bottom: 0.5em;
-  margin-top: 0.5em;
-  color: #111;
-}
-
-.entry-content .wp-block-pullquote cite {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.7111111111em;
-  line-height: 1.6;
-  text-transform: none;
-  color: #767676;
-}
-
-.entry-content .wp-block-pullquote.alignleft blockquote, .entry-content .wp-block-pullquote.alignright blockquote {
-  padding-right: 1rem;
-  margin-left: 0;
-  text-align: left;
-  max-width: 100%;
-}
-
-.entry-content .wp-block-pullquote.alignleft.is-style-solid-color, .entry-content .wp-block-pullquote.alignright.is-style-solid-color {
-  padding: calc(2 * 1rem);
-}
-
-.entry-content .wp-block-pullquote.alignleft:not(.is-style-solid-color) {
-  padding: 0 calc(2 * 1rem) 0 0;
-}
-
-.entry-content .wp-block-pullquote.alignright:not(.is-style-solid-color) {
-  padding: 0 0 0 calc(2 * 1rem);
-}
-
-.entry-content .wp-block-pullquote.is-style-solid-color p {
-  font-size: 2.25em;
-  line-height: 1.3;
-  margin-bottom: 0.5em;
-  margin-top: 0.5em;
-}
-
-.entry-content .wp-block-pullquote.is-style-solid-color blockquote {
-  margin: 0 auto;
-}
-
-.entry-content .wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) p,
-.entry-content .wp-block-pullquote.is-style-solid-color cite {
-  color: white;
-}
-
-.entry-content .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
-  background-color: #0073aa;
-}
-
-.entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-  padding-bottom: 1rem;
-}
-
-.entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
-  padding: 0 0 calc(2 * 1rem);
-  margin-left: 0;
-  margin-top: 0;
-}
-
-.entry-content .wp-block-quote:not(.is-large), .entry-content .wp-block-quote:not(.is-style-large) {
+.entry-content .wp-block-quote:not(.is-large),
+.entry-content .wp-block-quote:not(.is-style-large) {
   border-left: 2px solid #0073aa;
   padding-top: 0;
-  padding-bottom: 0;
-}
+  padding-bottom: 0; }
 
 .entry-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
-  line-height: 1.8;
-}
+  line-height: 1.8; }
 
 .entry-content .wp-block-quote cite {
-  font-size: 0.7111111111em;
-}
+  font-size: 0.71111em; }
 
-.entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
+.entry-content .wp-block-quote.is-large,
+.entry-content .wp-block-quote.is-style-large {
   padding: 1rem 0 1rem 2rem;
   margin: 1rem 0;
-  border-left: none;
-}
-
-.entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
-  font-size: 1.6875em;
-  line-height: 1.4;
-  font-style: italic;
-}
-
-.entry-content .wp-block-quote.is-large cite,
-.entry-content .wp-block-quote.is-large footer, .entry-content .wp-block-quote.is-style-large cite,
-.entry-content .wp-block-quote.is-style-large footer {
-  font-size: 0.7111111111em;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
-    margin: 1rem calc(2 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
-  }
-  .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
+  border-left: none; }
+  .entry-content .wp-block-quote.is-large p,
+  .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
-  }
-}
+    line-height: 1.4;
+    font-style: italic; }
+  .entry-content .wp-block-quote.is-large cite,
+  .entry-content .wp-block-quote.is-large footer,
+  .entry-content .wp-block-quote.is-style-large cite,
+  .entry-content .wp-block-quote.is-style-large footer {
+    font-size: 0.71111em; }
+  @media only screen and (min-width: 768px) {
+    .entry-content .wp-block-quote.is-large,
+    .entry-content .wp-block-quote.is-style-large {
+      margin: 1rem calc(2 * (100vw / 12));
+      max-width: calc(6 * (100vw / 12)); }
+      .entry-content .wp-block-quote.is-large p,
+      .entry-content .wp-block-quote.is-style-large p {
+        font-size: 1.6875em; } }
 
 .entry-content .wp-block-image img {
-  display: block;
-}
+  display: block; }
 
-.entry-content .wp-block-image.alignleft, .entry-content .wp-block-image.alignright {
-  max-width: 100%;
-}
+.entry-content .wp-block-image.alignleft,
+.entry-content .wp-block-image.alignright {
+  max-width: 100%; }
 
 .entry-content .wp-block-image.alignfull img {
   width: 100vw;
   margin-left: auto;
-  margin-right: auto;
-}
+  margin-right: auto; }
 
 .entry-content .wp-block-cover-image .wp-block-cover-image-text,
 .entry-content .wp-block-cover-image h2 {
@@ -2641,250 +2004,181 @@ body.page .main-navigation {
   font-size: 2.25em;
   font-weight: bold;
   width: calc(100vw - (2 * 1rem));
-  max-width: calc(100vw - (2 * 1rem));
-}
-
-@media only screen and (min-width: 768px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image h2 {
-    width: calc(8 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image h2 {
-    width: calc(6 * (100vw / 12 ));
-    max-width: calc(6 * (100vw / 12 ));
-  }
-}
+  max-width: calc(100vw - (2 * 1rem)); }
+  @media only screen and (min-width: 768px) {
+    .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+    .entry-content .wp-block-cover-image h2 {
+      width: calc(8 * (100vw / 12));
+      max-width: calc(8 * (100vw / 12)); } }
+  @media only screen and (min-width: 1168px) {
+    .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+    .entry-content .wp-block-cover-image h2 {
+      width: calc(6 * (100vw / 12 ));
+      max-width: calc(6 * (100vw / 12 )); } }
 
 .entry-content .wp-block-cover-image.alignleft h2,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text, .entry-content .wp-block-cover-image.alignright h2,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text, .entry-content .wp-block-cover-image.aligncenter h2,
+.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.alignright h2,
+.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.aligncenter h2,
 .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text {
   width: 100%;
   z-index: 1;
   left: 50%;
   position: absolute;
   transform: translate(-50%, -50%);
-  top: 50%;
-}
+  top: 50%; }
 
 .entry-content .wp-block-cover-image.has-left-content {
-  justify-content: center;
-}
-
-.entry-content .wp-block-cover-image.has-left-content h2,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text {
-  padding: 1rem;
-}
+  justify-content: center; }
+  .entry-content .wp-block-cover-image.has-left-content h2,
+  .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text {
+    padding: 1rem; }
 
 .entry-content .wp-block-cover-image.has-right-content {
-  justify-content: center;
-}
-
-.entry-content .wp-block-cover-image.has-right-content h2,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text {
-  padding: 1rem;
-}
+  justify-content: center; }
+  .entry-content .wp-block-cover-image.has-right-content h2,
+  .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text {
+    padding: 1rem; }
 
 .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
 .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
-  margin-bottom: 16px;
-}
+  margin-bottom: 16px; }
 
 .entry-content .wp-block-audio figcaption,
 .entry-content .wp-block-video figcaption,
 .entry-content .wp-block-image figcaption,
 .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
 .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
-  text-align: left;
-}
+  text-align: left; }
 
 .entry-content .wp-block-separator,
 .entry-content hr {
   margin-bottom: 2rem;
   margin-top: 2rem;
   /* Remove duplicate rule-line when a separator
-		 * is followed by an H1, or H2 */
-}
-
-.entry-content .wp-block-separator:not(.is-style-dots),
-.entry-content hr:not(.is-style-dots) {
-  background-color: #767676;
-  border: 0;
-  height: 2px;
-}
-
-.entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
-.entry-content hr:not(.is-style-wide):not(.is-style-dots) {
-  max-width: 2.25em;
-}
-
-.entry-content .wp-block-separator + h1:before,
-.entry-content .wp-block-separator + h2:before,
-.entry-content hr + h1:before,
-.entry-content hr + h2:before {
-  display: none;
-}
-
-.entry-content .wp-block-separator.is-style-dots:before,
-.entry-content hr.is-style-dots:before {
-  color: #767676;
-  font-size: 1.6875em;
-  letter-spacing: 0.8888888889em;
-  padding-left: 0.8888888889em;
-}
+		 * is followed by an H1, or H2 */ }
+  .entry-content .wp-block-separator:not(.is-style-dots),
+  .entry-content hr:not(.is-style-dots) {
+    background-color: #767676;
+    border: 0;
+    height: 2px; }
+  .entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
+  .entry-content hr:not(.is-style-wide):not(.is-style-dots) {
+    max-width: 2.25em; }
+  .entry-content .wp-block-separator + h1:before,
+  .entry-content .wp-block-separator + h2:before,
+  .entry-content hr + h1:before,
+  .entry-content hr + h2:before {
+    display: none; }
+  .entry-content .wp-block-separator.is-style-dots:before,
+  .entry-content hr.is-style-dots:before {
+    color: #767676;
+    font-size: 1.6875em;
+    letter-spacing: 0.88889em;
+    padding-left: 0.88889em; }
 
 .entry-content .wp-block-embed-twitter {
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 .entry-content .wp-block-table td, .entry-content .wp-block-table th {
-  border-color: #767676;
-}
+  border-color: #767676; }
 
 .entry-content .wp-block-file {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.entry-content .wp-block-file .wp-block-file__button {
-  transition: background 150ms ease-in-out;
-  border: none;
-  border-radius: 5px;
-  background: #0073aa;
-  font-size: 22px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  line-height: 1.2;
-  font-weight: bold;
-  padding: 0.75rem 1rem;
-}
-
-@media only screen and (min-width: 1168px) {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
   .entry-content .wp-block-file .wp-block-file__button {
+    transition: background 150ms ease-in-out;
+    border: none;
+    border-radius: 5px;
+    background: #0073aa;
     font-size: 22px;
-    padding: 0.875rem 1.5rem;
-  }
-}
-
-.entry-content .wp-block-file .wp-block-file__button:hover {
-  cursor: pointer;
-}
-
-.entry-content .wp-block-file .wp-block-file__button:hover, .entry-content .wp-block-file .wp-block-file__button:focus {
-  background: #111;
-}
-
-.entry-content .wp-block-file .wp-block-file__button:focus {
-  outline: thin dotted;
-  outline-offset: -4px;
-}
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    line-height: 1.2;
+    font-weight: bold;
+    padding: 0.75rem 1rem; }
+    @media only screen and (min-width: 1168px) {
+      .entry-content .wp-block-file .wp-block-file__button {
+        font-size: 22px;
+        padding: 0.875rem 1.5rem; } }
+    .entry-content .wp-block-file .wp-block-file__button:hover {
+      cursor: pointer; }
+    .entry-content .wp-block-file .wp-block-file__button:hover, .entry-content .wp-block-file .wp-block-file__button:focus {
+      background: #111; }
+    .entry-content .wp-block-file .wp-block-file__button:focus {
+      outline: thin dotted;
+      outline-offset: -4px; }
 
 .entry-content .wp-block-code {
-  border-radius: 0;
-}
-
-.entry-content .wp-block-code code {
-  font-size: 1.125em;
-}
+  border-radius: 0; }
+  .entry-content .wp-block-code code {
+    font-size: 1.125em; }
 
 .entry-content .wp-block-columns .wp-block-column > *:first-child {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
 .entry-content .wp-block-columns .wp-block-column > *:last-child {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
 .entry-content .wp-block-columns[class*='has-'] > * {
-  margin-right: 1rem;
-}
-
-.entry-content .wp-block-columns[class*='has-'] > *:last-child {
-  margin-right: 0;
-}
+  margin-right: 1rem; }
+  .entry-content .wp-block-columns[class*='has-'] > *:last-child {
+    margin-right: 0; }
 
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-weight: bold;
-}
-
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
-  font-weight: normal;
-}
+  font-weight: bold; }
+  .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+    font-weight: normal; }
 
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
-  font-size: inherit;
-}
+  font-size: inherit; }
 
 .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
-  font-size: 0.7111111111em;
-}
+  font-size: 0.71111em; }
 
 /* Jetpack */
 /* Jetpack specific modules */
 .author-description {
-  margin: 3.5em 0 2.1em;
-}
-
-.author-description:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
-
-.author-description h2.author-title {
-  display: inline;
-}
-
-.author-description p.author-bio {
-  word-spacing: -0.05em;
-  display: inline;
-  color: #767676;
-  line-height: 1.3;
-}
-
-.author-description p.author-bio:before {
-  display: inline-block;
-  content: "–";
-  transform: scaleX(1.8);
-  margin: 0 0.5em;
-}
-
-@media only screen and (min-width: 768px) {
-  .author-description p.author-bio:before {
-    margin: 0 0.35em;
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .author-description p.author-bio:before {
-    margin: 0 0.3em;
-  }
-}
-
-.author-description p.author-bio a.author-link {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-weight: 700;
-  display: inline-block;
-}
-
-.author-description p.author-bio a.author-link:hover {
-  color: #005177;
-  text-decoration: none;
-}
+  margin: 3.5em 0 2.1em; }
+  .author-description:before {
+    background: #767676;
+    content: "\020";
+    display: block;
+    height: 2px;
+    margin: 1rem 0;
+    width: 1em; }
+  .author-description h2.author-title {
+    display: inline; }
+  .author-description p.author-bio {
+    word-spacing: -0.05em;
+    display: inline;
+    color: #767676;
+    line-height: 1.3; }
+    .author-description p.author-bio:before {
+      display: inline-block;
+      content: "–";
+      transform: scaleX(1.8);
+      margin: 0 0.5em; }
+      @media only screen and (min-width: 768px) {
+        .author-description p.author-bio:before {
+          margin: 0 0.35em; } }
+      @media only screen and (min-width: 1168px) {
+        .author-description p.author-bio:before {
+          margin: 0 0.3em; } }
+    .author-description p.author-bio a.author-link {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+      font-weight: 700;
+      display: inline-block; }
+      .author-description p.author-bio a.author-link:hover {
+        color: #005177;
+        text-decoration: none; }
 
 /* Media */
 .page-content .wp-smiley,
@@ -2893,115 +2187,84 @@ body.page .main-navigation {
   border: none;
   margin-bottom: 0;
   margin-top: 0;
-  padding: 0;
-}
+  padding: 0; }
 
 embed,
 iframe,
 object {
-  max-width: 100%;
-}
+  max-width: 100%; }
 
 .custom-logo-link {
-  display: inline-block;
-}
+  display: inline-block; }
 
 .avatar {
   border-radius: 100%;
   display: block;
   height: calc(2.25 * 1rem);
   min-height: inherit;
-  width: calc(2.25 * 1rem);
-}
+  width: calc(2.25 * 1rem); }
 
 svg {
   transition: fill 120ms ease-in-out;
-  fill: currentColor;
-}
+  fill: currentColor; }
 
 /*--------------------------------------------------------------
 ## Captions
 --------------------------------------------------------------*/
 .wp-caption {
-  margin-bottom: calc(1.5 * 1rem);
-}
+  margin-bottom: calc(1.5 * 1rem); }
 
 .wp-caption img[class*="wp-image-"] {
   display: block;
   margin-left: auto;
-  margin-right: auto;
-}
+  margin-right: auto; }
 
 .wp-caption .wp-caption-text {
-  margin: calc(0.875 * 1rem) 0;
-}
+  margin: calc(0.875 * 1rem) 0; }
 
 .wp-caption-text {
-  text-align: center;
-}
+  text-align: center; }
 
 /*--------------------------------------------------------------
 ## Galleries
 --------------------------------------------------------------*/
 .gallery {
-  margin-bottom: calc(1.5 * 1rem);
-}
+  margin-bottom: calc(1.5 * 1rem); }
 
 .gallery-item {
   display: inline-block;
   text-align: center;
   vertical-align: top;
-  width: 100%;
-}
-
-.gallery-columns-2 .gallery-item {
-  max-width: calc(2 * (100vw / 12));
-}
-
-.gallery-columns-3 .gallery-item {
-  max-width: calc(3 * (100vw / 12));
-}
-
-.gallery-columns-4 .gallery-item {
-  max-width: calc(4 * (100vw / 12));
-}
-
-.gallery-columns-5 .gallery-item {
-  max-width: calc(5 * (100vw / 12));
-}
-
-.gallery-columns-6 .gallery-item {
-  max-width: calc(6 * (100vw / 12));
-}
-
-.gallery-columns-7 .gallery-item {
-  max-width: calc(7 * (100vw / 12));
-}
-
-.gallery-columns-8 .gallery-item {
-  max-width: calc(8 * (100vw / 12));
-}
-
-.gallery-columns-9 .gallery-item {
-  max-width: calc(9 * (100vw / 12));
-}
+  width: 100%; }
+  .gallery-columns-2 .gallery-item {
+    max-width: calc(2 * (100vw / 12)); }
+  .gallery-columns-3 .gallery-item {
+    max-width: calc(3 * (100vw / 12)); }
+  .gallery-columns-4 .gallery-item {
+    max-width: calc(4 * (100vw / 12)); }
+  .gallery-columns-5 .gallery-item {
+    max-width: calc(5 * (100vw / 12)); }
+  .gallery-columns-6 .gallery-item {
+    max-width: calc(6 * (100vw / 12)); }
+  .gallery-columns-7 .gallery-item {
+    max-width: calc(7 * (100vw / 12)); }
+  .gallery-columns-8 .gallery-item {
+    max-width: calc(8 * (100vw / 12)); }
+  .gallery-columns-9 .gallery-item {
+    max-width: calc(9 * (100vw / 12)); }
 
 .gallery-caption {
   display: block;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
-  text-align: left;
-}
+  text-align: left; }
 
 .gallery-item > div > a {
   display: block;
   line-height: 0;
-  box-shadow: 0 0 0 0 transparent;
-}
-
-.gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
-}
+  box-shadow: 0 0 0 0 transparent; }
+  .gallery-item > div > a:focus {
+    box-shadow: 0 0 0 2px #0073aa; }


### PR DESCRIPTION
Fixes #65 
Removes unnecessary alt text (which was even not translatable) from ::after CSS/SASS rule.

Screenshots:

Before:
![capture d ecran 2018-10-17 a 04 18 50](https://user-images.githubusercontent.com/1590998/47058246-921d7780-d1c4-11e8-8e5b-2d52b791aaa1.png)
After:
![capture d ecran 2018-10-17 a 04 20 12](https://user-images.githubusercontent.com/1590998/47058253-9a75b280-d1c4-11e8-802c-3c6a6bac84fe.png)

And also the same goes for the potential custom logo of the website (same CSS rule).
Before:
![capture d ecran 2018-10-17 a 04 18 59](https://user-images.githubusercontent.com/1590998/47058285-bbd69e80-d1c4-11e8-8914-13a32af574ce.png)
After:
![capture d ecran 2018-10-17 a 04 19 55](https://user-images.githubusercontent.com/1590998/47058293-c1cc7f80-d1c4-11e8-8c2a-7d1fa89ca627.png)


Cheers,
Jb

audrasjb on w.org