### PR TITLE
Remove unnecessary display property from .alignleft and .alignright

### DIFF
--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -1,11 +1,9 @@
 .alignleft {
-	display: inline;
 	float: left;
 	margin-right: $size__spacing-unit;
 }
 
 .alignright {
-	display: inline;
 	float: right;
 	margin-left: $size__spacing-unit;
 }

--- a/style.css
+++ b/style.css
@@ -49,7 +49,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Comments
 # Blocks
 # Jetpack
-# Infinite scroll
 # Media
 	## Captions
 	## Galleries
@@ -1203,13 +1202,11 @@ body.page .main-navigation {
 
 /* Alignments */
 .alignleft {
-  display: inline;
   float: left;
   margin-right: 1rem;
 }
 
 .alignright {
-  display: inline;
   float: right;
   margin-left: 1rem;
 }


### PR DESCRIPTION
Removes `display: inline;` from `.alignleft` and `.alignright` in `_alignments.scss`. This seemed to have no negative effects on the front end. 

Fixes #71