### PR TITLE
Feature/categories block editor styles

### DIFF
--- a/style-editor.scss
+++ b/style-editor.scss
@@ -407,7 +407,7 @@ ul.wp-block-archives,
 
 	li {
 		font-family: $font__heading;
-		font-size: $font__size-lg;
+		font-size: calc(#{$font__size_base} * #{$font__size-lg / 1em} );
 		font-weight: bold;
 		line-height: $font__line-height-heading;
 


### PR DESCRIPTION
fix for #118 
<img width="1120" alt="bildschirmfoto 2018-10-17 um 23 58 03" src="https://user-images.githubusercontent.com/20684594/47118719-7f5c7e80-d268-11e8-9733-a80e99858922.png">
