### PR TITLE
Add Gulp tasks for compiling scss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,33 @@
+// Imports
+const gulp = require( 'gulp' ),
+    banner = require( 'gulp-banner' ),
+    sass = require( 'gulp-sass' ),
+    autoprefixer = require( 'gulp-autoprefixer' ),
+    rename = require( 'gulp-rename' ),
+    log = require( 'fancy-log' );
+
+// These paths should alawys be ignored when watching files
+const alwaysIgnoredPaths = [ '!node_modules/**' ];
+
+function doSass( done ) {
+    if ( arguments.length && typeof arguments[ 0 ] !== 'function' ) {
+        log( 'Sass file ' + arguments[ 0 ].path + ' changed.' );
+    }
+    log( 'Building CSS bundle...' );
+    gulp.src( 'style.scss' )
+        .pipe( sass( { outputStyle: 'expanded' } ).on( 'error', sass.logError ) )
+        .pipe( autoprefixer( { browsers: [ 'last 2 versions', 'ie >= 8' ] } ) )
+        .pipe( banner( '/* Do not modify this file directly. It is compiled from other files. */\n' ) )
+        .pipe( rename( 'style.css' ) )
+        .pipe( gulp.dest( './' ) )
+        .on( 'end', function() {
+            log( 'SCSS finished.' );
+        } );
+}
+
+gulp.task( 'sass', doSass );
+
+gulp.task( 'sass:watch', function() {
+    doSass();
+    gulp.watch( [ './**/*.scss', ...alwaysIgnoredPaths ], doSass );
+} );

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "twentynineteen",
+  "version": "1.0.0",
+  "description": "Default WP Theme",
+  "bugs": {
+    "url": "https://github.com/WordPress/twentynineteen/issues"
+  },
+  "homepage": "https://github.com/WordPress/twentynineteen#readme",
+  "devDependencies": {
+    "fancy-log": "^1.3.2",
+    "gulp": "^3.9.1",
+    "gulp-autoprefixer": "^6.0.0",
+    "gulp-banner": "^0.1.3",
+    "gulp-rename": "^1.4.0",
+    "gulp-sass": "^4.0.2"
+  }
+}


### PR DESCRIPTION
This adds a very basic Gulp process for compiling scss.

It currently only compiles to `style.css`, and does nothing for RTL, or the editor-style.css, etc. 

It can be expanded to create individual .css files in the `sass/` directory if needed. This is just a starting point for whatever is actually needed. 
 
To test (should probably be added to documentation somewhere): 
- Make sure you have `npm` [installed](https://www.npmjs.com/get-npm) 
- `npm install` to build the packages
- `gulp sass` (should build the new style.css)
- `gulp sass:watch` (should automatically build new css file on changes to any scss file in `/sass`)

cc @allancole 