### PR TITLE
Remove dash behind site title if tagline is empty

### DIFF
--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -10,9 +10,11 @@
 	// Only show description on front page.
 	$description = ( is_home() || is_front_page() ) ? get_bloginfo( 'description', 'display' ) : null;
 	?>
+    <?php if ( ! empty($description) ) : ?>
 	<p class="site-description">
 		<span class="separator">&mdash;</span> <?php echo $description; ?>
 	</p>
+    <?php endif; ?>
 	<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
 		<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'twentynineteen' ); ?>">
 			<?php 


### PR DESCRIPTION
Fixes #110 

<table>
<tr>
<td>Before:

![110 - before](https://user-images.githubusercontent.com/3323310/47132340-9aada500-d2cd-11e8-9002-8fa63b3a7d1b.png)
</td>
<td>After:

![110 - after](https://user-images.githubusercontent.com/3323310/47132342-9aada500-d2cd-11e8-9e9f-53d4193d63ec.png)
</td>
</tr>
</table>