### PR TITLE
Fixed Latest Posts Page showing the Title and and meta data of the First Post.

### DIFF
--- a/header.php
+++ b/header.php
@@ -23,12 +23,12 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'twentynineteen' ); ?></a>
 
-		<header id="masthead" class="<?php echo ! is_archive() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header' ?>">
+		<header id="masthead" class="<?php echo ! is_home() && ! is_archive() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header' ?>">
 			<div class="site-branding-container">
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 			</div><!-- .layout-wrap -->
 
-			<?php if ( ! is_archive() && twentynineteen_can_show_post_thumbnail() ) : ?>
+			<?php if ( ! is_home() && ! is_archive() && twentynineteen_can_show_post_thumbnail() ) : ?>
 				<div class="hentry">
 					<?php the_post(); ?>
 					<div class="entry-header">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -149,7 +149,7 @@ if ( ! function_exists( 'twentynineteen_post_thumbnail' ) ) :
 		?>
 
 		<figure class="post-thumbnail">
-			<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1" style="background-image: url(<?php echo esc_url($post_thumbnail) ?>);">
+			<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1" style="background-image: url(<?php echo esc_url( $post_thumbnail ); ?>);">
 				<?php
 				the_post_thumbnail( 'post-thumbnail', array(
 					'alt' => the_title_attribute( array(

--- a/style.css
+++ b/style.css
@@ -644,15 +644,6 @@ h1, h2, h3, h4, h5, h6 {
   margin: 1rem 0;
 }
 
-h1:not(.site-title):before, h2:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
-
 hr {
   background-color: #767676;
   border: 0;


### PR DESCRIPTION
Latest Posts Page showing the Title and metadata of the First Post showing in the header hero area.
Whereas the page shows all the post below it.
Eventually, It was repeating the first post twice unless we ignore the first sticky posts for Main Blog page.

I'm not sure what exactly we're planning here.

For the time being the PR saves us from some confusion.

WordPress.org: mmaumio