### PR TITLE
do not show featured image if 'your latest posts' is selected

### DIFF
--- a/header.php
+++ b/header.php
@@ -23,12 +23,12 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'twentynineteen' ); ?></a>
 
-		<header id="masthead" class="<?php echo ! is_archive() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header' ?>">
+		<header id="masthead" class="<?php echo ! is_home() && ! is_archive() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header' ?>">
 			<div class="site-branding-container">
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 			</div><!-- .layout-wrap -->
 
-			<?php if ( ! is_archive() && twentynineteen_can_show_post_thumbnail() ) : ?>
+			<?php if ( ! is_home() && ! is_archive() && twentynineteen_can_show_post_thumbnail() ) : ?>
 				<div class="hentry">
 					<?php the_post(); ?>
 					<div class="entry-header">


### PR DESCRIPTION
Closes #148 

`! is_home()` check prevents featured image block from appearing on 'your latest posts' or 'posts page' (if homepage set to 'a static page')