### PR TITLE
AMP compatibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -117,7 +117,10 @@ add_action( 'after_setup_theme', 'twentynineteen_content_width', 0 );
 function twentynineteen_scripts() {
 	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri() );
 
-	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
+	// Don't include js on AMP endpoints.
+	if ( ! is_amp_endpoint ) {
+		wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
+	}
 
 	if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) {
 		wp_add_inline_style( 'twentynineteen-style', twentynineteen_header_featured_image_css() );

--- a/functions.php
+++ b/functions.php
@@ -98,9 +98,9 @@ add_action( 'after_setup_theme', 'twentynineteen_setup' );
 
 
 /**
- * Set AMP flag.
+ * Check if AMP plugin is enabled and if AMP endpoint.
  */
-function is_amp_enabled() {
+function twentynineteen_amp_enabled() {
 	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 }
 
@@ -126,7 +126,7 @@ function twentynineteen_scripts() {
 	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri() );
 
 	// Don't include js on AMP endpoints.
-	if ( ! is_amp_enabled ) {
+	if ( ! twentynineteen_amp_enabled ) {
 		wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -96,6 +96,10 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 endif;
 add_action( 'after_setup_theme', 'twentynineteen_setup' );
 
+function is_amp_enabled() {
+	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+}
+
 /**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  *
@@ -118,7 +122,7 @@ function twentynineteen_scripts() {
 	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri() );
 
 	// Don't include js on AMP endpoints.
-	if ( ! is_amp_endpoint ) {
+	if ( ! is_amp_enabled ) {
 		wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -96,6 +96,10 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 endif;
 add_action( 'after_setup_theme', 'twentynineteen_setup' );
 
+
+/**
+ * Set AMP flag.
+ */
 function is_amp_enabled() {
 	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 }

--- a/header.php
+++ b/header.php
@@ -14,7 +14,7 @@
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
-	<?php if ( ! is_amp_enabled() ) { ?>
+	<?php if ( ! twentynineteen_amp_enabled() ) { ?>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<?php } else { ?>
 	<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/header.php
+++ b/header.php
@@ -14,7 +14,7 @@
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
-	<?php if ( ! is_amp_endpoint() ) { ?>
+	<?php if ( ! is_amp_enabled() ) { ?>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<?php } else { ?>
 	<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/header.php
+++ b/header.php
@@ -14,7 +14,11 @@
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<?php if ( ! is_amp_endpoint() ) { ?>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<?php } else { ?>
+	<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+	<?php } ?>
 	<link rel="profile" href="https://gmpg.org/xfn/11" />
 	<?php wp_head(); ?>
 </head>


### PR DESCRIPTION
This is just a start on #94 , I will keep working on this PR as the theme develops to check the theme is AMP compatible. These changes just resolve some AMP validation issues popping up in the validation checker.

- Adds `twentynineteen_amp_enabled()` function to check whether response is being served as AMP and plugin is enabled.
- Don't enqueue `skip-link-focus-fix.js` on AMP responses since it is not allowed in AMP.
- Conditional added around viewport meta tag as `minimum-scale=1` is required in AMP but probably not desirable in non-AMP cases.

