### PR TITLE
Escaping author display name in get_the_author() in author-info.php

### DIFF
--- a/template-parts/post/author-info.php
+++ b/template-parts/post/author-info.php
@@ -10,7 +10,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-description">
 	<h2 class="author-title">
 		<span class="author-heading"><?php _e( 'Published by', 'twentynineteen' ); ?></span>
-		<?php echo get_the_author(); ?>
+		<?php echo esc_html( get_the_author() ); ?>
 	</h2>
 	<p class="author-bio">
 		<?php the_author_meta( 'description' ); ?>


### PR DESCRIPTION
esc_url() function not being used in author-info.php to escape the output of author display name with get_author_name()
