### PR TITLE
Add minimum-scale=1 to meta viewport

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,7 +14,7 @@
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 	<link rel="profile" href="https://gmpg.org/xfn/11" />
 	<?php wp_head(); ?>
 </head>


### PR DESCRIPTION
The use of `minimum-scale=1` is [required](https://www.ampproject.org/docs/fundamentals/spec#vprt) for valid AMP documents:

> contain a `<meta name="viewport" content="width=device-width,minimum-scale=1">` tag inside their head tag. It's also recommended to include `initial-scale=1`.

The theme is already doing the required`width=device-width` and the recommended `initial-scale=1`, but it is not doing `minimum-scale=1`. Any reason not to include it?