### PR TITLE
Only show site-title as a h1 when it's the homepage/frontpage

### DIFF
--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -8,6 +8,7 @@ h2.author-title,
 .comments-title,
 .comment-author .fn,
 .no-comments,
+.site-title,
 h1, h2, h3, h4, h5, h6 {
 	font-family: $font__heading;
 	font-weight: 700;

--- a/style.css
+++ b/style.css
@@ -428,6 +428,7 @@ h2.author-title,
 .comments-title,
 .comment-author .fn,
 .no-comments,
+.site-title,
 h1, h2, h3, h4, h5, h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 700;

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -12,8 +12,12 @@
 		<div class="site-logo"><?php the_custom_logo(); ?></div>
 	<?php endif; ?>
 
-	<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-
+	<?php if ( is_front_page() && is_home() ) : ?>
+		<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+	<?php else : ?>
+		<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+	<?php endif; ?>
+	
 	<?php
 		$description = get_bloginfo( 'description', 'display' );
 		if ( $description || is_customize_preview() ) :


### PR DESCRIPTION
For better SEO, and for preventing the appearance of more than one h1 on the page. Fixes #5, and addresses one checkbox  in #41.

This is basically just an updated version of #3 (it was quicker than solving the merge conflicts in that branch), so @audrasjb gets all the props for this one. 🙌