### PR TITLE
Escaping author display name in get_the_author() in author-info.php

### DIFF
--- a/template-parts/post/author-info.php
+++ b/template-parts/post/author-info.php
@@ -9,8 +9,7 @@
 if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-description">
 	<h2 class="author-title">
-		<span class="author-heading"><?php _e( 'Published by', 'twentynineteen' ); ?></span>
-		<?php echo get_the_author(); ?>
+		<span class="author-heading"><?php echo esc_html( sprintf( __( 'Published by %s', 'twentynineteen' ), get_the_author() ) ); ?></span>
 	</h2>
 	<p class="author-bio">
 		<?php the_author_meta( 'description' ); ?>


### PR DESCRIPTION
Added as Fresh PR for the existing issue due to some conflict with the previous branch.