### PR TITLE
Position comments navigation below comments list

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -84,17 +84,6 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 		<?php
 
-		// Show comment form at bottom if showing newest comments at the bottom.
-		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
-			?>
-			<div class="comment-form-flex">
-				<span class="screen-reader-text"><?php esc_html_e( 'Leave a comment', 'twentynineteen' ); ?></span>
-				<?php twentynineteen_comment_form( 'asc' ); ?>
-				<h2 class="comments-title" aria-hidden="true"><?php esc_html_e( 'Leave a comment', 'twentynineteen' ); ?></h2>
-			</div>
-			<?php
-		endif;
-
 		// Show comment navigation
 		if ( have_comments() ) :
 			$prev_icon     = twentynineteen_get_icon_svg( 'chevron_left', 22 );
@@ -106,6 +95,17 @@ if ( post_password_required() ) {
 					'next_text' => sprintf( '<span class="nav-next-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span> %s', __( 'Next', 'twentynineteen' ), __( 'Comments', 'twentynineteen' ), $next_icon ),
 				)
 			);
+		endif;
+
+		// Show comment form at bottom if showing newest comments at the bottom.
+		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
+			?>
+			<div class="comment-form-flex">
+				<span class="screen-reader-text"><?php esc_html_e( 'Leave a comment', 'twentynineteen' ); ?></span>
+				<?php twentynineteen_comment_form( 'asc' ); ?>
+				<h2 class="comments-title" aria-hidden="true"><?php esc_html_e( 'Leave a comment', 'twentynineteen' ); ?></h2>
+			</div>
+			<?php
 		endif;
 
 		// If comments are closed and there are comments, let's leave a little note, shall we?


### PR DESCRIPTION
Fixes #211 

Due to yesterdays Github issues, this PR got stuck somewhere. I just added a space behind the comment to push it again.