### PR TITLE
Remove unused IE stylesheet enqueue.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -135,8 +135,6 @@ function twentynineteen_scripts() {
 
 	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
 
-	wp_enqueue_style( 'ie-theme', get_stylesheet_directory_uri() . '/css/ie.css' );
-
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 
 	if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) {


### PR DESCRIPTION
Removes an unused IE stylesheet. I don't think this is intentionally included in here, but CC-ing @allancole to confirm. 

Fixes #248 