### PR TITLE
Generate post thumbnail variable for single post pages.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -140,6 +140,7 @@ if ( ! function_exists( 'twentynineteen_post_thumbnail' ) ) :
 		}
 
 		if ( is_singular() ) :
+			$post_thumbnail = get_the_post_thumbnail_url( get_the_ID(), 'post-thumbnail' );
 			?>
 
 			<figure class="post-thumbnail">


### PR DESCRIPTION
#240 removed the generation of `$post_thumbnail` variable in post lists. But it also seems to have removed the overlay from single post pages as well.

I'm not 100% sure why that happened, but generating the `$post_thumbnail` for `is_singular()` posts seems to fix. 

cc @allancole for a review. 