### PR TITLE
Avoid CI conflict with stock twentynineteen theme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ before_script:
     - theme_slug=$(basename $(pwd))
     - theme_dir=$WP_DEVELOP_DIR/src/wp-content/themes/$theme_slug
     - cd ..
+    # Avoid conflict with stock twentynineteen theme
+    - if [ -d $theme_dir ]; then rm -r $theme_dir; fi
     - mv $theme_slug $theme_dir
     # Set up WordPress configuration.
     - cd $WP_DEVELOP_DIR


### PR DESCRIPTION
The reason our CI builds are failing is that `twentynineteen` is now included on the WordPress 5.0 branch we clone for test. This PR simply removes `wp-content/themes/twentynineteen` before moving the development version of twentynineteen into its place.

cc @kjellr 