### PR TITLE
Adjust main menu

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -2,11 +2,7 @@
 
 .main-navigation {
 
-	display: inline;
-
-	@include media(tablet) {
-		display: block;
-	}
+	display: block;
 
 	body.page & {
 		display: block;
@@ -25,15 +21,17 @@
 		> li {
 
 			display: inline;
+			position: relative;
 
 			> a {
 
 				font-weight: 700;
 				color: $color__link;
+				margin-right: #{0.5 * $size__spacing-unit};
 
 				+ svg {
 					color: $color__link;
-					margin-right: #{-0.25 * $size__spacing-unit};
+					margin-right: #{0.5 * $size__spacing-unit};
 				}
 
 				&:hover {
@@ -42,20 +40,12 @@
 						color: $color__link-hover;
 					}
 				}
-
-				&:after {
-					content: ",";
-					display: inline;
-					color: $color__text-light;
-				}
 			}
 
 			&.menu-item-has-children {
 
-				&:after {
-					content: ",";
-					display: inline;
-					color: $color__text-light;
+				> a {
+					margin-right: #{0.125 * $size__spacing-unit};
 				}
 
 				& > a,
@@ -66,10 +56,6 @@
 						display: none;
 					}
 				}
-			}
-
-			&:last-child> a:after {
-				content: ".";
 			}
 
 			&:last-child > a {
@@ -147,9 +133,11 @@
 	.main-menu .menu-item-has-children:hover > .sub-menu,
 	.main-menu .menu-item-has-children .sub-menu:hover {
 		display: block;
-		left: inherit;
-		margin-top: -2px;
+		left: 0;
+		margin-top: 0;
 		opacity: 1;
+		position: absolute;
+		width: max-content;
 
 		.sub-menu {
 
@@ -173,7 +161,7 @@
 	.main-menu .menu-item-has-children:focus-within > .sub-menu {
 		display: block;
 		left: inherit;
-		margin-top: -2px;
+		margin-top: 0;
 		opacity: 1;
 
 		.sub-menu {

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -3,6 +3,7 @@
 .main-navigation {
 
 	display: block;
+	margin-top: #{0.25 * $size__spacing-unit};
 
 	body.page & {
 		display: block;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -31,7 +31,6 @@
 
 	@include media(tablet) {
 		margin: 0 calc(2 * (100vw / 12));
-		max-width: 22em;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -913,6 +913,7 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   display: block;
+  margin-top: 0.25rem;
   /*
 	 * :focus-within needs its own selector so other similar
 	 * selectors don’t get ignored if a browser doesn’t recognize it

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -133,8 +133,7 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -556,18 +555,14 @@ h6 {
 .error-404 .page-title,
 .comments-title,
 blockquote {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
   word-break: break-word;
 }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    -webkit-hyphens: none;
-        -ms-hyphens: none;
-            hyphens: none;
+    hyphens: none;
   }
 }
 
@@ -917,17 +912,11 @@ a:focus {
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  display: inline;
+  display: block;
   /*
 	 * :focus-within needs its own selector so other similar
 	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation {
-    display: block;
-  }
 }
 
 body.page .main-navigation {
@@ -946,16 +935,18 @@ body.page .main-navigation {
 
 .main-navigation .main-menu > li {
   display: inline;
+  position: relative;
 }
 
 .main-navigation .main-menu > li > a {
   font-weight: 700;
   color: #0073aa;
+  margin-left: 0.5rem;
 }
 
 .main-navigation .main-menu > li > a + svg {
   color: #0073aa;
-  margin-left: -0.25rem;
+  margin-left: 0.5rem;
 }
 
 .main-navigation .main-menu > li > a:hover {
@@ -966,26 +957,14 @@ body.page .main-navigation {
   color: #005177;
 }
 
-.main-navigation .main-menu > li > a:after {
-  content: ",";
-  display: inline;
-  color: #767676;
-}
-
-.main-navigation .main-menu > li.menu-item-has-children:after {
-  content: ",";
-  display: inline;
-  color: #767676;
+.main-navigation .main-menu > li.menu-item-has-children > a {
+  margin-left: 0.125rem;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children > a:after,
 .main-navigation .main-menu > li.menu-item-has-children .menu-item-has-children > a:after {
   content: "";
   display: none;
-}
-
-.main-navigation .main-menu > li:last-child > a:after {
-  content: ".";
 }
 
 .main-navigation .main-menu > li:last-child > a {
@@ -1004,6 +983,8 @@ body.page .main-navigation {
   opacity: 0;
   right: -999em;
   z-index: 99999;
+  -webkit-transition: opacity 0.5s ease-in-out;
+  -moz-transition: opacity 0.5s ease-in-out;
   transition: opacity 0.5s ease-in-out;
 }
 
@@ -1051,9 +1032,11 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children .sub-menu:hover {
   display: block;
-  right: inherit;
-  margin-top: -2px;
+  right: 0;
+  margin-top: 0;
   opacity: 1;
+  position: absolute;
+  width: max-content;
 }
 
 .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu .sub-menu,
@@ -1076,7 +1059,7 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: inherit;
-  margin-top: -2px;
+  margin-top: 0;
   opacity: 1;
 }
 
@@ -1175,10 +1158,7 @@ body.page .main-navigation {
 
 .post-navigation .nav-links a .meta-nav {
   color: #767676;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
@@ -1190,9 +1170,7 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a .post-title {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
 }
 
 .post-navigation .nav-links a:hover {
@@ -1321,8 +1299,7 @@ body.page .main-navigation {
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
-  -webkit-clip-path: inset(50%);
-          clip-path: inset(50%);
+  clip-path: inset(50%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -1338,8 +1315,7 @@ body.page .main-navigation {
   border-radius: 3px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
   clip: auto !important;
-  -webkit-clip-path: none;
-          clip-path: none;
+  clip-path: none;
   color: #21759b;
   display: block;
   font-size: 14px;
@@ -1449,7 +1425,6 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .site-branding {
     margin: 0 calc(2 * (100vw / 12));
-    max-width: 22em;
   }
 }
 
@@ -1611,6 +1586,7 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .hentry svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
+  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 

--- a/style.css
+++ b/style.css
@@ -918,6 +918,7 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   display: block;
+  margin-top: 0.25rem;
   /*
 	 * :focus-within needs its own selector so other similar
 	 * selectors don’t get ignored if a browser doesn’t recognize it

--- a/style.css
+++ b/style.css
@@ -917,17 +917,11 @@ a:focus {
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  display: inline;
+  display: block;
   /*
 	 * :focus-within needs its own selector so other similar
 	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation {
-    display: block;
-  }
 }
 
 body.page .main-navigation {
@@ -946,16 +940,18 @@ body.page .main-navigation {
 
 .main-navigation .main-menu > li {
   display: inline;
+  position: relative;
 }
 
 .main-navigation .main-menu > li > a {
   font-weight: 700;
   color: #0073aa;
+  margin-right: 0.5rem;
 }
 
 .main-navigation .main-menu > li > a + svg {
   color: #0073aa;
-  margin-right: -0.25rem;
+  margin-right: 0.5rem;
 }
 
 .main-navigation .main-menu > li > a:hover {
@@ -966,26 +962,14 @@ body.page .main-navigation {
   color: #005177;
 }
 
-.main-navigation .main-menu > li > a:after {
-  content: ",";
-  display: inline;
-  color: #767676;
-}
-
-.main-navigation .main-menu > li.menu-item-has-children:after {
-  content: ",";
-  display: inline;
-  color: #767676;
+.main-navigation .main-menu > li.menu-item-has-children > a {
+  margin-right: 0.125rem;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children > a:after,
 .main-navigation .main-menu > li.menu-item-has-children .menu-item-has-children > a:after {
   content: "";
   display: none;
-}
-
-.main-navigation .main-menu > li:last-child > a:after {
-  content: ".";
 }
 
 .main-navigation .main-menu > li:last-child > a {
@@ -1051,9 +1035,13 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children .sub-menu:hover {
   display: block;
-  left: inherit;
-  margin-top: -2px;
+  left: 0;
+  margin-top: 0;
   opacity: 1;
+  position: absolute;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
 }
 
 .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu .sub-menu,
@@ -1076,7 +1064,7 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: inherit;
-  margin-top: -2px;
+  margin-top: 0;
   opacity: 1;
 }
 
@@ -1449,7 +1437,6 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .site-branding {
     margin: 0 calc(2 * (100vw / 12));
-    max-width: 22em;
   }
 }
 


### PR DESCRIPTION
Fixes #32 partially

What I've done:

- Display main menu in full width
- Removed commas between menu items
- Removed dot behind last menu item
- Show drop-down menu below parent menu item

What needs to be done:

- Implement priority+ navigation pattern as described in https://github.com/WordPress/twentynineteen/issues/32#issuecomment-431892606

<table>
<tr>
<td>Before:

![32 - before](https://user-images.githubusercontent.com/3323310/47433088-df53a780-d7c9-11e8-92a8-f063f4483730.png)</td>
<td>After:

![32 - after](https://user-images.githubusercontent.com/3323310/47433090-dfec3e00-d7c9-11e8-980c-400117e55d73.png)</td>
</tr>
</table>
