### PR TITLE
❌ REMOVE: SVG Icons ID Attribute

### DIFF
--- a/classes/class-twentynineteen-svg-icons.php
+++ b/classes/class-twentynineteen-svg-icons.php
@@ -32,7 +32,7 @@ class TwentyNineteen_SVG_Icons {
 			$arr = array();
 		}
 		if ( array_key_exists( $icon, $arr ) ) {
-			$repl = sprintf( '<svg id="%s-icon-%s" class="svg-icon" width="%d" height="%d" aria-hidden="true" role="img" ', $group, $icon, $size, $size );
+			$repl = sprintf( '<svg class="svg-icon" width="%d" height="%d" aria-hidden="true" role="img" ', $size, $size );
 			$svg  = preg_replace( '/^<svg /', $repl, trim( $arr[ $icon ] ) ); // Add extra attributes to SVG code.
 			$svg  = preg_replace( "/([\n\t]+)/", ' ', $svg ); // Remove newlines & tabs.
 			$svg  = preg_replace( '/>\s*</', '><', $svg ); // Remove white space between SVG tags.


### PR DESCRIPTION
Quick fix for #267 

Removed the ID attribute for SVG icons to avoid duplicate IDs 💯 