### PR TITLE
Add a filter for overriding the post-thumbnail display setting

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -110,7 +110,7 @@ add_filter( 'get_the_archive_description', 'twentynineteen_get_the_archive_descr
  * Determines if post thumbnail can be displayed.
  */
 function twentynineteen_can_show_post_thumbnail() {
-	return ! post_password_required() && ! is_attachment() && has_post_thumbnail();
+	return apply_filters( 'twentynineteen_can_show_post_thumbnail', ! post_password_required() && ! is_attachment() && has_post_thumbnail() );
 }
 
 /**


### PR DESCRIPTION
This allows plugins to manipulate or override the visibility of the featured image. 