### PR TITLE
Fixes small typo in social menu aria-label

### DIFF
--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -39,7 +39,7 @@
 		</nav><!-- #site-navigation -->
 	<?php endif; ?>
 	<?php if ( has_nav_menu( 'social' ) ) : ?>
-		<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Footer Social Links Menu', 'twentynineteen' ); ?>">
+		<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'twentynineteen' ); ?>">
 			<?php
 			wp_nav_menu(
 				array(


### PR DESCRIPTION
This fixes the mislabeled Social Menu that appears in the header (not the footer).