### PR TITLE
Use the 3rd printf format arg in twentynineteen_posted_on()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -26,7 +26,7 @@ if ( ! function_exists( 'twentynineteen_posted_on' ) ) :
 		);
 
 		printf(
-			'<span class="posted-on">%1$s<a href="%2$s" rel="bookmark">' . $time_string . '</a></span>',
+			'<span class="posted-on">%1$s<a href="%2$s" rel="bookmark">%3$s</a></span>',
 			twentynineteen_get_icon_svg( 'watch', 16 ),
 			esc_url( get_permalink() ),
 			$time_string


### PR DESCRIPTION
Pretty minor issue. Just seemed odd to concatenate the `$time_string` while the rest are all using the printf format variables, especially while `$time_string` was already being passed as a replacement. 

WP.org Username: iCaleb