### PR TITLE
Remove unused variable $classes

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -190,8 +190,6 @@ if ( ! function_exists( 'twentynineteen_comment_avatar' ) ) :
 			$id_or_email = get_current_user_id();
 		}
 
-		$classes = array( 'comment-author', 'vcard' );
-
 		return sprintf( '<div class="comment-user-avatar comment-author vcard">%s</div>', get_avatar( $id_or_email, twentynineteen_get_avatar_size() ) );
 	}
 endif;


### PR DESCRIPTION
Looks like these two classes were just added straight to the markup instead.

WP.org Username: iCaleb