### PR TITLE
Remove link attributes ‘aria-haspopup’ and ‘aria-expanded’

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -184,27 +184,6 @@ function twentynineteen_get_discussion_data() {
 }
 
 /**
- * WCAG 2.0 Attributes for Dropdown Menus
- *
- * Adjustments to menu attributes tot support WCAG 2.0 recommendations
- * for flyout and dropdown menus.
- *
- * @ref https://www.w3.org/WAI/tutorials/menus/flyout/
- */
-function twentynineteen_nav_menu_link_attributes( $atts, $item, $args, $depth ) {
-
-	// Add [aria-haspopup] and [aria-expanded] to menu items that have children
-	$item_has_children = in_array( 'menu-item-has-children', $item->classes );
-	if ( $item_has_children ) {
-		$atts['aria-haspopup'] = 'true';
-		$atts['aria-expanded'] = 'false';
-	}
-
-	return $atts;
-}
-add_filter( 'nav_menu_link_attributes', 'twentynineteen_nav_menu_link_attributes', 10, 4 );
-
-/**
  * Add a dropdown icon to top-level menu items
  */
 function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {


### PR DESCRIPTION
Fixes #270 

Before:

```
<a href="http://build.wordpress-develop.test/?page_id=2" aria-haspopup="true" aria-expanded="false">About The Tests</a>
```

After:

```
<a href="http://build.wordpress-develop.test/?page_id=2">About The Tests</a>
```