### PR TITLE
Update cover image block name

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -405,9 +405,11 @@
 	}
 
 	//! Cover Image
-	.wp-block-cover-image {
+	.wp-block-cover-image,
+	.wp-block-cover {
 
 		.wp-block-cover-image-text,
+		.wp-block-cover-text,
 		h2 {
 			font-family: $font__heading;
 			font-size: $font__size-lg;
@@ -432,7 +434,8 @@
 		&.alignright,
 		&.aligncenter {
 			h2,
-			.wp-block-cover-image-text {
+			.wp-block-cover-image-text,
+			.wp-block-cover-text {
 				width: 100%;
 				z-index: 1;
 				left: 50%;
@@ -446,7 +449,8 @@
 			justify-content: center;
 
 			h2,
-			.wp-block-cover-image-text {
+			.wp-block-cover-image-text,
+			.wp-block-cover-text {
 				padding: $size__spacing-unit;
 			}
 		}
@@ -455,7 +459,8 @@
 			justify-content: center;
 
 			h2,
-			.wp-block-cover-image-text {
+			.wp-block-cover-image-text,
+			.wp-block-cover-text {
 				padding: $size__spacing-unit;
 			}
 		}

--- a/style-editor.css
+++ b/style-editor.css
@@ -133,46 +133,46 @@ figcaption,
   margin: 0 0.25em 0 0;
 }
 
-/** === Cover Image === */
-.wp-block-cover-image h2,
-.wp-block-cover-image .wp-block-cover-image-text {
+/** === Cover === */
+.wp-block-cover h2,
+.wp-block-cover .wp-block-cover-text {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 2.25em;
   font-weight: bold;
   line-height: 1.4;
 }
 
-.wp-block-cover-image.has-left-content {
+.wp-block-cover.has-left-content {
   justify-content: center;
 }
 
-.wp-block-cover-image.has-left-content h2,
-.wp-block-cover-image.has-left-content .wp-block-cover-image-text {
+.wp-block-cover.has-left-content h2,
+.wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1em;
 }
 
-.wp-block-cover-image.has-right-content {
+.wp-block-cover.has-right-content {
   justify-content: center;
 }
 
-.wp-block-cover-image.has-right-content h2,
-.wp-block-cover-image.has-right-content .wp-block-cover-image-text {
+.wp-block-cover.has-right-content h2,
+.wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1em;
 }
 
-body[data-type="core/cover-image"][data-align="left"] h2,
-body[data-type="core/cover-image"][data-align="left"] .wp-block-cover-image-text,
-body[data-type="core/cover-image"][data-align="right"] h2,
-body[data-type="core/cover-image"][data-align="right"] .wp-block-cover-image-text {
+body[data-type="core/cover"][data-align="left"] h2,
+body[data-type="core/cover"][data-align="left"] .wp-block-cover-text,
+body[data-type="core/cover"][data-align="right"] h2,
+body[data-type="core/cover"][data-align="right"] .wp-block-cover-text {
   width: 100%;
   max-width: 305px;
 }
 
 @media only screen and (min-width: 1168px) {
-  body[data-type="core/cover-image"][data-align="wide"] h2,
-  body[data-type="core/cover-image"][data-align="wide"] .wp-block-cover-image-text,
-  body[data-type="core/cover-image"][data-align="full"] h2,
-  body[data-type="core/cover-image"][data-align="full"] .wp-block-cover-image-text {
+  body[data-type="core/cover"][data-align="wide"] h2,
+  body[data-type="core/cover"][data-align="wide"] .wp-block-cover-text,
+  body[data-type="core/cover"][data-align="full"] h2,
+  body[data-type="core/cover"][data-align="full"] .wp-block-cover-text {
     padding: 0;
     width: calc(6 * (100vw / 12));
     max-width: calc(6 * (100vw / 12));

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -123,12 +123,12 @@ figcaption,
 	}
 }
 
-/** === Cover Image === */
+/** === Cover === */
 
-.wp-block-cover-image {
+.wp-block-cover {
 
 	h2,
-	.wp-block-cover-image-text {
+	.wp-block-cover-text {
 		font-family: $font__heading;
 		font-size: $font__size-xl;
 		font-weight: bold;
@@ -139,7 +139,7 @@ figcaption,
 		justify-content: center;
 
 		h2,
-		.wp-block-cover-image-text {
+		.wp-block-cover-text {
 			padding: 1em;
 		}
 	}
@@ -148,28 +148,28 @@ figcaption,
 		justify-content: center;
 
 		h2,
-		.wp-block-cover-image-text {
+		.wp-block-cover-text {
 			padding: 1em;
 		}
 	}
 }
 
-body[data-type="core/cover-image"][data-align="left"],
-body[data-type="core/cover-image"][data-align="right"] {
+body[data-type="core/cover"][data-align="left"],
+body[data-type="core/cover"][data-align="right"] {
 
 	h2,
-	.wp-block-cover-image-text {
+	.wp-block-cover-text {
 		width: 100%;
 		max-width: 305px;
 	}
 }
 
-body[data-type="core/cover-image"][data-align="wide"],
-body[data-type="core/cover-image"][data-align="full"] {
+body[data-type="core/cover"][data-align="wide"],
+body[data-type="core/cover"][data-align="full"] {
 
 	@include media(desktop) {
 		h2,
-		.wp-block-cover-image-text {
+		.wp-block-cover-text {
 			padding: 0;
 			width: calc(6 * (100vw / 12));
 			max-width: calc(6 * (100vw / 12));

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2973,7 +2973,11 @@ body.page .main-navigation {
 }
 
 .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image h2 {
+.entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry-content .wp-block-cover-image h2,
+.entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry-content .wp-block-cover .wp-block-cover-text,
+.entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1.6875em;
   font-weight: bold;
@@ -2983,7 +2987,11 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image h2 {
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     width: calc(8 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
@@ -2992,16 +3000,32 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 1168px) {
   .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image h2 {
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
     width: calc(6 * (100vw / 12 ));
     max-width: calc(6 * (100vw / 12 ));
   }
 }
 
 .entry-content .wp-block-cover-image.alignleft h2,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text, .entry-content .wp-block-cover-image.alignright h2,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text, .entry-content .wp-block-cover-image.aligncenter h2,
-.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text {
+.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry-content .wp-block-cover-image.alignright h2,
+.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry-content .wp-block-cover-image.aligncenter h2,
+.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
+.entry-content .wp-block-cover.alignleft h2,
+.entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
+.entry-content .wp-block-cover.alignleft .wp-block-cover-text,
+.entry-content .wp-block-cover.alignright h2,
+.entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
+.entry-content .wp-block-cover.alignright .wp-block-cover-text,
+.entry-content .wp-block-cover.aligncenter h2,
+.entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
+.entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
   width: 100%;
   z-index: 1;
   right: 50%;
@@ -3010,21 +3034,31 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry-content .wp-block-cover-image.has-left-content {
+.entry-content .wp-block-cover-image.has-left-content,
+.entry-content .wp-block-cover.has-left-content {
   justify-content: center;
 }
 
 .entry-content .wp-block-cover-image.has-left-content h2,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text {
+.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
+.entry-content .wp-block-cover.has-left-content h2,
+.entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1rem;
 }
 
-.entry-content .wp-block-cover-image.has-right-content {
+.entry-content .wp-block-cover-image.has-right-content,
+.entry-content .wp-block-cover.has-right-content {
   justify-content: center;
 }
 
 .entry-content .wp-block-cover-image.has-right-content h2,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text {
+.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
+.entry-content .wp-block-cover.has-right-content h2,
+.entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -2973,7 +2973,11 @@ body.page .main-navigation {
 }
 
 .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image h2 {
+.entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry-content .wp-block-cover-image h2,
+.entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry-content .wp-block-cover .wp-block-cover-text,
+.entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1.6875em;
   font-weight: bold;
@@ -2983,7 +2987,11 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image h2 {
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     width: calc(8 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
@@ -2992,16 +3000,32 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 1168px) {
   .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image h2 {
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
     width: calc(6 * (100vw / 12 ));
     max-width: calc(6 * (100vw / 12 ));
   }
 }
 
 .entry-content .wp-block-cover-image.alignleft h2,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text, .entry-content .wp-block-cover-image.alignright h2,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text, .entry-content .wp-block-cover-image.aligncenter h2,
-.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text {
+.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry-content .wp-block-cover-image.alignright h2,
+.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry-content .wp-block-cover-image.aligncenter h2,
+.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
+.entry-content .wp-block-cover.alignleft h2,
+.entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
+.entry-content .wp-block-cover.alignleft .wp-block-cover-text,
+.entry-content .wp-block-cover.alignright h2,
+.entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
+.entry-content .wp-block-cover.alignright .wp-block-cover-text,
+.entry-content .wp-block-cover.aligncenter h2,
+.entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
+.entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
   width: 100%;
   z-index: 1;
   left: 50%;
@@ -3010,21 +3034,31 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry-content .wp-block-cover-image.has-left-content {
+.entry-content .wp-block-cover-image.has-left-content,
+.entry-content .wp-block-cover.has-left-content {
   justify-content: center;
 }
 
 .entry-content .wp-block-cover-image.has-left-content h2,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text {
+.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
+.entry-content .wp-block-cover.has-left-content h2,
+.entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1rem;
 }
 
-.entry-content .wp-block-cover-image.has-right-content {
+.entry-content .wp-block-cover-image.has-right-content,
+.entry-content .wp-block-cover.has-right-content {
   justify-content: center;
 }
 
 .entry-content .wp-block-cover-image.has-right-content h2,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text {
+.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
+.entry-content .wp-block-cover.has-right-content h2,
+.entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
+.entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1rem;
 }
 


### PR DESCRIPTION
Fixes #293

The cover image block [got renamed](https://github.com/WordPress/gutenberg/pull/10659) when it added video functionality  in Gutenberg 4.1.0. This PR makes the necessary changes for our theme:

- Renames styles in `style-editor.css`
- Adds additional name selector in `_blocks.scss` (We want to include both the new and the old name here, to support cover image blocks created using prior versions of Gutenberg)

To test:
-  Update to Gutenberg 4.1.0
- Check out a cover image block.

_Before:_ 

<img width="721" alt="screen shot 2018-10-24 at 9 24 14 pm" src="https://user-images.githubusercontent.com/1202812/47470312-38740900-d7d3-11e8-8908-b196d2521b34.png">

_After_

<img width="719" alt="screen shot 2018-10-24 at 9 24 26 pm" src="https://user-images.githubusercontent.com/1202812/47470316-3b6ef980-d7d3-11e8-889b-867dcf4c3190.png">