### PR TITLE
Automatically hide overflowing menu items in a dropdown menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -136,6 +136,8 @@ function twentynineteen_scripts() {
 
 	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
 
+	wp_enqueue_script( 'twentynineteen-priority-menu', get_template_directory_uri() . '/js/priority-menu.js', array(), '20151215', true );
+
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 
 	if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) {

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -1,0 +1,124 @@
+(function() {
+	/**
+	 * Prepends an element to a container.
+	 *
+	 * @param {Element} container
+	 * @param {Element} element
+	 */
+	function prependElement(container, element) {
+		if (container.firstChild) {
+			return container.insertBefore(element, container.firstChild);
+		} else {
+			return container.appendChild(element);
+		}
+	}
+
+	/**
+	 * Shows an element by adding a hidden className.
+	 *
+	 * @param {Element} element
+	 */
+	function showElement(element) {
+		// classList.remove is not supported in IE11
+		element.className = element.className.replace("is-hidden", "");
+	}
+
+	/**
+	 * Hides an element by removing the hidden className.
+	 *
+	 * @param {Element} element
+	 */
+	function hideElement(element) {
+		// classList.add is not supported in IE11
+		if (!element.classList.contains("is-hidden")) {
+			element.className += " is-hidden";
+		}
+	}
+
+	/**
+	 * Toggles the element visibility.
+	 *
+	 * @param {Element} element
+	 */
+	function toggleElementVisibility(element) {
+		if (element.classList.contains("is-hidden")) {
+			showElement(element);
+		} else {
+			hideElement(element);
+		}
+	}
+
+	var navContainer = document.querySelector(".main-navigation ");
+	// Adds the necessary UI to operate the menu.
+	navContainer.innerHTML +=
+		'<button class="main-menu-more is-hidden">More</button>' +
+		'<ul class="hidden-links is-hidden"></ul>';
+	var navContainer = document.querySelector(".main-navigation ");
+	var toggleButton = document.querySelector(".main-navigation .main-menu-more");
+	var visibleList = document.querySelector(".main-navigation .main-menu");
+	var hiddenList = document.querySelector(".main-navigation .hidden-links");
+	var breaks = [];
+
+	/**
+	 * Returns the currently available space in the menu container.
+	 *
+	 * @returns {number} Available space
+	 */
+	function getAvailableSpace() {
+		return toggleButton.classList.contains("hidden")
+			? navContainer.offsetWidth
+			: navContainer.offsetWidth - toggleButton.offsetWidth - 30;
+	}
+
+	/**
+	 * Returns whether the current menu is overflowing or not.
+	 *
+	 * @returns {boolean} Is overflowing
+	 */
+	function isOverflowingNavivation() {
+		return visibleList.offsetWidth > getAvailableSpace();
+	}
+
+	/**
+	 * Refreshes the list item from the menu depending on the menu size
+	 */
+	function updateNavigationMenu() {
+		if (isOverflowingNavivation()) {
+			// Record the width of the list
+			breaks.push(visibleList.offsetWidth);
+			// Move item to the hidden list
+			prependElement(hiddenList, visibleList.lastChild);
+			// Show the toggle button
+			showElement(toggleButton);
+		} else {
+			// There is space for another item in the nav
+			if (getAvailableSpace() > breaks[breaks.length - 1]) {
+				// Move the item to the visible list
+				visibleList.appendChild(hiddenList.firstChild);
+				breaks.pop();
+			}
+
+			// Hide the dropdown btn if hidden list is empty
+			if (breaks.length < 1) {
+				hideElement(toggleButton);
+				hideElement(hiddenList);
+			}
+		}
+
+		// Recur if the visible list is still overflowing the nav
+		if (isOverflowingNavivation()) {
+			updateNavigationMenu();
+		}
+	}
+
+	// Event listeners
+	window.addEventListener("resize", function() {
+		updateNavigationMenu();
+	});
+
+	toggleButton.addEventListener("click", function() {
+		toggleElementVisibility(hiddenList);
+	});
+
+	updateNavigationMenu();
+})();

--- a/sass/mixins/_utilities.scss
+++ b/sass/mixins/_utilities.scss
@@ -42,3 +42,7 @@
 		@content;
 	}
 }
+
+.is-hidden {
+	display: none;
+}

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -14,21 +14,19 @@
 	}
 
 	.main-menu {
-
-		display: inline;
+		display: inline-table;
 		margin: 0;
 		padding: 0;
 
 		> li {
-
-			display: inline;
+			display: table-cell;
 			position: relative;
 
 			> a {
-
 				font-weight: 700;
 				color: $color__link;
 				margin-right: #{0.5 * $size__spacing-unit};
+				white-space: nowrap;
 
 				+ svg {
 					color: $color__link;

--- a/style-editor-frame.css
+++ b/style-editor-frame.css
@@ -7,6 +7,10 @@ NOTE: This file customizes items that are out of the normal scope of style-edito
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
+.is-hidden {
+  display: none;
+}
+
 /** === Title === */
 body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
   background: #767676;

--- a/style-editor.css
+++ b/style-editor.css
@@ -9,6 +9,10 @@ when Gutenberg supports styling those variations more intuitively.
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
+.is-hidden {
+  display: none;
+}
+
 /** === Content Width === */
 .wp-block {
   width: calc(100vw - (2 * 1rem));

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -56,6 +56,10 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
+.is-hidden {
+  display: none;
+}
+
 /* Normalize */
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
@@ -935,13 +939,13 @@ body.page .main-navigation {
 }
 
 .main-navigation .main-menu {
-  display: inline;
+  display: inline-table;
   margin: 0;
   padding: 0;
 }
 
 .main-navigation .main-menu > li {
-  display: inline;
+  display: table-cell;
   position: relative;
 }
 
@@ -949,6 +953,7 @@ body.page .main-navigation {
   font-weight: 700;
   color: #0073aa;
   margin-left: 0.5rem;
+  white-space: nowrap;
 }
 
 .main-navigation .main-menu > li > a + svg {

--- a/style.css
+++ b/style.css
@@ -56,6 +56,10 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
+.is-hidden {
+  display: none;
+}
+
 /* Normalize */
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
@@ -935,13 +939,13 @@ body.page .main-navigation {
 }
 
 .main-navigation .main-menu {
-  display: inline;
+  display: inline-table;
   margin: 0;
   padding: 0;
 }
 
 .main-navigation .main-menu > li {
-  display: inline;
+  display: table-cell;
   position: relative;
 }
 
@@ -949,6 +953,7 @@ body.page .main-navigation {
   font-weight: 700;
   color: #0073aa;
   margin-right: 0.5rem;
+  white-space: nowrap;
 }
 
 .main-navigation .main-menu > li > a + svg {


### PR DESCRIPTION
closes #268 

This PR tries to add the automatic hiding of menu elements overflowing with the container. That way the menu always shows up in a single line.

In its current state, I did the minimal CSS changes to make it work, it’s still needs to be polished design-wise and probably a11y wise too but the behavior is there.
