### PR TITLE
Only show dash in header if site title and tagline are available

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -109,6 +109,11 @@
 	@include media(tablet) {
 		display: inline;
 	}
+
+	&:not(:empty) + .site-description:not(:empty):before {
+		content: "\2014";
+		margin: 0 .2em;
+	}
 }
 
 // Site description
@@ -119,9 +124,4 @@
 	color: $color__text-light;
 	font-weight: normal;
 	margin: 0;
-
-	&:not(:empty):before {
-		content: "\2014";
-		margin: 0 .2em;
-	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1529,16 +1529,16 @@ body.page .main-navigation {
   }
 }
 
+.site-title:not(:empty) + .site-description:not(:empty):before {
+  content: "\2014";
+  margin: 0 .2em;
+}
+
 .site-description {
   display: inline;
   color: #767676;
   font-weight: normal;
   margin: 0;
-}
-
-.site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
 }
 
 .site-header.featured-image {

--- a/style.css
+++ b/style.css
@@ -1529,16 +1529,16 @@ body.page .main-navigation {
   }
 }
 
+.site-title:not(:empty) + .site-description:not(:empty):before {
+  content: "\2014";
+  margin: 0 .2em;
+}
+
 .site-description {
   display: inline;
   color: #767676;
   font-weight: normal;
   margin: 0;
-}
-
-.site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
 }
 
 .site-header.featured-image {

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -13,13 +13,13 @@
 		<div class="site-logo"><?php the_custom_logo(); ?></div>
 	<?php endif; ?>
 
-    <?php if ( ! empty( get_bloginfo( 'name' ) ) ) : ?>
-        <?php if ( is_front_page() && is_home() ) : ?>
-            <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-        <?php else : ?>
-            <p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-        <?php endif; ?>
-    <?php endif; ?>
+	<?php if ( ! empty( get_bloginfo( 'name' ) ) ) : ?>
+		<?php if ( is_front_page() && is_home() ) : ?>
+			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+		<?php else : ?>
+			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+		<?php endif; ?>
+	<?php endif; ?>
 
 	<?php
 	$description = get_bloginfo( 'description', 'display' );

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -13,11 +13,13 @@
 		<div class="site-logo"><?php the_custom_logo(); ?></div>
 	<?php endif; ?>
 
-	<?php if ( is_front_page() && is_home() ) : ?>
-		<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-	<?php else : ?>
-		<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-	<?php endif; ?>
+    <?php if ( ! empty( get_bloginfo( 'name' ) ) ) : ?>
+        <?php if ( is_front_page() && is_home() ) : ?>
+            <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+        <?php else : ?>
+            <p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+        <?php endif; ?>
+    <?php endif; ?>
 
 	<?php
 	$description = get_bloginfo( 'description', 'display' );


### PR DESCRIPTION
Fixes #310

<table>
<tr>
<td>Before:

![310 - before site title tagline](https://user-images.githubusercontent.com/3323310/47503001-45583180-d893-11e8-9af7-b3dfe6d3cf5f.png)</td>
<td>After:

![310 - after site title tagline](https://user-images.githubusercontent.com/3323310/47502652-90be1000-d892-11e8-8776-291e52d7d476.png)</td>
</tr>
</table>

<table>
<tr>
<td>Before:

![310 - before only site title](https://user-images.githubusercontent.com/3323310/47503003-45583180-d893-11e8-88ac-0156f5cee0b4.png)</td>
<td>After:

![310 - after only site title](https://user-images.githubusercontent.com/3323310/47502649-90257980-d892-11e8-8d34-4f7a3451540d.png)</td>
</tr>
</table>

<table>
<tr>
<td>Before:

![310 - before only tagline](https://user-images.githubusercontent.com/3323310/47503004-45f0c800-d893-11e8-9594-9fa2584caf91.png)</td>
<td>After:

![310 - after only tagline](https://user-images.githubusercontent.com/3323310/47502648-90257980-d892-11e8-866c-9ea60053c284.png)</td>
</tr>
</table>