### PR TITLE
add outline style to focus to make active links visible

### DIFF
--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -36,7 +36,8 @@ a:active {
 }
 
 a:focus {
-	outline: 0;
+	outline: thin;
+	outline-style: dotted;
 	text-decoration: underline;
 }
 

--- a/sass/navigation/_links.scss
+++ b/sass/navigation/_links.scss
@@ -15,7 +15,7 @@ a {
 	}
 
 	&:focus {
-		outline: 0;
+		outline: thin dotted;
 		text-decoration: underline;
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -51,7 +51,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 # Blocks
 # Media
 	## Captions
-	## Galleries
+	## Gallerie
 --------------------------------------------------------------*/
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
@@ -133,7 +133,8 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  text-decoration: underline dotted;
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -239,9 +240,9 @@ select {
  * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-[type=button],
-[type=reset],
-[type=submit] {
+[type="button"],
+[type="reset"],
+[type="submit"] {
   -webkit-appearance: button;
 }
 
@@ -249,9 +250,9 @@ button,
  * Remove the inner border and padding in Firefox.
  */
 button::-moz-focus-inner,
-[type=button]::-moz-focus-inner,
-[type=reset]::-moz-focus-inner,
-[type=submit]::-moz-focus-inner {
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -260,9 +261,9 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 button:-moz-focusring,
-[type=button]:-moz-focusring,
-[type=reset]:-moz-focusring,
-[type=submit]:-moz-focusring {
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
@@ -312,8 +313,8 @@ textarea {
  * 1. Add the correct box sizing in IE 10.
  * 2. Remove the padding in IE 10.
  */
-[type=checkbox],
-[type=radio] {
+[type="checkbox"],
+[type="radio"] {
   box-sizing: border-box;
   /* 1 */
   padding: 0;
@@ -323,8 +324,8 @@ textarea {
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-[type=number]::-webkit-inner-spin-button,
-[type=number]::-webkit-outer-spin-button {
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -332,7 +333,7 @@ textarea {
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-[type=search] {
+[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
   outline-offset: -2px;
@@ -342,7 +343,7 @@ textarea {
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type=search]::-webkit-search-decoration {
+[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
@@ -469,6 +470,7 @@ img:after,
 h1 {
   font-size: 2.25em;
 }
+
 @media only screen and (min-width: 768px) {
   h1 {
     font-size: 2.8125em;
@@ -482,12 +484,13 @@ h1 {
 h2 {
   font-size: 1.6875em;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-title,
-.not-found .page-title,
-.error-404 .page-title,
-.has-larger-font-size,
-h2 {
+  .not-found .page-title,
+  .error-404 .page-title,
+  .has-larger-font-size,
+  h2 {
     font-size: 2.25em;
   }
 }
@@ -516,7 +519,7 @@ h4 {
 .pagination .nav-links,
 .comment-content,
 h5 {
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
 }
 
 .entry-meta,
@@ -531,7 +534,7 @@ h5 {
 #cancel-comment-reply-link,
 img:after,
 h6 {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
 }
 
 .site-title,
@@ -554,14 +557,18 @@ h6 {
 .error-404 .page-title,
 .comments-title,
 blockquote {
-  hyphens: auto;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
   word-break: break-word;
 }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    hyphens: none;
+    -webkit-hyphens: none;
+        -ms-hyphens: none;
+            hyphens: none;
   }
 }
 
@@ -579,21 +586,22 @@ blockquote > p {
   font-style: italic;
   line-height: 1.2;
 }
+
 blockquote cite {
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
 pre {
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-family: "Courier 10 Pitch", Courier, monospace;
   line-height: 1.8;
   overflow: auto;
 }
 
 code, kbd, tt, var {
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
 }
 
@@ -614,9 +622,11 @@ big {
 a {
   text-decoration: none;
 }
+
 a:hover {
   text-decoration: none;
 }
+
 a:focus {
   text-decoration: underline;
 }
@@ -657,7 +667,8 @@ a:active {
 }
 
 a:focus {
-  outline: 0;
+  outline: thin;
+  outline-style: dotted;
   text-decoration: underline;
 }
 
@@ -668,7 +679,7 @@ h1, h2, h3, h4, h5, h6 {
 
 h1:not(.site-title):before, h2:before {
   background: #767676;
-  content: " ";
+  content: "\020";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -689,6 +700,7 @@ ol {
 ul {
   list-style: disc;
 }
+
 ul ul {
   list-style-type: circle;
 }
@@ -729,9 +741,11 @@ blockquote {
   margin-right: -2rem;
   padding: 1rem 2rem 0.5rem 0;
 }
+
 blockquote > p {
   margin: 0 0 1rem;
 }
+
 blockquote cite {
   color: #767676;
 }
@@ -740,6 +754,7 @@ table {
   margin: 0 0 1rem;
   width: 100%;
 }
+
 table td, table th {
   border-color: #767676;
 }
@@ -747,9 +762,9 @@ table td, table th {
 /* Forms */
 .button,
 button,
-input[type=button],
-input[type=reset],
-input[type=submit] {
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
   transition: background 150ms ease-in-out;
   background: #0073aa;
   border: none;
@@ -757,54 +772,57 @@ input[type=submit] {
   box-sizing: border-box;
   color: white;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-weight: 600;
   line-height: 1.2;
   outline: none;
   padding: 0.66rem 1rem;
 }
+
 .button:hover,
 button:hover,
-input[type=button]:hover,
-input[type=reset]:hover,
-input[type=submit]:hover {
+input[type="button"]:hover,
+input[type="reset"]:hover,
+input[type="submit"]:hover {
   cursor: pointer;
 }
+
 .button:hover, .button:focus,
 button:hover,
 button:focus,
-input[type=button]:hover,
-input[type=button]:focus,
-input[type=reset]:hover,
-input[type=reset]:focus,
-input[type=submit]:hover,
-input[type=submit]:focus {
+input[type="button"]:hover,
+input[type="button"]:focus,
+input[type="reset"]:hover,
+input[type="reset"]:focus,
+input[type="submit"]:hover,
+input[type="submit"]:focus {
   background: #111;
 }
+
 .button:focus,
 button:focus,
-input[type=button]:focus,
-input[type=reset]:focus,
-input[type=submit]:focus {
+input[type="button"]:focus,
+input[type="reset"]:focus,
+input[type="submit"]:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-input[type=text],
-input[type=email],
-input[type=url],
-input[type=password],
-input[type=search],
-input[type=number],
-input[type=tel],
-input[type=range],
-input[type=date],
-input[type=month],
-input[type=week],
-input[type=time],
-input[type=datetime],
-input[type=datetime-local],
-input[type=color],
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
 textarea {
   -webkit-backface-visibility: hidden;
   background: #fff;
@@ -813,21 +831,22 @@ textarea {
   outline: none;
   padding: 0.5rem 0.66rem;
 }
-input[type=text]:focus,
-input[type=email]:focus,
-input[type=url]:focus,
-input[type=password]:focus,
-input[type=search]:focus,
-input[type=number]:focus,
-input[type=tel]:focus,
-input[type=range]:focus,
-input[type=date]:focus,
-input[type=month]:focus,
-input[type=week]:focus,
-input[type=time]:focus,
-input[type=datetime]:focus,
-input[type=datetime-local]:focus,
-input[type=color]:focus,
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
 textarea:focus {
   border-color: #0073aa;
   outline: thin solid rgba(0, 115, 170, 0.15);
@@ -854,14 +873,17 @@ a {
   transition: color 110ms ease-in-out;
   color: #0073aa;
 }
+
 a:visited {
   color: #0073aa;
 }
+
 a:hover, a:active {
   color: #005177;
   outline: 0;
   text-decoration: none;
 }
+
 a:focus {
   outline: 0;
   text-decoration: underline;
@@ -875,51 +897,63 @@ a:focus {
   display: block;
   margin-top: 0.25rem;
   /*
-   * :focus-within needs its own selector so other similar
-   * selectors don’t get ignored if a browser doesn’t recognize it
-   */
+	 * :focus-within needs its own selector so other similar
+	 * selectors don’t get ignored if a browser doesn’t recognize it
+	 */
 }
+
 body.page .main-navigation {
   display: block;
 }
+
 .main-navigation > div {
   display: inline;
 }
+
 .main-navigation .main-menu {
   display: inline;
   margin: 0;
   padding: 0;
 }
+
 .main-navigation .main-menu > li {
   display: inline;
   position: relative;
 }
+
 .main-navigation .main-menu > li > a {
   font-weight: 700;
   color: #0073aa;
   margin-left: 0.5rem;
 }
+
 .main-navigation .main-menu > li > a + svg {
   color: #0073aa;
   margin-left: 0.5rem;
 }
+
 .main-navigation .main-menu > li > a:hover {
   color: #005177;
 }
+
 .main-navigation .main-menu > li > a:hover + svg {
   color: #005177;
 }
+
 .main-navigation .main-menu > li.menu-item-has-children > a {
   margin-left: 0.125rem;
 }
+
 .main-navigation .main-menu > li.menu-item-has-children > a:after,
 .main-navigation .main-menu > li.menu-item-has-children .menu-item-has-children > a:after {
   content: "";
   display: none;
 }
+
 .main-navigation .main-menu > li:last-child > a {
   margin-left: 0;
 }
+
 .main-navigation .sub-menu {
   background: #0073aa;
   color: #fff;
@@ -927,20 +961,22 @@ body.page .main-navigation {
   padding-right: 0;
   display: none;
   float: right;
+  width: -webkit-max-content;
+  width: -moz-max-content;
   width: max-content;
   position: absolute;
   opacity: 0;
   right: -999em;
   z-index: 99999;
-  -webkit-transition: opacity 0.5s ease-in-out;
-  -moz-transition: opacity 0.5s ease-in-out;
   transition: opacity 0.5s ease-in-out;
 }
+
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
     max-width: calc(3 * (100vw / 12));
   }
 }
+
 .main-navigation .sub-menu > li {
   clear: both;
   display: block;
@@ -948,28 +984,34 @@ body.page .main-navigation {
   position: relative;
   word-break: break-word;
 }
+
 .main-navigation .sub-menu > li.menu-item-has-children svg {
   position: absolute;
   left: 0.5rem;
   top: 0.65rem;
 }
+
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu > li.menu-item-has-children .menu-item-has-children > a:after {
-    content: "›";
+    content: "\203a";
   }
 }
+
 .main-navigation .sub-menu > li > a {
   color: #fff;
   display: block;
   line-height: 1.2;
-  padding: calc( .5 * 1rem ) 1rem calc( .5 * 1rem ) calc( 24px + 1rem );
+  padding: calc( .5 * 1rem) 1rem calc( .5 * 1rem) calc( 24px + 1rem);
 }
+
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus {
   background: #005177;
 }
+
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after {
   background: #005177;
 }
+
 .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:focus > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children .sub-menu:hover,
@@ -980,6 +1022,7 @@ body.page .main-navigation {
   opacity: 1;
   position: absolute;
 }
+
 .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:focus > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children .sub-menu:hover .sub-menu,
@@ -988,28 +1031,32 @@ body.page .main-navigation {
   position: relative;
   padding-right: 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:hover > .sub-menu .sub-menu,
-.main-navigation .main-menu .menu-item-has-children:focus > .sub-menu .sub-menu,
-.main-navigation .main-menu .menu-item-has-children .sub-menu:hover .sub-menu,
-.main-navigation .main-menu .menu-item-has-children .sub-menu:focus .sub-menu {
+  .main-navigation .main-menu .menu-item-has-children:focus > .sub-menu .sub-menu,
+  .main-navigation .main-menu .menu-item-has-children .sub-menu:hover .sub-menu,
+  .main-navigation .main-menu .menu-item-has-children .sub-menu:focus .sub-menu {
     padding-right: 0;
     position: absolute;
     right: 100%;
     top: 0;
   }
 }
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: inherit;
   margin-top: 0;
   opacity: 1;
 }
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
   margin-top: inherit;
   position: relative;
   padding-right: 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
@@ -1021,9 +1068,10 @@ body.page .main-navigation {
 
 /* Social menu */
 .social-navigation {
-  margin-top: calc(1rem / 2 );
+  margin-top: calc(1rem / 2);
   text-align: right;
 }
+
 .social-navigation ul.social-links-menu {
   content: "";
   display: table;
@@ -1032,15 +1080,18 @@ body.page .main-navigation {
   margin: 0;
   padding: 0;
 }
+
 .social-navigation ul.social-links-menu li {
   display: inline-block;
   vertical-align: bottom;
   vertical-align: -webkit-baseline-middle;
   list-style: none;
 }
+
 .social-navigation ul.social-links-menu li:nth-child(n+2) {
   margin-right: 0.1em;
 }
+
 .social-navigation ul.social-links-menu li a {
   border-bottom: 1px solid transparent;
   display: block;
@@ -1048,20 +1099,24 @@ body.page .main-navigation {
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
 }
+
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
   color: #111;
   opacity: 0.6;
 }
+
 .social-navigation ul.social-links-menu li a:focus {
   color: #111;
   opacity: 1;
   border-bottom: 1px solid #111;
 }
+
 .social-navigation ul.social-links-menu li a svg {
   display: block;
   width: 32px;
   height: 32px;
 }
+
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {
   transform: rotate(45deg);
 }
@@ -1073,29 +1128,34 @@ body.page .main-navigation {
 .post-navigation {
   margin: calc(3 * 1rem) 0;
 }
+
 @media only screen and (min-width: 768px) {
   .post-navigation {
     margin: calc(3 * 1rem) calc(2 * (100vw / 12));
     max-width: calc(6 * (100vw / 12));
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .post-navigation {
     margin: calc(3 * 1rem) 0;
     max-width: 100%;
   }
 }
+
 .post-navigation .nav-links {
   margin: 0 1rem;
   max-width: 100%;
   display: flex;
   flex-direction: column;
 }
+
 @media only screen and (min-width: 768px) {
   .post-navigation .nav-links {
     margin: 0;
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
@@ -1103,10 +1163,15 @@ body.page .main-navigation {
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 .post-navigation .nav-links a .meta-nav {
   color: #767676;
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
+
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
   display: none;
   content: "—";
@@ -1114,41 +1179,53 @@ body.page .main-navigation {
   color: #767676;
   height: 1em;
 }
+
 .post-navigation .nav-links a .post-title {
-  hyphens: auto;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
 }
+
 .post-navigation .nav-links a:hover {
   color: #005177;
 }
+
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous,
-.post-navigation .nav-links .nav-next {
+  .post-navigation .nav-links .nav-next {
     min-width: calc(50% - 2 * 1rem);
   }
 }
+
 .post-navigation .nav-links .nav-previous {
   order: 2;
 }
+
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous {
     order: 1;
   }
 }
+
 .post-navigation .nav-links .nav-previous + .nav-next {
   margin-bottom: 1rem;
 }
+
 .post-navigation .nav-links .nav-previous .meta-nav:before {
   display: inline;
 }
+
 .post-navigation .nav-links .nav-next {
   order: 1;
 }
+
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-next {
     order: 2;
     padding-right: 1rem;
   }
 }
+
 .post-navigation .nav-links .nav-next .meta-nav:after {
   display: inline;
 }
@@ -1158,26 +1235,31 @@ body.page .main-navigation {
   flex-wrap: wrap;
   padding: 0 calc(.5 * 1rem);
 }
+
 .pagination .nav-links > * {
   padding: calc(.5 * 1rem);
 }
+
 .pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
   padding-right: 0;
 }
+
 .pagination .nav-links > *.dots, .pagination .nav-links > *.next {
   padding-left: 0;
 }
+
 .pagination .nav-links .nav-next-text,
 .pagination .nav-links .nav-prev-text {
   display: none;
 }
+
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
-    margin-right: calc(2 * (100vw / 12) );
+    margin-right: calc(2 * (100vw / 12));
     padding: 0;
   }
   .pagination .nav-links .prev > *,
-.pagination .nav-links .next > * {
+  .pagination .nav-links .next > * {
     display: inline-block;
     vertical-align: text-bottom;
   }
@@ -1191,12 +1273,14 @@ body.page .main-navigation {
   flex-direction: row;
   margin: 0 1rem;
 }
+
 @media only screen and (min-width: 1168px) {
   .comment-navigation .nav-links {
     margin: 0 calc(2 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 .comment-navigation .nav-previous,
 .comment-navigation .nav-next {
   min-width: 50%;
@@ -1204,16 +1288,19 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;
 }
+
 .comment-navigation .nav-previous .secondary-text,
 .comment-navigation .nav-next .secondary-text {
   display: none;
 }
+
 @media only screen and (min-width: 768px) {
   .comment-navigation .nav-previous .secondary-text,
-.comment-navigation .nav-next .secondary-text {
+  .comment-navigation .nav-next .secondary-text {
     display: inline;
   }
 }
+
 .comment-navigation .nav-previous svg,
 .comment-navigation .nav-next svg {
   vertical-align: middle;
@@ -1221,10 +1308,12 @@ body.page .main-navigation {
   margin: 0 -0.35em;
   top: -1px;
 }
+
 .comment-navigation .nav-previous a:hover,
 .comment-navigation .nav-next a:hover {
   color: #0073aa;
 }
+
 .comment-navigation .nav-next {
   text-align: left;
 }
@@ -1234,7 +1323,8 @@ body.page .main-navigation {
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
+  -webkit-clip-path: inset(50%);
+          clip-path: inset(50%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -1244,12 +1334,14 @@ body.page .main-navigation {
   word-wrap: normal !important;
   /* Many screen reader and browser combinations announce broken words as they would appear visually. */
 }
+
 .screen-reader-text:focus {
   background-color: #f1f1f1;
   border-radius: 3px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
   clip: auto !important;
-  clip-path: none;
+  -webkit-clip-path: none;
+          clip-path: none;
   color: #21759b;
   display: block;
   font-size: 14px;
@@ -1333,6 +1425,7 @@ body.page .main-navigation {
 .site-header {
   padding: 1em;
 }
+
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
@@ -1354,6 +1447,7 @@ body.page .main-navigation {
   color: #767676;
   position: relative;
 }
+
 @media only screen and (min-width: 768px) {
   .site-branding {
     margin: 0 calc(2 * (100vw / 12));
@@ -1365,6 +1459,7 @@ body.page .main-navigation {
   z-index: 999;
   margin-bottom: calc(.66 * 1rem);
 }
+
 @media only screen and (min-width: 768px) {
   .site-logo {
     margin-bottom: 0;
@@ -1374,6 +1469,7 @@ body.page .main-navigation {
     z-index: 999;
   }
 }
+
 .site-logo .custom-logo-link {
   border-radius: 100%;
   box-sizing: content-box;
@@ -1384,12 +1480,15 @@ body.page .main-navigation {
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
+
 .site-logo .custom-logo-link .custom-logo {
   min-height: inherit;
 }
+
 .site-logo .custom-logo-link:hover, .site-logo .custom-logo-link:active, .site-logo .custom-logo-link:focus {
   box-shadow: 0 0 0 2px black;
 }
+
 @media only screen and (min-width: 768px) {
   .site-logo .custom-logo-link {
     width: 64px;
@@ -1403,31 +1502,38 @@ body.page .main-navigation {
   color: #111;
   /* When there is no description set, make sure navigation appears below title. */
 }
+
 .featured-image .site-title {
   margin: 0;
 }
+
 @media only screen and (min-width: 768px) {
   .featured-image .site-title {
     display: inline-block;
   }
 }
+
 .site-title + .main-navigation {
   display: block;
 }
+
 .site-title a {
   color: inherit;
 }
+
 .site-title a:hover {
   color: #4a4a4a;
 }
+
 @media only screen and (min-width: 768px) {
   .site-title {
     display: inline;
   }
 }
+
 .site-title:not(:empty) + .site-description:not(:empty):before {
-  content: "—";
-  margin: 0 0.2em;
+  content: "\2014";
+  margin: 0 .2em;
 }
 
 .site-description {
@@ -1460,28 +1566,35 @@ body.page .main-navigation {
   /* Fourth layer: overlay. */
   /* Fifth layer: readability overlay */
 }
+
 .site-header.featured-image .entry-meta {
   font-weight: 500;
 }
+
 .site-header.featured-image .entry-meta > span {
   margin-left: 1rem;
 }
+
 .site-header.featured-image .entry-meta > span:last-child {
   margin-left: 0;
 }
+
 .site-header.featured-image .entry-meta a {
   transition: color 110ms ease-in-out;
   color: currentColor;
 }
+
 .site-header.featured-image .entry-meta a:hover {
   text-decoration: none;
 }
+
 .site-header.featured-image .entry-meta .svg-icon {
   position: relative;
   display: inline-block;
   vertical-align: middle;
   margin-left: 0.5em;
 }
+
 .site-header.featured-image .site-branding .site-title,
 .site-header.featured-image .site-branding .site-description,
 .site-header.featured-image .main-navigation a:after,
@@ -1492,6 +1605,7 @@ body.page .main-navigation {
 .site-header.featured-image .entry-title {
   color: white;
 }
+
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .social-navigation a,
 .site-header.featured-image .site-title a,
@@ -1499,6 +1613,7 @@ body.page .main-navigation {
   color: white;
   transition: opacity 110ms ease-in-out;
 }
+
 .site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active,
 .site-header.featured-image .social-navigation a:hover,
 .site-header.featured-image .social-navigation a:active,
@@ -1509,49 +1624,58 @@ body.page .main-navigation {
   color: white;
   opacity: 0.6;
 }
+
 .site-header.featured-image .main-navigation a:focus,
 .site-header.featured-image .social-navigation a:focus,
 .site-header.featured-image .site-title a:focus,
 .site-header.featured-image .site-featured-image a:focus {
   color: white;
 }
+
 .site-header.featured-image .social-navigation a:focus {
   color: white;
   opacity: 1;
   border-bottom: 1px solid white;
 }
+
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
-  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
+
 .site-header.featured-image .site-featured-image .entry-header {
   margin-bottom: 0;
   margin-right: 0;
   margin-left: 0;
 }
+
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
     margin-right: calc(2 * (100vw / 12));
     margin-left: calc(2 * (100vw / 12));
   }
 }
+
 .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: white;
 }
+
 .site-header.featured-image .custom-logo-link {
   background: white;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
+
 .site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
+
 .site-header.featured-image .site-branding,
 .site-header.featured-image .site-featured-image .entry-header {
   position: relative;
   z-index: 10;
 }
+
 .site-header.featured-image .site-branding-container:before,
 .site-header.featured-image .site-branding-container:after,
 .site-header.featured-image .site-featured-image:before,
@@ -1560,10 +1684,11 @@ body.page .main-navigation {
   position: absolute;
   top: 0;
   right: 0;
-  content: " ";
+  content: "\020";
   width: 100%;
   height: 100%;
 }
+
 .site-header.featured-image .site-branding-container:before {
   background-position: center;
   background-repeat: no-repeat;
@@ -1571,47 +1696,55 @@ body.page .main-navigation {
   filter: grayscale(100%);
   z-index: 1;
 }
+
 .site-header.featured-image .site-featured-image:before {
   background: #0073aa;
   mix-blend-mode: screen;
   opacity: 0.1;
   z-index: 2;
 }
+
 .site-header.featured-image .site-featured-image:after {
   background: #0073aa;
   mix-blend-mode: multiply;
   opacity: 1;
   z-index: 3;
 }
+
 .site-header.featured-image .site-branding-container:after {
   background: rgba(255, 255, 255, 0.35);
   mix-blend-mode: overlay;
   opacity: 0.5;
   z-index: 4;
 }
+
 .site-header.featured-image:after {
   background: #000e14;
   /**
-   * Add a transition to the readability overlay, to add a subtle
-   * but smooth effect when resizing the screen.
-   */
+		 * Add a transition to the readability overlay, to add a subtle
+		 * but smooth effect when resizing the screen.
+		 */
   transition: opacity 1200ms ease-in-out;
   z-index: 5;
   opacity: 0.38;
 }
+
 @media only screen and (min-width: 768px) {
   .site-header.featured-image:after {
     opacity: 0.18;
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .site-header.featured-image:after {
     opacity: 0.1;
   }
 }
+
 .site-header.featured-image ::-moz-selection {
   background: rgba(255, 255, 255, 0.17);
 }
+
 .site-header.featured-image ::selection {
   background: rgba(255, 255, 255, 0.17);
 }
@@ -1629,7 +1762,7 @@ body.page .main-navigation {
   display: inline-block;
   font-weight: bold;
   line-height: 1;
-  padding: 0.25rem;
+  padding: .25rem;
   position: absolute;
   text-transform: uppercase;
   top: -1rem;
@@ -1648,58 +1781,71 @@ body.page .main-navigation {
 .entry {
   margin-top: calc(6 * 1rem);
 }
+
 .entry:first-of-type {
   margin-top: 0;
 }
+
 .entry .entry-header {
   margin: calc(3 * 1rem) 1rem 1rem;
   position: relative;
 }
+
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12 ) ) 1rem;
+    margin: calc(3 * 1rem) calc(2 * (100vw / 12 )) 1rem;
   }
 }
+
 .entry .entry-title {
   margin: 0;
 }
+
 .entry .entry-title:before {
   background: #767676;
-  content: " ";
+  content: "\020";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
+
 .entry .entry-title a {
   color: inherit;
 }
+
 .entry .entry-title a:hover {
   color: #4a4a4a;
 }
+
 .entry .entry-meta,
 .entry .entry-footer {
   color: #767676;
   font-weight: 500;
 }
+
 .entry .entry-meta > span,
 .entry .entry-footer > span {
   margin-left: 1rem;
 }
+
 .entry .entry-meta > span:last-child,
 .entry .entry-footer > span:last-child {
   margin-left: 0;
 }
+
 .entry .entry-meta a,
 .entry .entry-footer a {
   transition: color 110ms ease-in-out;
   color: currentColor;
 }
+
 .entry .entry-meta a:hover,
 .entry .entry-footer a:hover {
   text-decoration: none;
   color: #0073aa;
 }
+
 .entry .entry-meta .svg-icon,
 .entry .entry-footer .svg-icon {
   position: relative;
@@ -1707,18 +1853,22 @@ body.page .main-navigation {
   vertical-align: middle;
   margin-left: 0.5em;
 }
+
 .entry .entry-meta {
   margin: 1rem 0;
 }
+
 @media only screen and (min-width: 1168px) {
   .entry .entry-meta.has-discussion .comment-count {
     float: left;
     position: relative;
   }
 }
+
 .entry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
   display: none;
 }
+
 @media only screen and (min-width: 1168px) {
   .entry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
     bottom: 100%;
@@ -1726,54 +1876,66 @@ body.page .main-navigation {
     position: absolute;
   }
 }
+
 .entry .entry-footer {
   margin: calc(2 * 1rem) 1rem 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
     margin: calc(3 * 1rem) calc(2 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
     max-width: calc(6 * (100vw / 12));
   }
 }
+
 .entry .post-thumbnail {
   margin: 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .entry .post-thumbnail {
     margin: 1rem calc(2 * (100vw / 12));
   }
 }
+
 .entry .post-thumbnail:focus {
   outline: none;
 }
+
 .entry .post-thumbnail .post-thumbnail-inner {
   display: block;
 }
+
 .entry .post-thumbnail .post-thumbnail-inner img {
   position: relative;
   display: block;
   width: 100%;
 }
+
 .image-filters-enabled .entry .post-thumbnail {
   position: relative;
   display: block;
 }
+
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner {
   position: relative;
   filter: grayscale(100%);
   z-index: 1;
 }
+
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
   display: block;
   width: 100%;
   height: 100%;
   z-index: 10;
 }
+
 .image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
   position: absolute;
   display: block;
@@ -1781,64 +1943,77 @@ body.page .main-navigation {
   height: 100%;
   top: 0;
   right: 0;
-  content: " ";
+  content: "\020";
   display: block;
   pointer-events: none;
 }
+
 .image-filters-enabled .entry .post-thumbnail:before {
   background: #0073aa;
   mix-blend-mode: screen;
   opacity: 0.1;
   z-index: 2;
 }
+
 .image-filters-enabled .entry .post-thumbnail:after {
   background: #0073aa;
   mix-blend-mode: multiply;
   opacity: 1;
   z-index: 3;
 }
+
 .entry .entry-content .more-link {
   transition: color 110ms ease-in-out;
   display: inline;
   color: inherit;
 }
+
 .entry .entry-content .more-link:after {
   content: "»";
   margin-right: 0.5em;
 }
+
 .entry .entry-content .more-link:hover {
   color: #0073aa;
   text-decoration: none;
 }
+
 .entry .entry-content a {
   text-decoration: underline;
 }
+
 .entry .entry-content a:hover {
   text-decoration: none;
 }
+
 .entry .entry-content > iframe[style] {
   margin: 32px 1rem !important;
   max-width: calc(100vw - (2 * 1rem)) !important;
 }
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
     margin: 32px calc(2 * (100vw / 12)) !important;
     max-width: calc(8 * (100vw / 12)) !important;
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
     max-width: calc(6 * (100vw / 12)) !important;
   }
 }
+
 .entry .entry-content .wp-audio-shortcode {
   max-width: calc(100vw - (2 * 1rem));
 }
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
     max-width: calc(6 * (100vw / 12));
@@ -1849,37 +2024,44 @@ body.page .main-navigation {
 .author-bio {
   margin: calc(2 * 1rem) 1rem 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .author-bio {
     margin: calc(3 * 1rem) calc(2 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 @media only screen and (min-width: 768px) {
   .author-bio {
     max-width: calc(6 * (100vw / 12));
   }
 }
+
 .author-bio .author-title {
   display: inline;
 }
+
 .author-bio .author-title:before {
   background: #767676;
-  content: " ";
+  content: "\020";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
+
 .author-bio .author-description {
   display: inline;
   color: #767676;
   font-size: 1.125em;
   line-height: 1.2;
 }
+
 .author-bio .author-description .author-link {
   display: inline-block;
 }
+
 .author-bio .author-description .author-link:hover {
   color: #005177;
   text-decoration: none;
@@ -1901,9 +2083,11 @@ body.page .main-navigation {
 	 * post itself (this happens on pages).
 	 */
 }
+
 .entry + .comments-area {
   margin-top: calc(3 * 1rem);
 }
+
 .comments-area .comments-title-wrap,
 .comments-area .comment-list,
 .comments-area .comment-navigation,
@@ -1912,6 +2096,7 @@ body.page .main-navigation {
 .comments-area .no-comments {
   margin: calc(2 * 1rem) 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap,
   .comments-area .comment-list,
@@ -1923,17 +2108,20 @@ body.page .main-navigation {
     max-width: calc(6 * (100vw / 12));
   }
 }
+
 .comments-area .comments-title-wrap {
   align-items: baseline;
   display: flex;
   justify-content: space-between;
 }
+
 .comments-area .comments-title-wrap .comments-title {
   margin: 0;
 }
+
 .comments-area .comments-title-wrap .comments-title:before {
   background: #767676;
-  content: " ";
+  content: "\020";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -1948,19 +2136,22 @@ body.page .main-navigation {
 #respond {
   position: relative;
 }
+
 #respond .comment-user-avatar {
   margin: 1rem 0 -1rem;
 }
+
 #respond .comment .comment-form {
   padding-right: 0;
 }
+
 #respond > small {
   display: block;
   font-size: 22px;
   position: absolute;
   right: calc(1rem + 100%);
   top: calc(-3.5 * 1rem);
-  width: calc(100vw / 12 );
+  width: calc(100vw / 12);
 }
 
 #comments > .comments-title:last-child {
@@ -1971,14 +2162,17 @@ body.page .main-navigation {
   display: flex;
   flex-direction: column;
 }
+
 .comment-form-flex .comments-title {
   display: none;
   margin: 0;
   order: 1;
 }
+
 .comment-form-flex #respond {
   order: 2;
 }
+
 .comment-form-flex #respond + .comments-title {
   display: block;
 }
@@ -1987,10 +2181,12 @@ body.page .main-navigation {
   list-style: none;
   padding: 0;
 }
+
 .comment-list .children {
   margin: 0;
   padding: 0 1rem 0 0;
 }
+
 .comment-list > .comment:first-child {
   margin-top: 0;
 }
@@ -2000,9 +2196,11 @@ body.page .main-navigation {
   bottom: 0;
   position: absolute;
 }
+
 #respond + .comment-reply {
   display: none;
 }
+
 .comment-reply .comment-reply-link {
   display: inline-block;
 }
@@ -2011,6 +2209,7 @@ body.page .main-navigation {
   list-style: none;
   position: relative;
 }
+
 @media only screen and (min-width: 768px) {
   .comment {
     padding-right: calc(.5 * (1rem + calc(100vw / 12 )));
@@ -2019,27 +2218,33 @@ body.page .main-navigation {
     padding-right: 0;
   }
 }
+
 .comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link-sep,
 .comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link {
   opacity: 1;
 }
+
 .comment .comment-body {
   margin: calc(2 * 1rem) 0;
 }
+
 .comment .comment-meta {
   position: relative;
 }
+
 @media only screen and (min-width: 768px) {
   .comment .comment-author {
     display: inline-block;
     vertical-align: baseline;
   }
 }
+
 .comment .comment-author .avatar {
   float: right;
   margin-left: 1rem;
   position: relative;
 }
+
 @media only screen and (min-width: 768px) {
   .comment .comment-author .avatar {
     float: inherit;
@@ -2049,22 +2254,27 @@ body.page .main-navigation {
     left: calc(100% + 1rem);
   }
 }
+
 .comment .comment-author .fn {
   position: relative;
   display: block;
 }
+
 @media only screen and (min-width: 768px) {
   .comment .comment-author .fn {
     display: inline-block;
     vertical-align: baseline;
   }
 }
+
 .comment .comment-author .fn a {
   color: inherit;
 }
+
 .comment .comment-author .fn a:hover {
   color: #005177;
 }
+
 .comment .comment-author .post-author-badge {
   border-radius: 100%;
   display: block;
@@ -2075,11 +2285,13 @@ body.page .main-navigation {
   top: -3px;
   width: 18px;
 }
+
 @media only screen and (min-width: 768px) {
   .comment .comment-author .post-author-badge {
     left: calc(100% + 0.75rem);
   }
 }
+
 .comment .comment-author .post-author-badge svg {
   width: inherit;
   height: inherit;
@@ -2087,6 +2299,7 @@ body.page .main-navigation {
   fill: white;
   transform: scale(0.875);
 }
+
 @media only screen and (min-width: 768px) {
   .comment .comment-metadata {
     display: inline-block;
@@ -2095,6 +2308,7 @@ body.page .main-navigation {
     vertical-align: baseline;
   }
 }
+
 .comment .comment-metadata > a,
 .comment .comment-metadata .comment-edit-link {
   display: inline-block;
@@ -2102,18 +2316,22 @@ body.page .main-navigation {
   color: #767676;
   vertical-align: baseline;
 }
+
 .comment .comment-metadata > a time,
 .comment .comment-metadata .comment-edit-link time {
   vertical-align: baseline;
 }
+
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
   color: #4a4a4a;
   text-decoration: none;
 }
+
 .comment .comment-metadata > * {
   display: inline-block;
 }
+
 .comment .comment-metadata .edit-link-sep {
   color: #767676;
   margin: 0 0.2em;
@@ -2121,37 +2339,46 @@ body.page .main-navigation {
   transition: opacity 200ms ease-in-out;
   vertical-align: baseline;
 }
+
 .comment .comment-metadata .edit-link {
   color: #767676;
   transition: opacity 200ms ease-in-out;
   opacity: 0;
 }
+
 .comment .comment-metadata .edit-link svg {
   transform: scale(0.8);
   vertical-align: baseline;
   margin-left: 0.1em;
 }
+
 .comment .comment-metadata .comment-edit-link {
   position: relative;
   padding-right: 1rem;
   margin-right: -1rem;
   z-index: 1;
 }
+
 .comment .comment-metadata .comment-edit-link:hover {
   color: #0073aa;
 }
+
 .comment .comment-content {
   margin: 1rem 0;
 }
+
 .comment .comment-content > *:first-child {
   margin-top: 0;
 }
+
 .comment .comment-content > *:last-child {
   margin-bottom: 0;
 }
+
 .comment .comment-content a {
   text-decoration: underline;
 }
+
 .comment .comment-content a:hover {
   text-decoration: none;
 }
@@ -2160,6 +2387,7 @@ body.page .main-navigation {
 #cancel-comment-reply-link {
   font-weight: 500;
 }
+
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
   color: #005177;
@@ -2172,6 +2400,7 @@ body.page .main-navigation {
   margin: 0;
   padding: 0;
 }
+
 .discussion-avatar-list li {
   position: relative;
   list-style: none;
@@ -2179,17 +2408,21 @@ body.page .main-navigation {
   padding: 0;
   float: right;
 }
+
 .discussion-avatar-list .comment-user-avatar img {
   height: calc(1.5 * 1rem);
   width: calc(1.5 * 1rem);
 }
+
 .discussion-meta .discussion-avatar-list {
   display: inline-block;
   margin-left: 8px;
 }
+
 .discussion-meta .discussion-meta-info {
   margin: 0;
 }
+
 .discussion-meta .discussion-meta-info .svg-icon {
   vertical-align: middle;
   fill: currentColor;
@@ -2200,24 +2433,27 @@ body.page .main-navigation {
 .comment-form .comment-notes,
 .comment-form label {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   color: #767676;
 }
+
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-author,
-.comment-form .comment-form-email {
+  .comment-form .comment-form-email {
     width: calc(50% - 0.5rem);
     float: right;
   }
 }
+
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-email {
     margin-right: 1rem;
   }
 }
-.comment-form input[name=author],
-.comment-form input[name=email],
-.comment-form input[name=url] {
+
+.comment-form input[name="author"],
+.comment-form input[name="email"],
+.comment-form input[name="url"] {
   display: block;
   width: 100%;
 }
@@ -2230,14 +2466,16 @@ body.page .main-navigation {
 .error404 .page-header {
   margin: 1rem 1rem calc(3 * 1rem);
 }
+
 @media only screen and (min-width: 768px) {
   .archive .page-header,
-.search .page-header,
-.error404 .page-header {
+  .search .page-header,
+  .error404 .page-header {
     margin: 0 calc(2 * (100vw / 12)) calc(3 * 1rem);
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 .archive .page-header .page-title,
 .search .page-header .page-title,
 .error404 .page-header .page-title {
@@ -2245,11 +2483,13 @@ body.page .main-navigation {
   display: inline;
   letter-spacing: normal;
 }
+
 .archive .page-header .page-title:before,
 .search .page-header .page-title:before,
 .error404 .page-header .page-title:before {
   display: none;
 }
+
 .archive .page-header .search-term,
 .archive .page-header .page-description,
 .search .page-header .search-term,
@@ -2259,6 +2499,7 @@ body.page .main-navigation {
   display: inherit;
   clear: both;
 }
+
 .archive .page-header .search-term:after,
 .archive .page-header .page-description:after,
 .search .page-header .search-term:after,
@@ -2281,17 +2522,20 @@ body.page .main-navigation {
 .no-results.not-found .page-content {
   margin: calc(3 * 1rem) 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .error-404.not-found .page-content,
-.no-results.not-found .page-content {
+  .no-results.not-found .page-content {
     margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2);
   }
 }
+
 .error-404.not-found .search-submit,
 .no-results.not-found .search-submit {
   vertical-align: middle;
   margin: 1rem 0;
 }
+
 .error-404.not-found .search-field,
 .no-results.not-found .search-field {
   width: 100%;
@@ -2304,21 +2548,26 @@ body.page .main-navigation {
 .site-footer {
   color: #767676;
 }
+
 .site-footer .site-info {
   margin: calc(2 * 1rem) 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .site-footer .site-info {
     margin: calc(3 * 1rem) calc(2 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 .site-footer .site-info .imprint {
   margin-left: 1rem;
 }
+
 .site-footer a {
   color: inherit;
 }
+
 .site-footer a:hover {
   text-decoration: none;
   color: #0073aa;
@@ -2329,6 +2578,7 @@ body.page .main-navigation {
   margin: 0 0 1rem;
   /* Make sure select elements fit in widgets. */
 }
+
 .widget select {
   max-width: 100%;
 }
@@ -2340,51 +2590,58 @@ body.page .main-navigation {
   margin: 32px 1rem;
   max-width: calc(100vw - (2 * 1rem));
   /*
-  	// Set top margins for headings
-  	& + h1:before,
-  	& + h2:before,
-  	& + h3,
-  	& + h4,
-  	& + h5,
-  	& + h6 {
-  		margin-top: calc(4 * 1rem);
-  	}
-  */
+	// Set top margins for headings
+	& + h1:before,
+	& + h2:before,
+	& + h3,
+	& + h4,
+	& + h5,
+	& + h6 {
+		margin-top: calc(4 * 1rem);
+	}
+*/
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content > *,
-.entry-summary > * {
+  .entry-summary > * {
     margin: 32px calc(2 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .entry-content > *,
-.entry-summary > * {
+  .entry-summary > * {
     max-width: calc(6 * (100vw / 12));
   }
 }
+
 .entry-content > * > *:first-child,
 .entry-summary > * > *:first-child {
   margin-top: 0;
 }
+
 .entry-content > * > *:last-child,
 .entry-summary > * > *:last-child {
   margin-bottom: 0;
 }
+
 .entry-content > *.alignwide,
 .entry-summary > *.alignwide {
   margin-right: auto;
   margin-left: auto;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignwide,
-.entry-summary > *.alignwide {
+  .entry-summary > *.alignwide {
     margin-right: calc(1 * (100vw / 12));
     margin-left: calc(1 * (100vw / 12));
     max-width: calc(10 * (100vw / 12));
   }
 }
+
 .entry-content > *.alignfull,
 .entry-summary > *.alignfull {
   margin-top: calc(2 * 1rem);
@@ -2393,25 +2650,29 @@ body.page .main-navigation {
   margin-right: 0;
   max-width: 100%;
 }
+
 .entry-content > *.alignleft,
 .entry-summary > *.alignleft {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignleft,
-.entry-summary > *.alignleft {
+  .entry-summary > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     margin-left: calc(2 * 1rem);
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .entry-content > *.alignleft,
-.entry-summary > *.alignleft {
+  .entry-summary > *.alignleft {
     max-width: calc(3 * (100vw / 12));
   }
 }
+
 .entry-content > *.alignright,
 .entry-summary > *.alignright {
   float: left;
@@ -2420,9 +2681,10 @@ body.page .main-navigation {
   margin-right: 1rem;
   margin-left: 1rem;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignright,
-.entry-summary > *.alignright {
+  .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-right: calc(2 * 1rem);
     margin-left: calc(2 * (100vw / 12));
@@ -2432,30 +2694,39 @@ body.page .main-navigation {
 .entry-content .wp-block-audio {
   width: 100%;
 }
+
 .entry-content .wp-block-audio audio {
   width: 100%;
 }
-.entry-content .wp-block-audio.alignleft audio, .entry-content .wp-block-audio.alignright audio {
+
+.entry-content .wp-block-audio.alignleft audio,
+.entry-content .wp-block-audio.alignright audio {
   max-width: 190px;
 }
+
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-audio.alignleft audio, .entry-content .wp-block-audio.alignright audio {
+  .entry-content .wp-block-audio.alignleft audio,
+  .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
+
 @media only screen and (min-width: 1379px) {
-  .entry-content .wp-block-audio.alignleft audio, .entry-content .wp-block-audio.alignright audio {
+  .entry-content .wp-block-audio.alignleft audio,
+  .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
+
 .entry-content .wp-block-video video {
   width: 100%;
 }
+
 .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   background: #0073aa;
-  font-size: 0.8888888889em;
+  font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.2;
   box-sizing: border-box;
@@ -2465,82 +2736,104 @@ body.page .main-navigation {
   color: white;
   outline: none;
 }
+
 .entry-content .wp-block-button .wp-block-button__link:hover {
   cursor: pointer;
 }
+
 .entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:focus {
   background: #111;
 }
+
 .entry-content .wp-block-button .wp-block-button__link:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
+
 .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   background: transparent;
   border: 2px solid #0073aa;
 }
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color), .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #0073aa;
 }
+
 .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   border-color: #111;
   color: #111;
 }
+
 .entry-content .wp-block-archives,
 .entry-content .wp-block-categories,
 .entry-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
+
 .entry-content .wp-block-archives li,
 .entry-content .wp-block-categories li,
 .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.6875 );
+  font-size: calc(22px * 1.6875);
   font-weight: bold;
   line-height: 1.2;
 }
+
 .entry-content .wp-block-archives li a:after,
 .entry-content .wp-block-categories li a:after,
 .entry-content .wp-block-latest-posts li a:after {
   color: #767676;
   content: ",";
 }
+
 .entry-content .wp-block-archives li:last-child a:after,
 .entry-content .wp-block-categories li:last-child a:after,
 .entry-content .wp-block-latest-posts li:last-child a:after {
   color: #767676;
   content: ".";
 }
+
 .entry-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 2rem;
 }
+
 .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: "";
+  content: '';
 }
+
 .entry-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
+
 .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: "";
+  content: '';
 }
+
 .entry-content .wp-block-preformatted {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
+
 .entry-content .wp-block-verse {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-size: 22px;
   line-height: 1.8;
 }
+
 .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
@@ -2548,15 +2841,18 @@ body.page .main-navigation {
   font-weight: bold;
   margin: 0 0 0 0.25em;
 }
+
 .entry-content .wp-block-pullquote {
   border: none;
   padding: 1rem;
 }
+
 .entry-content .wp-block-pullquote blockquote {
   border: none;
   padding-bottom: calc(2 * 1rem);
   margin-left: 0;
 }
+
 .entry-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
@@ -2565,93 +2861,113 @@ body.page .main-navigation {
   margin-top: 0.5em;
   color: #111;
 }
+
 .entry-content .wp-block-pullquote p em {
   font-style: normal;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
+
 .entry-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   line-height: 1.6;
   text-transform: none;
   color: #767676;
 }
+
 .entry-content .wp-block-pullquote.alignleft, .entry-content .wp-block-pullquote.alignright {
   padding: 0;
 }
+
 .entry-content .wp-block-pullquote.alignleft blockquote, .entry-content .wp-block-pullquote.alignright blockquote {
   margin-right: 0;
   padding: 0;
   text-align: right;
   max-width: 100%;
 }
+
 .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
+
 .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   margin: 0 auto;
 }
+
 .entry-content .wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) p,
 .entry-content .wp-block-pullquote.is-style-solid-color cite {
   color: white;
 }
+
 .entry-content .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
   background-color: #0073aa;
 }
+
 .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
   padding: 1rem 1rem 0;
 }
+
 .entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
-  padding: 0 0 calc( 1.5 * 1rem );
+  padding: 0 0 calc( 1.5 * 1rem);
   margin-right: 0;
   margin-top: 0;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-    padding: calc( 2 * 1rem ) calc( 2 * 1rem ) 1rem;
+    padding: calc( 2 * 1rem) calc( 2 * 1rem) 1rem;
   }
 }
+
 .entry-content .wp-block-quote:not(.is-large), .entry-content .wp-block-quote:not(.is-style-large) {
   border-right: 2px solid #0073aa;
   padding-top: 0;
   padding-bottom: 0;
 }
+
 .entry-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
+
 .entry-content .wp-block-quote cite {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
 }
+
 .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
   padding: 1rem 2rem 1rem 0;
   margin: 1rem 0;
   border-right: none;
 }
+
 .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
+
 .entry-content .wp-block-quote.is-large cite,
 .entry-content .wp-block-quote.is-large footer, .entry-content .wp-block-quote.is-style-large cite,
 .entry-content .wp-block-quote.is-style-large footer {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
     margin: 1rem calc(2 * (100vw / 12));
@@ -2661,17 +2977,21 @@ body.page .main-navigation {
     font-size: 1.6875em;
   }
 }
+
 .entry-content .wp-block-image img {
   display: block;
 }
+
 .entry-content .wp-block-image.alignleft, .entry-content .wp-block-image.alignright {
   max-width: 100%;
 }
+
 .entry-content .wp-block-image.alignfull img {
   width: 100vw;
   margin-right: auto;
   margin-left: auto;
 }
+
 .entry-content .wp-block-cover-image .wp-block-cover-image-text,
 .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry-content .wp-block-cover-image h2,
@@ -2684,29 +3004,32 @@ body.page .main-navigation {
   width: calc(100vw - (2 * 1rem));
   max-width: calc(100vw - (2 * 1rem));
 }
+
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image .wp-block-cover-text,
-.entry-content .wp-block-cover-image h2,
-.entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry-content .wp-block-cover .wp-block-cover-text,
-.entry-content .wp-block-cover h2 {
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     width: calc(8 * (100vw / 12));
     max-width: calc(8 * (100vw / 12));
   }
 }
+
 @media only screen and (min-width: 1168px) {
   .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image .wp-block-cover-text,
-.entry-content .wp-block-cover-image h2,
-.entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry-content .wp-block-cover .wp-block-cover-text,
-.entry-content .wp-block-cover h2 {
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
     width: calc(6 * (100vw / 12 ));
     max-width: calc(6 * (100vw / 12 ));
   }
 }
+
 .entry-content .wp-block-cover-image.alignleft h2,
 .entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
 .entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry-content .wp-block-cover-image.alignright h2,
@@ -2730,10 +3053,12 @@ body.page .main-navigation {
   transform: translate(50%, -50%);
   top: 50%;
 }
+
 .entry-content .wp-block-cover-image.has-left-content,
 .entry-content .wp-block-cover.has-left-content {
   justify-content: center;
 }
+
 .entry-content .wp-block-cover-image.has-left-content h2,
 .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
 .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
@@ -2742,10 +3067,12 @@ body.page .main-navigation {
 .entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1rem;
 }
+
 .entry-content .wp-block-cover-image.has-right-content,
 .entry-content .wp-block-cover.has-right-content {
   justify-content: center;
 }
+
 .entry-content .wp-block-cover-image.has-right-content h2,
 .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
 .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
@@ -2754,60 +3081,72 @@ body.page .main-navigation {
 .entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1rem;
 }
+
 .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
 .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
+
 .entry-content .wp-block-audio figcaption,
 .entry-content .wp-block-video figcaption,
 .entry-content .wp-block-image figcaption,
 .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
 .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
   text-align: right;
 }
+
 .entry-content .wp-block-separator,
 .entry-content hr {
   margin-bottom: 2rem;
   margin-top: 2rem;
   /* Remove duplicate rule-line when a separator
-   * is followed by an H1, or H2 */
+		 * is followed by an H1, or H2 */
 }
+
 .entry-content .wp-block-separator:not(.is-style-dots),
 .entry-content hr:not(.is-style-dots) {
   background-color: #767676;
   border: 0;
   height: 2px;
 }
+
 .entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
 .entry-content hr:not(.is-style-wide):not(.is-style-dots) {
   max-width: 2.25em;
 }
-.entry-content .wp-block-separator + h1:before, .entry-content .wp-block-separator + h2:before,
+
+.entry-content .wp-block-separator + h1:before,
+.entry-content .wp-block-separator + h2:before,
 .entry-content hr + h1:before,
 .entry-content hr + h2:before {
   display: none;
 }
+
 .entry-content .wp-block-separator.is-style-dots:before,
 .entry-content hr.is-style-dots:before {
   color: #767676;
   font-size: 1.6875em;
-  letter-spacing: 0.8888888889em;
-  padding-right: 0.8888888889em;
+  letter-spacing: 0.88889em;
+  padding-right: 0.88889em;
 }
+
 .entry-content .wp-block-embed-twitter {
   overflow: hidden;
 }
+
 .entry-content .wp-block-table td, .entry-content .wp-block-table th {
   border-color: #767676;
 }
+
 .entry-content .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+
 .entry-content .wp-block-file .wp-block-file__button {
   transition: background 150ms ease-in-out;
   border: none;
@@ -2819,55 +3158,70 @@ body.page .main-navigation {
   font-weight: bold;
   padding: 0.75rem 1rem;
 }
+
 @media only screen and (min-width: 1168px) {
   .entry-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
+
 .entry-content .wp-block-file .wp-block-file__button:hover {
   cursor: pointer;
 }
+
 .entry-content .wp-block-file .wp-block-file__button:hover, .entry-content .wp-block-file .wp-block-file__button:focus {
   background: #111;
 }
+
 .entry-content .wp-block-file .wp-block-file__button:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
+
 .entry-content .wp-block-code {
   border-radius: 0;
 }
+
 .entry-content .wp-block-code code {
   font-size: 1.125em;
 }
+
 .entry-content .wp-block-columns .wp-block-column > *:first-child {
   margin-top: 0;
 }
+
 .entry-content .wp-block-columns .wp-block-column > *:last-child {
   margin-bottom: 0;
 }
-.entry-content .wp-block-columns[class*=has-] > * {
+
+.entry-content .wp-block-columns[class*='has-'] > * {
   margin-left: 1rem;
 }
-.entry-content .wp-block-columns[class*=has-] > *:last-child {
+
+.entry-content .wp-block-columns[class*='has-'] > *:last-child {
   margin-left: 0;
 }
+
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;
 }
+
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: normal;
 }
+
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
 .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
+
 .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
 }
+
 /* Media */
 .page-content .wp-smiley,
 .entry-content .wp-smiley,
@@ -2908,7 +3262,7 @@ svg {
   margin-bottom: calc(1.5 * 1rem);
 }
 
-.wp-caption img[class*=wp-image-] {
+.wp-caption img[class*="wp-image-"] {
   display: block;
   margin-right: auto;
   margin-left: auto;
@@ -2938,37 +3292,46 @@ svg {
   vertical-align: top;
   width: 100%;
 }
+
 .gallery-columns-2 .gallery-item {
-  max-width: calc( ( 12 / 2 ) * (100% / 12) );
+  max-width: calc( ( 12 / 2 ) * (100% / 12));
 }
+
 .gallery-columns-3 .gallery-item {
-  max-width: calc( ( 12 / 3 ) * (100% / 12) );
+  max-width: calc( ( 12 / 3 ) * (100% / 12));
 }
+
 .gallery-columns-4 .gallery-item {
-  max-width: calc( ( 12 / 4 ) * (100% / 12) );
+  max-width: calc( ( 12 / 4 ) * (100% / 12));
 }
+
 .gallery-columns-5 .gallery-item {
-  max-width: calc( ( 12 / 5 ) * (100% / 12) );
+  max-width: calc( ( 12 / 5 ) * (100% / 12));
 }
+
 .gallery-columns-6 .gallery-item {
-  max-width: calc( ( 12 / 6 ) * (100% / 12) );
+  max-width: calc( ( 12 / 6 ) * (100% / 12));
 }
+
 .gallery-columns-7 .gallery-item {
-  max-width: calc( ( 12 / 7 ) * (100% / 12) );
+  max-width: calc( ( 12 / 7 ) * (100% / 12));
 }
+
 .gallery-columns-8 .gallery-item {
-  max-width: calc( ( 12 / 8 ) * (100% / 12) );
+  max-width: calc( ( 12 / 8 ) * (100% / 12));
 }
+
 .gallery-columns-9 .gallery-item {
-  max-width: calc( ( 12 / 9 ) * (100% / 12) );
+  max-width: calc( ( 12 / 9 ) * (100% / 12));
 }
+
 .gallery-item:last-of-type {
   margin-left: 0;
 }
 
 .gallery-caption {
   display: block;
-  font-size: 0.7111111111em;
+  font-size: 0.71111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
@@ -2980,6 +3343,7 @@ svg {
   line-height: 0;
   box-shadow: 0 0 0 0 transparent;
 }
+
 .gallery-item > div > a:focus {
   box-shadow: 0 0 0 2px #0073aa;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -880,12 +880,12 @@ a:visited {
 
 a:hover, a:active {
   color: #005177;
-  outline: thin dotted;
+  outline: 0;
   text-decoration: none;
 }
 
 a:focus {
-  outline: 0;
+  outline: thin dotted;
   text-decoration: underline;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -880,7 +880,7 @@ a:visited {
 
 a:hover, a:active {
   color: #005177;
-  outline: 0;
+  outline: thin dotted;
   text-decoration: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 # Blocks
 # Media
 	## Captions
-	## Galleries
+	## Gallerie
 --------------------------------------------------------------*/
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
@@ -667,7 +667,8 @@ a:active {
 }
 
 a:focus {
-  outline: 0;
+  outline: thin;
+  outline-style: dotted;
   text-decoration: underline;
 }
 

--- a/style.css
+++ b/style.css
@@ -885,7 +885,7 @@ a:hover, a:active {
 }
 
 a:focus {
-  outline: 0;
+  outline: thin dotted;
   text-decoration: underline;
 }
 

--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 # Blocks
 # Media
 	## Captions
-	## Gallerie
+	## Galleries
 --------------------------------------------------------------*/
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several

--- a/style.scss
+++ b/style.scss
@@ -51,7 +51,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 # Blocks
 # Media
 	## Captions
-	## Gallerie
+	## Galleries
 --------------------------------------------------------------*/
 @import "sass/variables-site/variables-site";
 @import "sass/mixins/mixins-master";

--- a/style.scss
+++ b/style.scss
@@ -51,7 +51,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 # Blocks
 # Media
 	## Captions
-	## Galleries
+	## Gallerie
 --------------------------------------------------------------*/
 @import "sass/variables-site/variables-site";
 @import "sass/mixins/mixins-master";


### PR DESCRIPTION
Currently the a:focus for entry-content does not have an visible inpact. 

Therefore I suggest to add an outline (thin & dotted) to show the link. 

![links_no_visible_focus](https://user-images.githubusercontent.com/21318377/47515680-d0313000-d883-11e8-9d7a-5b3b9a60060a.gif)


WordPress.org Username: travel_girl  :-) 