### PR TITLE
Use excerpts on archive and search results

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -34,7 +34,7 @@ get_header();
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				get_template_part( 'template-parts/content/content', 'archive' );
+				get_template_part( 'template-parts/content/content', 'excerpt' );
 
 				// End the loop.
 			endwhile;

--- a/archive.php
+++ b/archive.php
@@ -34,7 +34,7 @@ get_header();
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				get_template_part( 'template-parts/content/content' );
+				get_template_part( 'template-parts/content/content', 'archive' );
 
 				// End the loop.
 			endwhile;

--- a/search.php
+++ b/search.php
@@ -34,7 +34,7 @@ get_header();
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				get_template_part( 'template-parts/content/content', 'archive' );
+				get_template_part( 'template-parts/content/content', 'excerpt' );
 
 				// End the loop.
 			endwhile;

--- a/search.php
+++ b/search.php
@@ -21,9 +21,7 @@ get_header();
 				<h1 class="page-title">
 					<?php esc_html_e( 'Search results for:', 'twentynineteen' ); ?>
 				</h1>
-				<div class="page-description">
-					<?php echo get_search_query(); ?>
-				</div>
+				<div class="page-description"><?php echo get_search_query(); ?></div>
 			</header><!-- .page-header -->
 
 			<?php
@@ -36,7 +34,7 @@ get_header();
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				get_template_part( 'template-parts/content/content' );
+				get_template_part( 'template-parts/content/content', 'archive' );
 
 				// End the loop.
 			endwhile;

--- a/template-parts/content/content-archive.php
+++ b/template-parts/content/content-archive.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Template part for displaying post archives and search results
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage Twenty_Nineteen
+ * @since 1.0.0
+ */
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<header class="entry-header">
+		<?php
+		if ( is_sticky() && is_home() && ! is_paged() ) {
+			printf( '<span class="sticky-post">%s</span>', __( 'Featured', 'twentynineteen' ) );
+		}
+		the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
+		?>
+
+	</header><!-- .entry-header -->
+
+	<?php twentynineteen_post_thumbnail(); ?>
+
+	<div class="entry-content">
+		<?php
+		the_excerpt(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentynineteen' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			)
+		);
+
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentynineteen' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+	</div><!-- .entry-content -->
+
+	<footer class="entry-footer">
+		<?php twentynineteen_entry_footer(); ?>
+	</footer><!-- .entry-footer -->
+</article><!-- #post-${ID} -->

--- a/template-parts/content/content-excerpt.php
+++ b/template-parts/content/content-excerpt.php
@@ -19,35 +19,12 @@
 		}
 		the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 		?>
-
 	</header><!-- .entry-header -->
 
 	<?php twentynineteen_post_thumbnail(); ?>
 
 	<div class="entry-content">
-		<?php
-		the_excerpt(
-			sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentynineteen' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
-				get_the_title()
-			)
-		);
-
-		wp_link_pages(
-			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentynineteen' ),
-				'after'  => '</div>',
-			)
-		);
-		?>
+		<?php the_excerpt(); ?>
 	</div><!-- .entry-content -->
 
 	<footer class="entry-footer">


### PR DESCRIPTION
On archives and search results, the theme should show excerpts for better SEO and easier scanning through posts.

Fixes: #89 

Also fixes a small spacing issue in the search term.