### PR TITLE
Update classic editor blockquote styles

### DIFF
--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -69,10 +69,9 @@ figure {
 }
 
 blockquote {
-
 	border-left: 2px solid $color__link;
 	margin-left: -($size__spacing-unit * 2);
-	padding: $size__spacing-unit 0 ($size__spacing-unit * .5) ($size__spacing-unit * 2);
+	padding: 0 0 0 $size__spacing-unit;
 
 	> p {
 		margin: 0 0 $size__spacing-unit;

--- a/sass/typography/_copy.scss
+++ b/sass/typography/_copy.scss
@@ -9,14 +9,8 @@ dfn, cite, em, i {
 
 blockquote {
 
-	> p {
-		font-size: $font__size-lg;
-		font-style: italic;
-		line-height: $font__line-height-heading;
-	}
-
 	cite {
-		font-size: $font__size-sm;
+		font-size: $font__size-xs;
 		font-style: normal;
 		font-family: $font__heading;
 	}

--- a/style-editor.css
+++ b/style-editor.css
@@ -502,6 +502,19 @@ ul.wp-block-archives li:last-child a:after,
 
 .wp-block-freeform {
   /* Add style for galleries in classic-editor block */
+  /* Add style for galleries in classic-editor block */
+}
+
+.wp-block-freeform blockquote {
+  border-left: 2px solid #0073aa;
+}
+
+.wp-block-freeform blockquote cite {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.71111em;
+  font-style: normal;
+  line-height: 1.6;
+  color: #767676;
 }
 
 .wp-block-freeform .gallery {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -499,6 +499,19 @@ ul.wp-block-archives,
 .wp-block-freeform {
 
 	/* Add style for galleries in classic-editor block */
+	blockquote {
+		border-left: 2px solid $color__link;
+
+		cite {
+			font-family: $font__heading;
+			font-size: $font__size-xs;
+			font-style: normal;
+			line-height: 1.6;
+			color: $color__text-light;
+		}
+	}
+
+	/* Add style for galleries in classic-editor block */
 	.gallery {
 
 		display: flex;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -582,7 +582,7 @@ dfn, cite, em, i {
 }
 
 blockquote cite {
-  font-size: 0.88889em;
+  font-size: 0.71111em;
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -581,12 +581,6 @@ dfn, cite, em, i {
   font-style: italic;
 }
 
-blockquote > p {
-  font-size: 1.6875em;
-  font-style: italic;
-  line-height: 1.2;
-}
-
 blockquote cite {
   font-size: 0.88889em;
   font-style: normal;
@@ -739,7 +733,7 @@ figure {
 blockquote {
   border-right: 2px solid #0073aa;
   margin-right: -2rem;
-  padding: 1rem 2rem 0.5rem 0;
+  padding: 0 1rem 0 0;
 }
 
 blockquote > p {
@@ -830,7 +824,7 @@ textarea {
   border: solid 1px #ccc;
   box-sizing: border-box;
   outline: none;
-  padding: 0.35rem 0.66rem;
+  padding: 0.36rem 0.66rem;
 }
 
 input[type="text"]:focus,

--- a/style.css
+++ b/style.css
@@ -581,14 +581,8 @@ dfn, cite, em, i {
   font-style: italic;
 }
 
-blockquote > p {
-  font-size: 1.6875em;
-  font-style: italic;
-  line-height: 1.2;
-}
-
 blockquote cite {
-  font-size: 0.88889em;
+  font-size: 0.71111em;
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
@@ -739,7 +733,7 @@ figure {
 blockquote {
   border-left: 2px solid #0073aa;
   margin-left: -2rem;
-  padding: 1rem 0 0.5rem 2rem;
+  padding: 0 0 0 1rem;
 }
 
 blockquote > p {


### PR DESCRIPTION
Styles blockquotes that are produced by the classic editor so they're identical to those produced in Gutenberg. Also syncs up editor styles for block quotes when they're created in the classic editor block vs. in Gutenberg itself. 

Fixes #63

_Before:_
<img width="673" alt="47471372-f39ea100-d7d7-11e8-9ff2-9f6dfc60e242-1" src="https://user-images.githubusercontent.com/1202812/47581745-53a05f00-d920-11e8-9511-d82d918ef67a.png">

_After:_
![screen shot 2018-10-26 at 1 00 17 pm](https://user-images.githubusercontent.com/1202812/47581795-7f234980-d920-11e8-969f-557f407d980e.png)

_After (Classic Editor block):_
![screen shot 2018-10-26 at 1 06 51 pm](https://user-images.githubusercontent.com/1202812/47581823-9104ec80-d920-11e8-9263-d4e289dd0d3f.png)
