### PR TITLE
Remove underline from Gutenberg buttons

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -131,6 +131,7 @@
 			line-height: $font__line-height-heading;
 			box-sizing: border-box;
 			font-weight: bold;
+			text-decoration: none;
 			padding: ($size__spacing-unit * .76) $size__spacing-unit;
 			outline: none;
 			color: white;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -830,7 +830,7 @@ textarea {
   border: solid 1px #ccc;
   box-sizing: border-box;
   outline: none;
-  padding: 0.35rem 0.66rem;
+  padding: 0.36rem 0.66rem;
 }
 
 input[type="text"]:focus,
@@ -2748,6 +2748,7 @@ body.page .main-navigation {
   line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
+  text-decoration: none;
   padding: 0.76rem 1rem;
   outline: none;
   color: white;

--- a/style.css
+++ b/style.css
@@ -2748,6 +2748,7 @@ body.page .main-navigation {
   line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
+  text-decoration: none;
   padding: 0.76rem 1rem;
   outline: none;
   color: white;


### PR DESCRIPTION
At some point, our Gutenberg buttons picked up an underline: 

![screen shot 2018-10-26 at 2 03 05 pm](https://user-images.githubusercontent.com/1202812/47584397-4f783f80-d928-11e8-84f4-0c3490dfced3.png)

This was not intentional. This PR restores them to the way they were supposed to be: 

![screen shot 2018-10-26 at 2 01 42 pm](https://user-images.githubusercontent.com/1202812/47584403-5901a780-d928-11e8-9973-a35540254fb5.png)
