### PR TITLE
Fixes empty header markup in single-pages

### DIFF
--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -12,13 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php if ( ! twentynineteen_can_show_post_thumbnail() ) : ?>
 	<header class="entry-header">
-		<?php
-		if ( ! twentynineteen_can_show_post_thumbnail() ) {
-			get_template_part( 'template-parts/header/entry', 'header' );
-		}
-		?>
+		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
+	<?php endif; ?>
 
 	<div class="entry-content">
 		<?php


### PR DESCRIPTION
When a singular page has a featured image, it inserts an empty `<header>` element that should be removed since the actual header appears in the site-header.

![image](https://user-images.githubusercontent.com/709581/47596236-e1953d80-d952-11e8-9a39-688fab57dfb7.png)
