### PR TITLE
 Fix comment avatars in singular featured-image-headers

### DIFF
--- a/header.php
+++ b/header.php
@@ -32,7 +32,8 @@
 			<?php if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) : ?>
 				<div class="site-featured-image">
 					<?php the_post(); ?>
-					<div class="entry-header">
+					<?php $discussion = ! is_page() && twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null; ?>
+					<div class="<?php echo ( ! empty( $discussion ) && count( $discussion->authors ) > 0 ) ? 'entry-header has-discussion' : 'entry-header'; ?>">
 						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 					</div><!-- .entry-header -->
 					<?php rewind_posts(); ?>

--- a/header.php
+++ b/header.php
@@ -33,44 +33,7 @@
 				<div class="site-featured-image">
 					<?php the_post(); ?>
 					<div class="entry-header">
-						<?php if ( ! is_page() ) : ?>
-						<?php $discussion = twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null; ?>
-						<?php endif; ?>
-
-						<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-
-						<?php if ( ! is_page() ) : ?>
-						<div class="<?php echo ( ! empty( $discussion ) && count( $discussion->authors ) > 0 ) ? 'entry-meta has-discussion' : 'entry-meta'; ?>">
-							<?php twentynineteen_posted_by(); ?>
-							<?php twentynineteen_posted_on(); ?>
-							<span class="comment-count">
-								<?php
-								if ( ! empty( $discussion ) ) {
-									twentynineteen_discussion_avatars_list( $discussion->authors );}
-								?>
-								<?php twentynineteen_comment_count(); ?>
-							</span>
-							<?php
-							// Edit post link.
-								edit_post_link(
-									sprintf(
-										wp_kses(
-											/* translators: %s: Name of current post. Only visible to screen readers. */
-											__( 'Edit <span class="screen-reader-text">%s</span>', 'twentynineteen' ),
-											array(
-												'span' => array(
-													'class' => array(),
-												),
-											)
-										),
-										get_the_title()
-									),
-									'<span class="edit-link">' . twentynineteen_get_icon_svg( 'edit', 16 ),
-									'</span>'
-								);
-							?>
-						</div><!-- .entry-meta -->
-						<?php endif; ?>
+						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 					</div><!-- .entry-header -->
 					<?php rewind_posts(); ?>
 				</div>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -166,7 +166,7 @@ function twentynineteen_get_discussion_data() {
 	}
 	$authors    = array();
 	$commenters = array();
-	$user_id    = is_user_logged_in() ? get_current_user_id() : -1;
+	$user_id    = -1; // is_user_logged_in() ? get_current_user_id() : -1;
 	$comments   = get_comments(
 		array(
 			'post_id' => $current_post_id,

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -8,61 +8,6 @@
 	/* Add text shadow to text, to increase readability. */
 	text-shadow: 0 1px 2px rgba(black, 0.35);
 
-	.entry-meta {
-
-		font-weight: 500;
-
-		> span {
-
-			margin-right: $size__spacing-unit;
-			display: inline-block;
-
-			&:last-child {
-				margin-right: 0;
-			}
-		}
-
-		a {
-
-			@include link-transition;
-			color: currentColor;
-
-			&:hover {
-				text-decoration: none;
-			}
-		}
-
-		.svg-icon {
-			position: relative;
-			display: inline-block;
-			vertical-align: middle;
-			margin-right: 0.5em;
-		}
-
-		&.has-discussion {
-
-			.discussion-avatar-list {
-				display: none;
-			}
-
-			@include media (tablet) {
-				display: flex;
-				position: relative;
-
-				.comment-count {
-					position: absolute;
-					right: 0;
-				}
-
-				.discussion-avatar-list {
-					display: block;
-					position: absolute;
-					bottom: 100%;
-				}
-			}
-		}
-	}
-
 	/* Set white text color when featured image is set. */
 	.site-branding .site-title,
 	.site-branding .site-description,
@@ -113,7 +58,7 @@
 				filter: drop-shadow(0 1px 2px rgba(black, 0.35) );
 	}
 
-	/* Site header featured image styles */
+	/* Entry header */
 
 	.site-featured-image .entry-header {
 
@@ -131,6 +76,70 @@
 
 			&:before {
 				background: $color__background-body;
+			}
+		}
+
+		/* Entry meta */
+
+		.entry-meta {
+
+			font-weight: 500;
+
+			> span {
+
+				margin-right: $size__spacing-unit;
+				display: inline-block;
+
+				&:last-child {
+					margin-right: 0;
+				}
+			}
+
+			a {
+
+				@include link-transition;
+				color: currentColor;
+
+				&:hover {
+					text-decoration: none;
+				}
+			}
+
+			.svg-icon {
+				position: relative;
+				display: inline-block;
+				vertical-align: middle;
+				margin-right: 0.5em;
+			}
+
+			.discussion-avatar-list {
+				display: none;
+			}
+		}
+
+		&.has-discussion {
+
+			@include media (tablet) {
+
+				.entry-meta {
+					display: flex;
+					position: relative;
+				}
+
+				.entry-title {
+					padding-right: calc(1 * (100vw / 12) + #{$size__spacing-unit});
+				}
+
+				.entry-meta .comment-count {
+					position: absolute;
+					right: 0;
+				}
+
+				.entry-meta .discussion-avatar-list {
+					display: block;
+					position: absolute;
+					bottom: 100%;
+				}
 			}
 		}
 	}

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -15,6 +15,7 @@
 		> span {
 
 			margin-right: $size__spacing-unit;
+			display: inline-block;
 
 			&:last-child {
 				margin-right: 0;
@@ -36,6 +37,29 @@
 			display: inline-block;
 			vertical-align: middle;
 			margin-right: 0.5em;
+		}
+
+		&.has-discussion {
+
+			.discussion-avatar-list {
+				display: none;
+			}
+
+			@include media (tablet) {
+				display: flex;
+				position: relative;
+
+				.comment-count {
+					position: absolute;
+					right: 0;
+				}
+
+				.discussion-avatar-list {
+					display: block;
+					position: absolute;
+					bottom: 100%;
+				}
+			}
 		}
 	}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -329,11 +329,6 @@
 
 .discussion-meta {
 
-	.discussion-avatar-list {
-		display: inline-block;
-		margin-right: 8px;
-	}
-
 	.discussion-meta-info {
 		margin: 0;
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -15,7 +15,6 @@
 		margin-top: calc(3 * #{$size__spacing-unit});
 	}
 
-	.comments-title-wrap,
 	.comment-list,
 	.comment-navigation,
 	> .comment-respond,
@@ -30,13 +29,31 @@
 	}
 
 	.comments-title-wrap {
-		align-items: baseline;
-		display: flex;
-		justify-content: space-between;
+
+		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
+
+		@include media(tablet) {
+			align-items: baseline;
+			display: flex;
+			justify-content: space-between;
+			margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12));
+			max-width: calc(8 * (100vw / 12));
+		}
 
 		.comments-title {
 			@include post-section-dash;
 			margin: 0;
+
+			@include media(tablet) {
+				flex: 1 0 calc(3 * (100vw / 12);
+			}
+		}
+
+		.discussion-meta {
+			@include media(tablet) {
+				flex: 0 0 calc(2 * (100vw / 12);
+				margin-left: #{$size__spacing-unit};
+			}
 		}
 	}
 }

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -65,6 +65,7 @@
 		> span {
 
 			margin-right: $size__spacing-unit;
+			display: inline-block;
 
 			&:last-child {
 				margin-right: 0;
@@ -91,26 +92,7 @@
 	}
 
 	.entry-meta {
-
 		margin: $size__spacing-unit 0;
-
-		&.has-discussion .comment-count {
-
-			@include media(desktop) {
-				float: right;
-				position: relative;
-			}
-
-			.discussion-avatar-list {
-				display: none;
-
-				@include media(desktop) {
-					bottom: 100%;
-					display: block;
-					position: absolute;
-				}
-			}
-		}
 	}
 
 	.entry-footer {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1859,6 +1859,7 @@ body.page .main-navigation {
 .entry .entry-meta > span,
 .entry .entry-footer > span {
   margin-left: 1rem;
+  display: inline-block;
 }
 
 .entry .entry-meta > span:last-child,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1565,6 +1565,7 @@ body.page .main-navigation {
 
 .site-header.featured-image .entry-meta > span {
   margin-left: 1rem;
+  display: inline-block;
 }
 
 .site-header.featured-image .entry-meta > span:last-child {
@@ -1585,6 +1586,26 @@ body.page .main-navigation {
   display: inline-block;
   vertical-align: middle;
   margin-left: 0.5em;
+}
+
+.site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .entry-meta.has-discussion {
+    display: flex;
+    position: relative;
+  }
+  .site-header.featured-image .entry-meta.has-discussion .comment-count {
+    position: absolute;
+    left: 0;
+  }
+  .site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+  }
 }
 
 .site-header.featured-image .site-branding .site-title,
@@ -1867,25 +1888,6 @@ body.page .main-navigation {
 
 .entry .entry-meta {
   margin: 1rem 0;
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-meta.has-discussion .comment-count {
-    float: left;
-    position: relative;
-  }
-}
-
-.entry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
-    bottom: 100%;
-    display: block;
-    position: absolute;
-  }
 }
 
 .entry .entry-footer {
@@ -2423,11 +2425,6 @@ body.page .main-navigation {
 .discussion-avatar-list .comment-user-avatar img {
   height: calc(1.5 * 1rem);
   width: calc(1.5 * 1rem);
-}
-
-.discussion-meta .discussion-avatar-list {
-  display: inline-block;
-  margin-left: 8px;
 }
 
 .discussion-meta .discussion-meta-info {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1542,7 +1542,7 @@ body.page .main-navigation {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   /* Set white text color when featured image is set. */
   /* add focus state to social media icons */
-  /* Site header featured image styles */
+  /* Entry header */
   /* Custom Logo Link */
   /* Make sure important elements are above pseudo elements used for effects. */
   /* Set up image filter layer positioning */
@@ -1557,55 +1557,6 @@ body.page .main-navigation {
   /* Third layer: multiply. */
   /* Fourth layer: overlay. */
   /* Fifth layer: readability overlay */
-}
-
-.site-header.featured-image .entry-meta {
-  font-weight: 500;
-}
-
-.site-header.featured-image .entry-meta > span {
-  margin-left: 1rem;
-  display: inline-block;
-}
-
-.site-header.featured-image .entry-meta > span:last-child {
-  margin-left: 0;
-}
-
-.site-header.featured-image .entry-meta a {
-  transition: color 110ms ease-in-out;
-  color: currentColor;
-}
-
-.site-header.featured-image .entry-meta a:hover {
-  text-decoration: none;
-}
-
-.site-header.featured-image .entry-meta .svg-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin-left: 0.5em;
-}
-
-.site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-header.featured-image .entry-meta.has-discussion {
-    display: flex;
-    position: relative;
-  }
-  .site-header.featured-image .entry-meta.has-discussion .comment-count {
-    position: absolute;
-    left: 0;
-  }
-  .site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
-    display: block;
-    position: absolute;
-    bottom: 100%;
-  }
 }
 
 .site-header.featured-image .site-branding .site-title,
@@ -1680,6 +1631,7 @@ body.page .main-navigation {
   margin-bottom: 0;
   margin-right: 0;
   margin-left: 0;
+  /* Entry meta */
 }
 
 @media only screen and (min-width: 768px) {
@@ -1691,6 +1643,58 @@ body.page .main-navigation {
 
 .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: #fff;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta {
+  font-weight: 500;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta > span {
+  margin-left: 1rem;
+  display: inline-block;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta > span:last-child {
+  margin-left: 0;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta a {
+  transition: color 110ms ease-in-out;
+  color: currentColor;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta a:hover {
+  text-decoration: none;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta .svg-icon {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.5em;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
+    display: flex;
+    position: relative;
+  }
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-title {
+    padding-left: calc(1 * (100vw / 12) + 1rem);
+  }
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
+    position: absolute;
+    left: 0;
+  }
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .discussion-avatar-list {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+  }
 }
 
 .site-header.featured-image .custom-logo-link {
@@ -2102,7 +2106,6 @@ body.page .main-navigation {
   margin-top: calc(3 * 1rem);
 }
 
-.comments-area .comments-title-wrap,
 .comments-area .comment-list,
 .comments-area .comment-navigation,
 .comments-area > .comment-respond,
@@ -2112,7 +2115,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area .comments-title-wrap,
   .comments-area .comment-list,
   .comments-area .comment-navigation,
   .comments-area > .comment-respond,
@@ -2124,9 +2126,17 @@ body.page .main-navigation {
 }
 
 .comments-area .comments-title-wrap {
-  align-items: baseline;
-  display: flex;
-  justify-content: space-between;
+  margin: calc(2 * 1rem) 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap {
+    align-items: baseline;
+    display: flex;
+    justify-content: space-between;
+    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12));
+  }
 }
 
 .comments-area .comments-title-wrap .comments-title {
@@ -2140,6 +2150,19 @@ body.page .main-navigation {
   height: 2px;
   margin: 1rem 0;
   width: 1em;
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap .comments-title {
+    flex: 1 0 calc(3 * (100vw / 12));
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap .discussion-meta {
+    flex: 0 0 calc(2 * (100vw / 12));
+    margin-right: 1rem;
+  }
 }
 
 #comment {

--- a/style.css
+++ b/style.css
@@ -1565,6 +1565,7 @@ body.page .main-navigation {
 
 .site-header.featured-image .entry-meta > span {
   margin-right: 1rem;
+  display: inline-block;
 }
 
 .site-header.featured-image .entry-meta > span:last-child {
@@ -1585,6 +1586,26 @@ body.page .main-navigation {
   display: inline-block;
   vertical-align: middle;
   margin-right: 0.5em;
+}
+
+.site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .entry-meta.has-discussion {
+    display: flex;
+    position: relative;
+  }
+  .site-header.featured-image .entry-meta.has-discussion .comment-count {
+    position: absolute;
+    right: 0;
+  }
+  .site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+  }
 }
 
 .site-header.featured-image .site-branding .site-title,
@@ -1838,6 +1859,7 @@ body.page .main-navigation {
 .entry .entry-meta > span,
 .entry .entry-footer > span {
   margin-right: 1rem;
+  display: inline-block;
 }
 
 .entry .entry-meta > span:last-child,
@@ -1867,25 +1889,6 @@ body.page .main-navigation {
 
 .entry .entry-meta {
   margin: 1rem 0;
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-meta.has-discussion .comment-count {
-    float: right;
-    position: relative;
-  }
-}
-
-.entry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-meta.has-discussion .comment-count .discussion-avatar-list {
-    bottom: 100%;
-    display: block;
-    position: absolute;
-  }
 }
 
 .entry .entry-footer {
@@ -2423,11 +2426,6 @@ body.page .main-navigation {
 .discussion-avatar-list .comment-user-avatar img {
   height: calc(1.5 * 1rem);
   width: calc(1.5 * 1rem);
-}
-
-.discussion-meta .discussion-avatar-list {
-  display: inline-block;
-  margin-right: 8px;
 }
 
 .discussion-meta .discussion-meta-info {

--- a/style.css
+++ b/style.css
@@ -1542,7 +1542,7 @@ body.page .main-navigation {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   /* Set white text color when featured image is set. */
   /* add focus state to social media icons */
-  /* Site header featured image styles */
+  /* Entry header */
   /* Custom Logo Link */
   /* Make sure important elements are above pseudo elements used for effects. */
   /* Set up image filter layer positioning */
@@ -1557,55 +1557,6 @@ body.page .main-navigation {
   /* Third layer: multiply. */
   /* Fourth layer: overlay. */
   /* Fifth layer: readability overlay */
-}
-
-.site-header.featured-image .entry-meta {
-  font-weight: 500;
-}
-
-.site-header.featured-image .entry-meta > span {
-  margin-right: 1rem;
-  display: inline-block;
-}
-
-.site-header.featured-image .entry-meta > span:last-child {
-  margin-right: 0;
-}
-
-.site-header.featured-image .entry-meta a {
-  transition: color 110ms ease-in-out;
-  color: currentColor;
-}
-
-.site-header.featured-image .entry-meta a:hover {
-  text-decoration: none;
-}
-
-.site-header.featured-image .entry-meta .svg-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 0.5em;
-}
-
-.site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-header.featured-image .entry-meta.has-discussion {
-    display: flex;
-    position: relative;
-  }
-  .site-header.featured-image .entry-meta.has-discussion .comment-count {
-    position: absolute;
-    right: 0;
-  }
-  .site-header.featured-image .entry-meta.has-discussion .discussion-avatar-list {
-    display: block;
-    position: absolute;
-    bottom: 100%;
-  }
 }
 
 .site-header.featured-image .site-branding .site-title,
@@ -1680,6 +1631,7 @@ body.page .main-navigation {
   margin-bottom: 0;
   margin-left: 0;
   margin-right: 0;
+  /* Entry meta */
 }
 
 @media only screen and (min-width: 768px) {
@@ -1691,6 +1643,58 @@ body.page .main-navigation {
 
 .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: #fff;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta {
+  font-weight: 500;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta > span {
+  margin-right: 1rem;
+  display: inline-block;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta > span:last-child {
+  margin-right: 0;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta a {
+  transition: color 110ms ease-in-out;
+  color: currentColor;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta a:hover {
+  text-decoration: none;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta .svg-icon {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.5em;
+}
+
+.site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
+    display: flex;
+    position: relative;
+  }
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-title {
+    padding-right: calc(1 * (100vw / 12) + 1rem);
+  }
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
+    position: absolute;
+    right: 0;
+  }
+  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .discussion-avatar-list {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+  }
 }
 
 .site-header.featured-image .custom-logo-link {
@@ -2102,7 +2106,6 @@ body.page .main-navigation {
   margin-top: calc(3 * 1rem);
 }
 
-.comments-area .comments-title-wrap,
 .comments-area .comment-list,
 .comments-area .comment-navigation,
 .comments-area > .comment-respond,
@@ -2112,7 +2115,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area .comments-title-wrap,
   .comments-area .comment-list,
   .comments-area .comment-navigation,
   .comments-area > .comment-respond,
@@ -2124,9 +2126,17 @@ body.page .main-navigation {
 }
 
 .comments-area .comments-title-wrap {
-  align-items: baseline;
-  display: flex;
-  justify-content: space-between;
+  margin: calc(2 * 1rem) 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap {
+    align-items: baseline;
+    display: flex;
+    justify-content: space-between;
+    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12));
+  }
 }
 
 .comments-area .comments-title-wrap .comments-title {
@@ -2140,6 +2150,19 @@ body.page .main-navigation {
   height: 2px;
   margin: 1rem 0;
   width: 1em;
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap .comments-title {
+    flex: 1 0 calc(3 * (100vw / 12));
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap .discussion-meta {
+    flex: 0 0 calc(2 * (100vw / 12));
+    margin-left: 1rem;
+  }
 }
 
 #comment {

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -12,11 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<?php if ( ! twentynineteen_can_show_post_thumbnail() ) { ?>
+	<?php if ( ! twentynineteen_can_show_post_thumbnail() ) : ?>
 	<header class="entry-header">
 		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
-	<?php } ?>
+	<?php endif; ?>
 
 	<div class="entry-content">
 		<?php

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -12,13 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php if ( ! twentynineteen_can_show_post_thumbnail() ) { ?>
 	<header class="entry-header">
-		<?php
-		if ( ! twentynineteen_can_show_post_thumbnail() ) {
-			get_template_part( 'template-parts/header/entry', 'header' );
-		}
-		?>
+		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
+	<?php } ?>
 
 	<div class="entry-content">
 		<?php

--- a/template-parts/content/content-single.php
+++ b/template-parts/content/content-single.php
@@ -12,49 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-<?php if ( ! twentynineteen_can_show_post_thumbnail() ) : ?>
+	<?php if ( ! twentynineteen_can_show_post_thumbnail() ) : ?>
 	<header class="entry-header">
-		<?php if ( ! is_page() ) : ?>
-		<?php $discussion = twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null; ?>
-		<?php endif; ?>
-
-		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-
-		<?php if ( ! is_page() ) : ?>
-		<div class="<?php echo ( ! empty( $discussion ) && count( $discussion->authors ) > 0 ) ? 'entry-meta has-discussion' : 'entry-meta'; ?>">
-			<?php twentynineteen_posted_by(); ?>
-			<?php twentynineteen_posted_on(); ?>
-			<span class="comment-count">
-				<?php
-				if ( ! empty( $discussion ) ) {
-					twentynineteen_discussion_avatars_list( $discussion->authors );
-				}
-				?>
-				<?php twentynineteen_comment_count(); ?>
-			</span>
-			<?php
-			// Edit post link.
-				edit_post_link(
-					sprintf(
-						wp_kses(
-							/* translators: %s: Name of current post. Only visible to screen readers. */
-							__( 'Edit <span class="screen-reader-text">%s</span>', 'twentynineteen' ),
-							array(
-								'span' => array(
-									'class' => array(),
-								),
-							)
-						),
-						get_the_title()
-					),
-					'<span class="edit-link">' . twentynineteen_get_icon_svg( 'edit', 16 ),
-					'</span>'
-				);
-			?>
-		</div><!-- .meta-info -->
-		<?php endif; ?>
+		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
-<?php endif; ?>
+	<?php endif; ?>
 
 	<div class="entry-content">
 		<?php

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -23,7 +23,6 @@
 			the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 		endif;
 		?>
-
 	</header><!-- .entry-header -->
 
 	<?php twentynineteen_post_thumbnail(); ?>

--- a/template-parts/header/entry-header.php
+++ b/template-parts/header/entry-header.php
@@ -25,5 +25,24 @@ if ( ! is_page() ) : ?>
 		?>
 		<?php twentynineteen_comment_count(); ?>
 	</span>
+	<?php
+	// Edit post link.
+		edit_post_link(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers. */
+					__( 'Edit <span class="screen-reader-text">%s</span>', 'twentynineteen' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			),
+			'<span class="edit-link">' . twentynineteen_get_icon_svg( 'edit', 16 ),
+			'</span>'
+		);
+	?>
 </div><!-- .meta-info -->
 <?php endif; ?>

--- a/template-parts/header/entry-header.php
+++ b/template-parts/header/entry-header.php
@@ -7,14 +7,12 @@
  * @since 1.0.0
  */
 
-if ( ! is_page() ) : ?>
-<?php $discussion = twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null; ?>
-<?php endif; ?>
+$discussion = ! is_page() && twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null; ?>
 
 <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 
 <?php if ( ! is_page() ) : ?>
-<div class="<?php echo ( ! empty( $discussion ) && count( $discussion->authors ) > 0 ) ? 'entry-meta has-discussion' : 'entry-meta'; ?>">
+<div class="entry-meta">
 	<?php twentynineteen_posted_by(); ?>
 	<?php twentynineteen_posted_on(); ?>
 	<span class="comment-count">


### PR DESCRIPTION
Fixes: #342 

Also addresses a few other issues: 
• Unifies entry-header markup in all singular views with & without featured images
• Cleans up discussion avatar displays in header and in comments section
• Fixes text wrapping in .entry-meta to keep icons and link-text together at all times