### PR TITLE
adjust opacity featured image for IE and Edge

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -40,8 +40,13 @@
 	&:after {
 		background: $color__link;
 		mix-blend-mode: multiply;
-		opacity: 1;
+		opacity: .8;
 		z-index: 3;
+		
+		/* Browsers supporting mix-blend-mode don't need opacity < 1 */
+		@supports (mix-blend-mode: multiply) {
+			opacity: 1;
+		}
 	}
 }
 

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -217,17 +217,27 @@
 	  	/* When image filters are active, a blue overlay is added. */
 		.image-filters-enabled & {
 			background: $color__link;
-			opacity: 1;
+			opacity: .8;
 			z-index: 3;
+			
+			/* Browsers supporting mix-blend-mode don't need opacity < 1 */
+			@supports (mix-blend-mode: multiply) {
+				opacity: 1;
+			}
 		}
 	}
 
 	/* Fourth layer: overlay. */
   	.image-filters-enabled & .site-branding-container:after {
-  		background: rgba($color__background-body, 0.35);
+  		background: rgba(#000, 0.35);
 		mix-blend-mode: overlay;
 		opacity: 0.5;
 		z-index: 4;
+		
+		/* Browsers supporting mix-blend-mode can have a light overlay */
+		@supports (mix-blend-mode: overlay) {
+			background: rgba($color__background-body, 0.35);
+		}
 	}
 
 	/* Fifth layer: readability overlay */

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -259,10 +259,6 @@
 			@include media(tablet) {
 				opacity: 0.18;
 			}
-
-			@include media(desktop) {
-				opacity: 0.1;
-			}
 		}
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -140,7 +140,24 @@
 			display: block;
 
 			.post-thumbnail-inner {
-				@include filter-grayscale;
+				filter: grayscale(100%);
+				
+				&:after {
+					background: rgba(#000, 0.35);
+					content: "";
+					display: block;
+					height: 100%;
+					opacity: .5;
+					pointer-events: none;
+					position: absolute;
+					top: 0;
+					width: 100%;
+					z-index: 4;
+
+					@supports (mix-blend-mode: multiply) {
+						display: none;
+					}
+				}
 			}
 
 			&:before, &:after {
@@ -155,7 +172,7 @@
 			}
 
 			@include filter-duotone;
-
+			
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1801,12 +1801,6 @@ body.page .main-navigation {
   }
 }
 
-@media only screen and (min-width: 1168px) {
-  .image-filters-enabled .site-header.featured-image:after {
-    opacity: 0.1;
-  }
-}
-
 .site-header.featured-image ::-moz-selection {
   background: rgba(255, 255, 255, 0.17);
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1753,15 +1753,29 @@ body.page .main-navigation {
 
 .image-filters-enabled .site-header.featured-image .site-featured-image:after {
   background: #0073aa;
-  opacity: 1;
+  opacity: .8;
   z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled .site-header.featured-image .site-featured-image:after {
+    opacity: 1;
+  }
 }
 
 .image-filters-enabled .site-header.featured-image .site-branding-container:after {
-  background: rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.35);
   mix-blend-mode: overlay;
   opacity: 0.5;
   z-index: 4;
+  /* Browsers supporting mix-blend-mode can have a light overlay */
+}
+
+@supports (mix-blend-mode: overlay) {
+  .image-filters-enabled .site-header.featured-image .site-branding-container:after {
+    background: rgba(255, 255, 255, 0.35);
+  }
 }
 
 .site-header.featured-image:after {
@@ -1958,16 +1972,26 @@ body.page .main-navigation {
 }
 
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner {
-  position: relative;
   filter: grayscale(100%);
-  z-index: 1;
 }
 
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
+  background: rgba(0, 0, 0, 0.35);
+  content: "";
   display: block;
-  width: 100%;
   height: 100%;
-  z-index: 10;
+  opacity: .5;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 4;
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
+    display: none;
+  }
 }
 
 .image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
@@ -1992,8 +2016,15 @@ body.page .main-navigation {
 .image-filters-enabled .entry .post-thumbnail:after {
   background: #0073aa;
   mix-blend-mode: multiply;
-  opacity: 1;
+  opacity: .8;
   z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled .entry .post-thumbnail:after {
+    opacity: 1;
+  }
 }
 
 .entry .entry-content .more-link {

--- a/style.css
+++ b/style.css
@@ -1801,12 +1801,6 @@ body.page .main-navigation {
   }
 }
 
-@media only screen and (min-width: 1168px) {
-  .image-filters-enabled .site-header.featured-image:after {
-    opacity: 0.1;
-  }
-}
-
 .site-header.featured-image ::-moz-selection {
   background: rgba(255, 255, 255, 0.17);
 }

--- a/style.css
+++ b/style.css
@@ -1753,15 +1753,29 @@ body.page .main-navigation {
 
 .image-filters-enabled .site-header.featured-image .site-featured-image:after {
   background: #0073aa;
-  opacity: 1;
+  opacity: .8;
   z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled .site-header.featured-image .site-featured-image:after {
+    opacity: 1;
+  }
 }
 
 .image-filters-enabled .site-header.featured-image .site-branding-container:after {
-  background: rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.35);
   mix-blend-mode: overlay;
   opacity: 0.5;
   z-index: 4;
+  /* Browsers supporting mix-blend-mode can have a light overlay */
+}
+
+@supports (mix-blend-mode: overlay) {
+  .image-filters-enabled .site-header.featured-image .site-branding-container:after {
+    background: rgba(255, 255, 255, 0.35);
+  }
 }
 
 .site-header.featured-image:after {
@@ -1958,16 +1972,26 @@ body.page .main-navigation {
 }
 
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner {
-  position: relative;
   filter: grayscale(100%);
-  z-index: 1;
 }
 
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
+  background: rgba(0, 0, 0, 0.35);
+  content: "";
   display: block;
-  width: 100%;
   height: 100%;
-  z-index: 10;
+  opacity: .5;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 4;
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
+    display: none;
+  }
 }
 
 .image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
@@ -1992,8 +2016,15 @@ body.page .main-navigation {
 .image-filters-enabled .entry .post-thumbnail:after {
   background: #0073aa;
   mix-blend-mode: multiply;
-  opacity: 1;
+  opacity: .8;
   z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled .entry .post-thumbnail:after {
+    opacity: 1;
+  }
 }
 
 .entry .entry-content .more-link {


### PR DESCRIPTION
Should fix #121

Adjusting the opacity for browsers that do not support `mix-blend-mode` (mainly IE and Edge) to make the featured image partially visible (otherwise blue rectangle).
Works fine with the Customizer option for enabling/disabling the filter.

Note that there is still a small **bug** in Edge: when clicking the featured image in the post feed, the image is regains its color despite the `filter: grayscale(100%)` on it. I am not sure how to fix this...
IE11 does not support filtering so, there it is not an issue.