### PR TITLE
Align caption styles between classic editor and Gutenberg.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -498,7 +498,7 @@
 		line-height: $font__line-height-pre;
 		margin: 0;
 		padding: ( $size__spacing-unit * .5 );
-		text-align: left;
+		text-align: center;
 	}
 
 	//! Separator

--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -8,10 +8,12 @@
 	margin-right: auto;
 }
 
-.wp-caption .wp-caption-text {
-	margin: calc(0.875 * #{$size__spacing-unit}) 0;
-}
-
 .wp-caption-text {
+	color: $color__text-light;
+	font-size: $font__size-xs;
+	font-family: $font__heading;
+ 	line-height: $font__line-height-pre;
+ 	margin: 0;
+ 	padding: ( $size__spacing-unit * .5 );
 	text-align: center;
 }

--- a/style-editor.css
+++ b/style-editor.css
@@ -495,6 +495,13 @@ ul.wp-block-archives li:last-child a:after,
 /** === Classic Editor === */
 /* Properly center-align captions in the classic-editor block */
 .wp-caption dd {
+  color: #767676;
+  font-size: 0.71111em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.5rem;
+  text-align: left;
   text-align: center;
   -webkit-margin-start: 0px;
   margin-inline-start: 0px;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -490,6 +490,13 @@ ul.wp-block-archives,
 /* Properly center-align captions in the classic-editor block */
 .wp-caption {
 	dd {
+		color: $color__text-light;
+ 		font-size: $font__size-xs;
+ 		font-family: $font__heading;
+ 		line-height: $font__line-height-pre;
+ 		margin: 0;
+ 		padding: ( $size__spacing-unit * .5 );
+ 		text-align: left;
 		text-align: center;
 		-webkit-margin-start: 0px;
 		margin-inline-start: 0px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2764,6 +2764,24 @@ body.page .main-navigation {
   }
 }
 
+.entry-content > *.aligncenter,
+.entry-summary > *.aligncenter {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-content > *.aligncenter,
+  .entry-summary > *.aligncenter {
+    margin-right: calc(2 * (100vw / 12));
+    margin-left: calc(2 * (100vw / 12));
+    max-width: calc(10 * (100vw / 12));
+    position: relative;
+    right: 25%;
+    transform: translate(50%);
+  }
+}
+
 .entry-content .wp-block-audio {
   width: 100%;
 }
@@ -3171,7 +3189,7 @@ body.page .main-navigation {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
-  text-align: right;
+  text-align: center;
 }
 
 .entry-content .wp-block-separator,
@@ -3342,11 +3360,13 @@ svg {
   margin-left: auto;
 }
 
-.wp-caption .wp-caption-text {
-  margin: calc(0.875 * 1rem) 0;
-}
-
 .wp-caption-text {
+  color: #767676;
+  font-size: 0.71111em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.5rem;
   text-align: center;
 }
 

--- a/style.css
+++ b/style.css
@@ -134,7 +134,7 @@ abbr[title] {
   text-decoration: underline;
   /* 2 */
   -webkit-text-decoration: underline dotted;
-  text-decoration: underline dotted;
+          text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -2778,8 +2778,8 @@ body.page .main-navigation {
     max-width: calc(10 * (100vw / 12));
     position: relative;
     left: 25%;
-    transform: translateX(-50%);
-}
+    transform: translate(-50%);
+  }
 }
 
 .entry-content .wp-block-audio {
@@ -3189,7 +3189,7 @@ body.page .main-navigation {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
-  text-align: left;
+  text-align: center;
 }
 
 .entry-content .wp-block-separator,
@@ -3360,11 +3360,13 @@ svg {
   margin-right: auto;
 }
 
-.wp-caption .wp-caption-text {
-  margin: calc(0.875 * 1rem) 0;
-}
-
 .wp-caption-text {
+  color: #767676;
+  font-size: 0.71111em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.5rem;
   text-align: center;
 }
 


### PR DESCRIPTION
Currently, captions added via the Classic Editor are not styled like those in Gutenberg. This PR gets them both looking the same, on both the front and back end.

_Uses style fixes from #134. 👍_ 

**Before, front end (Image from classic editor on top):**

<img width="488" alt="screen shot 2018-10-28 at 9 06 07 pm" src="https://user-images.githubusercontent.com/1202812/47624683-67e98500-daf5-11e8-846c-084ecc686a29.png">

**Before, in editor (Image from classic editor on top):**

<img width="767" alt="screen shot 2018-10-28 at 9 05 54 pm" src="https://user-images.githubusercontent.com/1202812/47624684-68821b80-daf5-11e8-9309-65a6c392c5bb.png">

**After, front end (Image from classic editor on top):**

<img width="352" alt="screen shot 2018-10-28 at 9 08 18 pm" src="https://user-images.githubusercontent.com/1202812/47624706-9bc4aa80-daf5-11e8-9f70-c0c7b90a51a3.png">


**After, in editor (Image from classic editor on top):**

<img width="751" alt="screen shot 2018-10-28 at 8 56 41 pm" src="https://user-images.githubusercontent.com/1202812/47624698-85b6ea00-daf5-11e8-9e8b-625311de1774.png">