### PR TITLE
Adjust alignfull margins to match the editor. 

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -42,9 +42,9 @@
 		margin-right: auto;
 
 		@include media(tablet) {
-			margin-left: calc(1 * (100vw / 12));
-			margin-right: calc(1 * (100vw / 12));
-			max-width: calc(10 * (100vw / 12));
+			margin-left: calc(2 * (100vw / 12));
+			margin-right: calc(2 * (100vw / 12));
+			max-width: calc(8 * (100vw / 12));
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2715,9 +2715,9 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignwide,
   .entry-summary > *.alignwide {
-    margin-right: calc(1 * (100vw / 12));
-    margin-left: calc(1 * (100vw / 12));
-    max-width: calc(10 * (100vw / 12));
+    margin-right: calc(2 * (100vw / 12));
+    margin-left: calc(2 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2715,9 +2715,9 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignwide,
   .entry-summary > *.alignwide {
-    margin-left: calc(1 * (100vw / 12));
-    margin-right: calc(1 * (100vw / 12));
-    max-width: calc(10 * (100vw / 12));
+    margin-left: calc(2 * (100vw / 12));
+    margin-right: calc(2 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12));
   }
 }
 


### PR DESCRIPTION
To properly align to the left of the text and to the right of items that are floated right. Matches up with the treatment we use in the editor stylesheet.

Tiny piece of #236 

_Before:_
![screen shot 2018-10-29 at 2 27 45 pm](https://user-images.githubusercontent.com/1202812/47671853-e4787400-db86-11e8-9f6e-7c96bf6f99d7.png)


_After:_
![screen shot 2018-10-29 at 2 27 19 pm](https://user-images.githubusercontent.com/1202812/47671857-e6423780-db86-11e8-83ec-ac2c4a9f84d6.png)
