### PR TITLE
Clean up footer link colors

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -68,6 +68,7 @@ function twentynineteen_custom_colors_css() {
 		 * - comment navigation
 		 * - Comment edit link hover
 		 * - Site Footer Link hover
+		 * - Widget links
 		 */
 		a,
 		a:visited,
@@ -81,8 +82,8 @@ function twentynineteen_custom_colors_css() {
 		.comment-navigation .nav-previous a:hover,
 		.comment-navigation .nav-next a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
-		.site-footer a:hover,
-		#colophon a:hover,
+		#colophon .site-info a:hover,
+		.widget a,
 		.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 		.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 		.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
@@ -136,7 +137,8 @@ function twentynineteen_custom_colors_css() {
 		.author-bio .author-description .author-link:hover,
 		.comment .comment-author .fn a:hover,
 		.comment-reply-link:hover,
-		#cancel-comment-reply-link:hover {
+		#cancel-comment-reply-link:hover,
+		.widget a:hover {
 			color: hsl( ' . $primary_color . ', ' . $saturation . ', 23% ); /* base: #005177; */
 		}
 

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -8,8 +8,22 @@
 
 (function( $ ) {
 
+	// Default color.
+	wp.customize( 'colorscheme', function( value ) {
+		value.bind( function( to ) {
+
+			// Update custom color CSS.
+			var style = $( '#custom-theme-colors' );
+				hue = style.data( 'hue' ),
+				css = style.html();
+
+			// Equivalent to css.replaceAll, with hue followed by comma to prevent values with units from being changed.
+			css = css.split( hue + ',' ).join( to + ',' );
+			style.html( css ).data( 'hue', to );
+		});
+	});
+
 	// Primary color.
-	// Custom color hue.
 	wp.customize( 'colorscheme_hue', function( value ) {
 		value.bind( function( to ) {
 

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -13,7 +13,7 @@
 		value.bind( function( to ) {
 
 			// Update custom color CSS.
-			var style = $( '#custom-theme-colors' );
+			var style = $( '#custom-theme-colors' ),
 				hue = style.data( 'hue' ),
 				css = style.html();
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -17,6 +17,15 @@
 		}
 	}
 
+	.site-info a {
+		color: inherit;
+
+		&:hover {
+			text-decoration: none;
+			color: $color__link;
+		}
+	}
+
 	.widget-column {
 		display: flex;
 		flex-wrap: wrap;
@@ -31,14 +40,5 @@
 
 	.site-info {
 		color: $color__text-light;
-	}
-
-	a {
-		color: inherit;
-
-		&:hover {
-			text-decoration: none;
-			color: $color__link;
-		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2770,6 +2770,15 @@ body.page .main-navigation {
   margin-left: 1rem;
 }
 
+#colophon .site-info a {
+  color: inherit;
+}
+
+#colophon .site-info a:hover {
+  text-decoration: none;
+  color: #0073aa;
+}
+
 #colophon .widget-column {
   display: flex;
   flex-wrap: wrap;
@@ -2788,15 +2797,6 @@ body.page .main-navigation {
 
 #colophon .site-info {
   color: #767676;
-}
-
-#colophon a {
-  color: inherit;
-}
-
-#colophon a:hover {
-  text-decoration: none;
-  color: #0073aa;
 }
 
 /* Widgets */

--- a/style.css
+++ b/style.css
@@ -2770,6 +2770,15 @@ body.page .main-navigation {
   margin-right: 1rem;
 }
 
+#colophon .site-info a {
+  color: inherit;
+}
+
+#colophon .site-info a:hover {
+  text-decoration: none;
+  color: #0073aa;
+}
+
 #colophon .widget-column {
   display: flex;
   flex-wrap: wrap;
@@ -2788,15 +2797,6 @@ body.page .main-navigation {
 
 #colophon .site-info {
   color: #767676;
-}
-
-#colophon a {
-  color: inherit;
-}
-
-#colophon a:hover {
-  text-decoration: none;
-  color: #0073aa;
 }
 
 /* Widgets */


### PR DESCRIPTION
Previously, a `color: inherit` rule was forcing all widget links to be gray. This PR makes that rule specific to the `site-info`, as intended. It also makes sure widget links are updated with the color chosen in the customizer.