### PR TITLE
Rename `gutenberg` editor styles to `block-editor` instead.

### DIFF
--- a/style-editor-frame.css
+++ b/style-editor-frame.css
@@ -8,7 +8,7 @@ NOTE: This file customizes items that are out of the normal scope of style-edito
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /** === Title === */
-body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
+body.block-editor-page .block-editor .editor-post-title__block:before {
   background: #767676;
   content: "\020";
   display: block;
@@ -17,7 +17,7 @@ body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
   width: 1em;
 }
 
-body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
+body.block-editor-page .block-editor .editor-post-title__block:before {
   width: 2.8125em;
   margin-top: 0;
   margin-bottom: 0;
@@ -26,35 +26,35 @@ body.gutenberg-editor-page .gutenberg .editor-post-title__block:before {
   top: 0.5em;
 }
 
-body.gutenberg-editor-page .gutenberg .editor-post-title__block .editor-post-title__input {
+body.block-editor-page .block-editor .editor-post-title__block .editor-post-title__input {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 2.8125em;
 }
 
 /** === Default Appender === */
-body.gutenberg-editor-page .gutenberg .editor-default-block-appender__content {
+body.block-editor-page .block-editor .editor-default-block-appender__content {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-size: 22px;
 }
 
 /** === Off-Center Content === */
 @media only screen and (min-width: 768px) {
-  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-writing-flow {
+  body.block-editor-page .block-editor .edit-post-layout .editor-writing-flow {
     max-width: 80%;
     margin: 0 10%;
   }
-  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-post-title__block,
-  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-default-block-appender,
-  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-block-list__block {
+  body.block-editor-page .block-editor .edit-post-layout .editor-post-title__block,
+  body.block-editor-page .block-editor .edit-post-layout .editor-default-block-appender,
+  body.block-editor-page .block-editor .edit-post-layout .editor-block-list__block {
     margin-left: 0;
     margin-right: 0;
   }
-  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-block-list__block[data-align="full"] {
+  body.block-editor-page .block-editor .edit-post-layout .editor-block-list__block[data-align="full"] {
     width: calc( 125% + 88px + 28px);
     position: relative;
     left: calc( -12.5% - 46px - 14px);
   }
-  body.gutenberg-editor-page .gutenberg .edit-post-layout .editor-block-list__block[data-align="right"] {
+  body.block-editor-page .block-editor .edit-post-layout .editor-block-list__block[data-align="right"] {
     max-width: 125%;
   }
 }

--- a/style-editor-frame.scss
+++ b/style-editor-frame.scss
@@ -12,7 +12,7 @@ NOTE: This file customizes items that are out of the normal scope of style-edito
 
 /** === Title === */
 
-body.gutenberg-editor-page .gutenberg .editor-post-title__block {
+body.block-editor-page .block-editor .editor-post-title__block {
 	@include post-section-dash;
 
 	&:before {
@@ -32,14 +32,14 @@ body.gutenberg-editor-page .gutenberg .editor-post-title__block {
 
 /** === Default Appender === */
 
-body.gutenberg-editor-page .gutenberg .editor-default-block-appender__content {
+body.block-editor-page .block-editor .editor-default-block-appender__content {
 	font-family: $font__body;
 	font-size: $font__size_base;
 }
 
 /** === Off-Center Content === */
 
-body.gutenberg-editor-page .gutenberg .edit-post-layout {
+body.block-editor-page .block-editor .edit-post-layout {
 
 	@include media(tablet) {
 		.editor-writing-flow {


### PR DESCRIPTION
5.0 does not include gutenberg classnames in these places. 👍 