### PR TITLE
Replace word-break property with word-wrap

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -5,7 +5,6 @@
 
 	margin: 32px $size__spacing-unit;
 	max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
-	word-break: break-all;
 
 	@include media(tablet) {
 		margin: 32px calc(2 * (100vw / 12));

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -177,6 +177,10 @@
 
 	.entry-content {
 
+		p {
+			word-wrap: break-word;
+		}
+
 		.more-link {
 			@include link-transition;
 			display: inline;

--- a/style.css
+++ b/style.css
@@ -2149,6 +2149,10 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content p {
+  word-wrap: break-word;
+}
+
 .entry .entry-content .more-link {
   transition: color 110ms ease-in-out;
   display: inline;
@@ -2873,7 +2877,6 @@ body.page .main-navigation {
 .entry-summary > * {
   margin: 32px 1rem;
   max-width: calc(100vw - (2 * 1rem));
-  word-break: break-all;
   /*
 	// Set top margins for headings
 	& + h1:before,


### PR DESCRIPTION
Fixes #395

Word-break is too aggressive for what we want to do here, which is just prevent the overflow of long unbroken strings or URLs.

I attached this just to paragraphs within entry-content for now, to be conservative about its usage.

Before:
<img width="710" alt="screen shot 2018-10-29 at 9 41 47 pm" src="https://user-images.githubusercontent.com/1202812/47690199-7f8f3f00-dbc3-11e8-8bdf-e73d2c5a63cc.png">

After:
<img width="729" alt="screen shot 2018-10-29 at 9 42 01 pm" src="https://user-images.githubusercontent.com/1202812/47690201-81f19900-dbc3-11e8-8c7c-7e20fbfd29cf.png">

