### PR TITLE
remove 1 from widget area name

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -120,7 +120,7 @@ function twentynineteen_widgets_init() {
 
 	register_sidebar(
 		array(
-			'name'          => __( 'Footer 1', 'twentynineteen' ),
+			'name'          => __( 'Footer', 'twentynineteen' ),
 			'id'            => 'sidebar-1',
 			'description'   => __( 'Add widgets here to appear in your footer.', 'twentynineteen' ),
 			'before_widget' => '<section id="%1$s" class="widget %2$s">',


### PR DESCRIPTION
Supposing that there will be only one widget area, isn't 'Footer' a better name than 'Footer 1'?

Also, widget are styled in columns if there are more widgets added, so it is clearer to have Footer as name (unless we are expecting people adding more widget areas in the footer?).