### PR TITLE
Fix Undefined twentynineteen_l10n variable error. fixed #403

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@ Version 1.0:
 | @mdawaffe | @mdawaffe |
 | @kraftbj | @kraftbj |
 | @dereksmart | @dsmart |
+| @mayukojpn | @mayukojpn |

--- a/functions.php
+++ b/functions.php
@@ -160,11 +160,10 @@ function twentynineteen_scripts() {
 
 	if ( has_nav_menu( 'menu-1' ) ) {
 		wp_enqueue_script( 'twentynineteen-touch-navigation', get_theme_file_uri( '/js/touch-navigation.js' ), array(), '1.0', true );
-		$twentynineteen_l10n['expand']   = __( 'Expand child menu', 'twentynineteen' );
-		$twentynineteen_l10n['collapse'] = __( 'Collapse child menu', 'twentynineteen' );
+		$l10n_skip_link_focus_fix['expand']   = __( 'Expand child menu', 'twentynineteen' );
+		$l10n_skip_link_focus_fix['collapse'] = __( 'Collapse child menu', 'twentynineteen' );
+		wp_localize_script( 'twentynineteen-skip-link-focus-fix', 'twentynineteenScreenReaderText', $l10n_skip_link_focus_fix );
 	}
-
-	wp_localize_script( 'twentynineteen-skip-link-focus-fix', 'twentynineteenScreenReaderText', $twentynineteen_l10n );
 
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 


### PR DESCRIPTION
- Move `wp_localize_script` function to inside of conditional branch.
- Local scope variables don't need prefix.