### PR TITLE
Add `sizes` attribute for responsive images markup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -152,7 +152,7 @@ function twentynineteen_content_width() {
 		'default' => 723,
 		'wide'    => 800,
 		'full'    => 1024,
-		);
+	);
 }
 add_action( 'after_setup_theme', 'twentynineteen_content_width', 0 );
 

--- a/functions.php
+++ b/functions.php
@@ -147,7 +147,12 @@ function twentynineteen_content_width() {
 	// This variable is intended to be overruled from themes.
 	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-	$GLOBALS['content_width'] = apply_filters( 'twentynineteen_content_width', 640 );
+	$GLOBALS['content_width'] = apply_filters( 'twentynineteen_content_width', 740 );
+	$GLOBALS['block_width'] = array(
+		'default' => 723,
+		'wide'    => 800,
+		'full'    => 1024,
+		);
 }
 add_action( 'after_setup_theme', 'twentynineteen_content_width', 0 );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -113,6 +113,28 @@ function twentynineteen_image_filters_enabled() {
 }
 
 /**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for content images.
+ *
+ * @since Twenty Nineteen 1.0
+ *
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
+ *                      values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
+ */
+function twentynineteen_content_image_sizes_attr( $sizes, $size ) {
+	$width = $size[0];
+
+	if ( 723 <= $width ) {
+		$sizes = '(max-width: 767px) 723px, (max-width: 1167px) calc(8 * (100vw / 12)), (min-width: 1168px) calc(6 * (100vw / 12)), 100vw';
+	}
+
+	return $sizes;
+}
+add_filter( 'wp_calculate_image_sizes', 'twentynineteen_content_image_sizes_attr', 10, 2 );
+
+/**
  * Returns the size for avatars used in the theme.
  */
 function twentynineteen_get_avatar_size() {


### PR DESCRIPTION
Addresses #50. 

Prototype. Currently only works properly for "regular" width images. 

Notes: 
- `$GLOBALS['block_width']` section needs work as the theme uses fluid widths for all images on wider screens. Current values are effectively random.
- To provide correct `sizes` attributes for `alignwide` and `alignfull` images we need a way of knowing, from within the `wp_calculate_image_sizes` filter, what the width display setting is for the current image. At present it is only defined in a class on the parent `<figure>` element which to my knowledge is inaccessible from the filter.

Works as prototype for testing of [Gutenberg issue 6177](https://github.com/WordPress/gutenberg/issues/6177). 

cc @azaozz

Todo:

- [ ] `sizes` attributes for `alignwide` and `alignfull`
- [x] `sizes` attribute for featured images
