### PR TITLE
371 - Add stylelint with WPCS config to .travis.yml

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+sass/_normalize.scss

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-wordpress/scss",
+  "rules": {
+    "no-descending-specificity": null
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,20 @@ before_install:
   # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
   # https://twitter.com/kelunik/status/954242454676475904
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  # Make sure NVM is updated so it supports the --lts option.
+  - |
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+  # Install latest LTS version of Node.
+  - nvm install --lts
+  # Update NPM.
+  - npm install -g npm
+  # Output final versions.
+  - nvm --version
+  - node -v
+  - npm -v
 
 # Use this to prepare your build for testing.
 # e.g. copy database configurations, environment variables, etc.
@@ -80,7 +94,9 @@ before_script:
   - if [[ "$LINT" == "1" ]]; then composer install --no-suggest; fi
   # After CodeSniffer install you should refresh your path.
   - phpenv rehash;
-  # Install JSHint, a JavaScript Code Quality Tool
+  # Install Node dependencies.
+  - if [[ "$LINT" == "1" ]]; then npm install; fi
+  # Install JSHint, a JavaScript Code Quality Tool.
   # @link http://jshint.com/docs/
   - if [[ "$LINT" == "1" ]]; then npm install -g jshint; fi
   - if [[ "$LINT" == "1" ]]; then wget https://develop.svn.wordpress.org/trunk/.jshintrc; fi
@@ -94,7 +110,9 @@ script:
   # The usage of bash + || exit 1 is to ensure xargs does not exit on first error.
   - find . \( -name '*.php' \) -not -path "./vendor/*" | xargs -n1 bash -c 'php -lf $0 || exit 1'
   # Run the theme through JSHint
-  - if [[ "$LINT" == "1" ]]; then jshint --exclude ./vendor .; fi
+  - if [[ "$LINT" == "1" ]]; then jshint --exclude=./vendor,./node_modules .; fi
+  # Run all other Node-based lints.
+  - if [[ "$LINT" == "1" ]]; then npm run lint; fi
   # WordPress Coding Standards
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
   # -p flag: Show progress of the run.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "npm-run-all": "^4.1.3",
     "postcss-cli": "^6.0.1",
     "postcss-focus-within": "^3.0.0",
-    "rtlcss": "^2.4.0"
+    "rtlcss": "^2.4.0",
+    "stylelint": "^9.7.1",
+    "stylelint-config-wordpress": "^13.1.0"
   },
   "rtlcssConfig": {
     "options": {
@@ -39,6 +41,7 @@
     "build:rtl": "rtlcss style.css style-rtl.css",
     "build:print": "node-sass print.scss print.css --output-style expanded && postcss -r print.css",
     "build": "run-p \"build:*\"",
-    "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"
+    "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
+    "lint": "stylelint sass/"
   }
 }


### PR DESCRIPTION
Fixes #371 .

Example build: https://travis-ci.org/atanas-angelov-dev/twentynineteen/builds/449253585
Note that builds will now fail due to Stylelint rule violations in `master`.

WordPress Username: [atanasangelovdev](https://profiles.wordpress.org/atanasangelovdev)