### PR TITLE
Update post tags wrapper to `.tags-links`

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -99,7 +99,7 @@ if ( ! function_exists( 'twentynineteen_entry_footer' ) ) :
 			if ( $tags_list ) {
 				/* translators: 1: SVG icon. 2: posted in label, only visible to screen readers. 3: list of tags. */
 				printf(
-					'<span class="cat-links">%1$s<span class="screen-reader-text">%2$s </span>%3$s</span>',
+					'<span class="tags-links">%1$s<span class="screen-reader-text">%2$s </span>%3$s</span>',
 					twentynineteen_get_icon_svg( 'tag', 16 ),
 					esc_html__( 'Tags:', 'twentynineteen' ),
 					$tags_list


### PR DESCRIPTION
Previously, the post category wrapper and the post tags wrapper had the same class name. Updated them to match the more common `.tags-links` convention.