### PR TITLE
Remove extra white space from translatable text

### DIFF
--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -15,7 +15,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 	<p class="author-description">
 		<?php the_author_meta( 'description' ); ?>
 		<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-			<?php _e( 'View more posts ', 'twentynineteen' ); ?>
+			<?php _e( 'View more posts', 'twentynineteen' ); ?>
 		</a>
 	</p><!-- .author-description -->
 </div><!-- .author-bio -->


### PR DESCRIPTION
There is an extra white space after the word "posts", which creates an error prompt on translate.wordpress.org when a translator submits a correct translation.

WP.org username: [nao](https://profiles.wordpress.org/nao)