### PR TITLE
Fix submenu on mobile and desktop

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -67,12 +67,9 @@
 					top: 0.2rem;
 				}
 
-				&:not(:last-child) {
-
-					.mobile-submenu-expand,
-					.desktop-submenu-expand {
-						margin-right: #{0.5 * $size__spacing-unit};
-					}
+				.mobile-submenu-expand,
+				.desktop-submenu-expand {
+					margin-right: #{0.5 * $size__spacing-unit};
 				}
 			}
 
@@ -127,12 +124,9 @@
 					}
 				}
 
-				&:not(:last-child) {
-
-					.mobile-submenu-expand,
-					.desktop-submenu-expand {
-						margin-right: 0;
-					}
+				.mobile-submenu-expand,
+				.desktop-submenu-expand {
+					margin-right: 0;
 				}
 
 				@include media(tablet) {
@@ -206,12 +200,11 @@
 	.main-menu .menu-item-has-children:focus > .sub-menu,
 	.main-menu .menu-item-has-children .sub-menu:hover,
 	.main-menu .menu-item-has-children .sub-menu:focus {
-		display: table;
-		margin-top: 0;
-		opacity: 1;
-
 		/* Non-mobile position */
 		@include media(tablet) {
+			display: table;
+			margin-top: 0;
+			opacity: 1;
 			position: absolute;
 			left: 0;
 			right: auto;

--- a/style.css
+++ b/style.css
@@ -958,8 +958,8 @@ body.page .main-navigation {
   top: 0.2rem;
 }
 
-.main-navigation .main-menu > li.menu-item-has-children:not(:last-child) .mobile-submenu-expand,
-.main-navigation .main-menu > li.menu-item-has-children:not(:last-child) .desktop-submenu-expand {
+.main-navigation .main-menu > li.menu-item-has-children .mobile-submenu-expand,
+.main-navigation .main-menu > li.menu-item-has-children .desktop-submenu-expand {
   margin-right: 0.5rem;
 }
 
@@ -1014,8 +1014,8 @@ body.page .main-navigation {
   top: 0;
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children:not(:last-child) .mobile-submenu-expand,
-.main-navigation .sub-menu > li.menu-item-has-children:not(:last-child) .desktop-submenu-expand {
+.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand,
+.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand {
   margin-right: 0;
 }
 
@@ -1082,9 +1082,6 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children:focus > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children .sub-menu:hover,
 .main-navigation .main-menu .menu-item-has-children .sub-menu:focus {
-  display: table;
-  margin-top: 0;
-  opacity: 1;
   /* Non-mobile position */
 }
 
@@ -1093,6 +1090,9 @@ body.page .main-navigation {
   .main-navigation .main-menu .menu-item-has-children:focus > .sub-menu,
   .main-navigation .main-menu .menu-item-has-children .sub-menu:hover,
   .main-navigation .main-menu .menu-item-has-children .sub-menu:focus {
+    display: table;
+    margin-top: 0;
+    opacity: 1;
     position: absolute;
     left: 0;
     right: auto;


### PR DESCRIPTION
Fixes #412. Fixes #394.

This PR fixes an isssue where the last submenu chevron was offset. It also fixes a hover issue on mobile, where the submenu would appear on hover.

Before:

<img width="258" alt="screenshot 2018-10-31 at 11 34 26" src="https://user-images.githubusercontent.com/1204802/47782657-0ac21f00-dd01-11e8-8ba3-6b86feb9683f.png">

After:

![desktop](https://user-images.githubusercontent.com/1204802/47782659-0d247900-dd01-11e8-832f-7e40c16d8ac0.gif)

Before:

![before](https://user-images.githubusercontent.com/1204802/47782665-0f86d300-dd01-11e8-90ec-1b5363ba48c5.gif)

After:

![mobile](https://user-images.githubusercontent.com/1204802/47782670-11e92d00-dd01-11e8-91fb-97b9abe401f8.gif)
