### PR TITLE
Fix RTL alignments

### DIFF
--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -1,9 +1,11 @@
 .alignleft {
+	/*rtl:ignore*/
 	float: left;
 	margin-right: $size__spacing-unit;
 }
 
 .alignright {
+	/*rtl:ignore*/
 	float: right;
 	margin-left: $size__spacing-unit;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1478,12 +1478,12 @@ body.page .main-navigation {
 
 /* Alignments */
 .alignleft {
-  float: right;
+  float: left;
   margin-left: 1rem;
 }
 
 .alignright {
-  float: left;
+  float: right;
   margin-right: 1rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -1478,11 +1478,13 @@ body.page .main-navigation {
 
 /* Alignments */
 .alignleft {
+  /*rtl:ignore*/
   float: left;
   margin-right: 1rem;
 }
 
 .alignright {
+  /*rtl:ignore*/
   float: right;
   margin-left: 1rem;
 }


### PR DESCRIPTION
This fixes #325.

It should be paired with https://github.com/WordPress/gutenberg/pull/11293.

This PR adds RTL ignore comments to the block alignment classes so the values are not overridden.

Before:

<img width="905" alt="screenshot 2018-10-31 at 12 04 04" src="https://user-images.githubusercontent.com/1204802/47784395-b7060480-dd05-11e8-99d4-1c7c350f870a.png">

After:

<img width="876" alt="screenshot 2018-10-31 at 12 04 10" src="https://user-images.githubusercontent.com/1204802/47784396-b8cfc800-dd05-11e8-82ab-bcfdf9db7c77.png">
