### PR TITLE
add mail icon to mapping

### DIFF
--- a/classes/class-twentynineteen-svg-icons.php
+++ b/classes/class-twentynineteen-svg-icons.php
@@ -200,6 +200,9 @@ class TwentyNineteen_SVG_Icons {
 		'google-plus' => array(
 			'plus.google.com',
 		),
+		'mail'   => array(
+			'mailto:',
+		),
 		'slideshare'  => array(
 			'slideshare.net',
 		),


### PR DESCRIPTION
Related to #435 

Adding the envelope icon for an email address in the social navigation to the mapping.