### PR TITLE
Add theme support for responsive embeds

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -110,6 +110,9 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 			)
 		);
 
+		// Add support for responsive embedded content
+		add_theme_support( 'responsive-embeds' );
+
 	}
 endif;
 add_action( 'after_setup_theme', 'twentynineteen_setup' );


### PR DESCRIPTION
Adds theme support for [responsive embeds](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#responsive-embedded-content). Fixes #107

Before:
![videos-before](https://user-images.githubusercontent.com/1202812/47811623-9301ed80-dd1c-11e8-8003-3dc9a63847f7.gif)

After:
![videos-after](https://user-images.githubusercontent.com/1202812/47811627-95644780-dd1c-11e8-8cc8-6125e9102bd6.gif)