### PR TITLE
i18n: Add context to adjectives

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -52,8 +52,8 @@ function twentynineteen_customize_register( $wp_customize ) {
 			'type'    => 'radio',
 			'label'    => __( 'Color Scheme', 'twentynineteen' ),
 			'choices'  => array(
-				'default'  => __( 'Default', 'twentynineteen' ),
-				'custom' => __( 'Custom', 'twentynineteen' ),
+				'default'  => _x( 'Default', 'color scheme', 'twentynineteen' ),
+				'custom' => _x( 'Custom', 'color scheme', 'twentynineteen' ),
 			),
 			'section'  => 'colors',
 			'priority' => 5,

--- a/template-parts/content/content-excerpt.php
+++ b/template-parts/content/content-excerpt.php
@@ -15,7 +15,7 @@
 	<header class="entry-header">
 		<?php
 		if ( is_sticky() && is_home() && ! is_paged() ) {
-			printf( '<span class="sticky-post">%s</span>', __( 'Featured', 'twentynineteen' ) );
+			printf( '<span class="sticky-post">%s</span>', _x( 'Featured', 'post', 'twentynineteen' ) );
 		}
 		the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 		?>

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -15,7 +15,7 @@
 	<header class="entry-header">
 		<?php
 		if ( is_sticky() && is_home() && ! is_paged() ) {
-			printf( '<span class="sticky-post">%s</span>', __( 'Featured', 'twentynineteen' ) );
+			printf( '<span class="sticky-post">%s</span>', _x( 'Featured', 'post', 'twentynineteen' ) );
 		}
 		if ( is_singular() ) :
 			the_title( '<h1 class="entry-title">', '</h1>' );


### PR DESCRIPTION
One-word strings that are adjectives would be easier to translate if they had context.