### PR TITLE
Fix the width of nested blocks

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -26,6 +26,10 @@ when Gutenberg supports styling those variations more intuitively.
   }
 }
 
+.wp-block .wp-block {
+  width: 100%;
+}
+
 /** === Base Typography === */
 body {
   font-size: 22px;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -24,6 +24,10 @@ when Gutenberg supports styling those variations more intuitively.
 	@include media(desktop) {
 		width: calc(6 * (100vw / 12 ));
 	}
+
+	.wp-block {
+		width: 100%;
+	}
 }
 
 /** === Base Typography === */


### PR DESCRIPTION
Fixes #433 

Addresses a bug that arrived along with Gutenberg 4.2, where nested blocks (for instance, in  the Columns block or the Media + Text block) would extend beyond their container. 

**Before:**
<img width="1440" alt="screen shot 2018-11-01 at 2 12 11 pm" src="https://user-images.githubusercontent.com/1202812/47870690-83e47380-dde0-11e8-97ad-9be223ed8b64.png">

**After:**
<img width="1440" alt="screen shot 2018-11-01 at 2 10 55 pm" src="https://user-images.githubusercontent.com/1202812/47870695-86df6400-dde0-11e8-909c-bce06783aaec.png">
