### PR TITLE
Fix alignment of dot separator in the editor

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -405,7 +405,8 @@ body[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citati
 .wp-block-separator.is-style-dots:before {
   color: #767676;
   font-size: 1.6875em;
-  letter-spacing: 0.88889em;
+  letter-spacing: calc(2 * 1rem);
+  padding-left: calc(2 * 1rem);
 }
 
 /** === Latest Posts, Archives, Categories === */

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -412,7 +412,8 @@ body[data-type="core/pullquote"][data-align="right"] {
 	&.is-style-dots:before {
 		color: $color__text-light;
 		font-size: $font__size-lg;
-		letter-spacing: $font__size-sm;
+		letter-spacing: calc(2 * #{$size__spacing-unit});
+		padding-left: calc(2 * #{$size__spacing-unit});
 	}
 }
 


### PR DESCRIPTION
Addresses half of #429.

**Before:**
<img width="636" alt="screen shot 2018-11-01 at 2 37 28 pm" src="https://user-images.githubusercontent.com/1202812/47871983-d1aeab00-dde3-11e8-965f-f8ba0aa686b0.png">

**After:**
<img width="649" alt="screen shot 2018-11-01 at 2 36 33 pm" src="https://user-images.githubusercontent.com/1202812/47871985-d4110500-dde3-11e8-91e8-d0309f884c71.png">
