### PR TITLE
Update cover image text alignment

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -154,17 +154,9 @@ figcaption,
   line-height: 1.4;
 }
 
-.wp-block-cover.has-left-content {
-  justify-content: center;
-}
-
 .wp-block-cover.has-left-content h2,
 .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1em;
-}
-
-.wp-block-cover.has-right-content {
-  justify-content: center;
 }
 
 .wp-block-cover.has-right-content h2,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -151,7 +151,6 @@ figcaption,
 	}
 
 	&.has-left-content {
-		justify-content: center;
 
 		h2,
 		.wp-block-cover-text {
@@ -160,7 +159,6 @@ figcaption,
 	}
 
 	&.has-right-content {
-		justify-content: center;
 
 		h2,
 		.wp-block-cover-text {


### PR DESCRIPTION
Fixes #295

Our styles were unnecessarily overriding default Gutenberg values and causing this bug. 🙂

**Before:**

![47470688-d5837180-d7d4-11e8-93dc-890594790baf](https://user-images.githubusercontent.com/1202812/47873158-d6289300-dde6-11e8-9ef6-943b7044466e.gif)

**After:**

![cover-image](https://user-images.githubusercontent.com/1202812/47873166-da54b080-dde6-11e8-9cb3-31d9d5193957.gif)