### PR TITLE
Fix columns, and other nesting containers

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -11,18 +11,18 @@ when Gutenberg supports styling those variations more intuitively.
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Calculates maximum width for post content */
 /** === Content Width === */
-.wp-block {
+:not(.editor-inner-blocks) > .editor-block-list__layout > .wp-block {
   width: calc(100vw - (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block {
+  :not(.editor-inner-blocks) > .editor-block-list__layout > .wp-block {
     width: calc(8 * (100vw / 12));
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .wp-block {
+  :not(.editor-inner-blocks) > .editor-block-list__layout > .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -14,7 +14,8 @@ when Gutenberg supports styling those variations more intuitively.
 
 /** === Content Width === */
 
-.wp-block {
+// Change the width of all top-level blocks, avoid touching nested blocks.
+:not(.editor-inner-blocks) > .editor-block-list__layout > .wp-block {
 	width: calc(100vw - (2 * #{$size__spacing-unit}));
 
 	@include media(tablet) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3479,6 +3479,7 @@ body.page .main-navigation {
 .entry-content .wp-block-separator.is-style-dots,
 .entry-content hr.is-style-dots {
   max-width: calc(100vw - (2 * 1rem));
+  text-align: center;
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
This PR fixes #433.

There are width rules in the editor style. These apply to all blocks, including nesting blocks.

In this PR I made them specific only to top level blocks.

<img width="803" alt="screenshot 2018-11-02 at 12 58 10" src="https://user-images.githubusercontent.com/1204802/47914249-2b27e000-de9f-11e8-8842-3c0597e224ca.png">
