### PR TITLE
Add space to entry header on small screens

### DIFF
--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -61,7 +61,7 @@
 	/* Entry header */
 
 	.site-featured-image .entry-header {
-
+		margin-top: calc( 4 * #{$size__spacing-unit});
 		margin-bottom: 0;
 		margin-left: 0;
 		margin-right: 0;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -1,23 +1,26 @@
 // Site header
 
 .site-header {
-
 	padding: 1em;
+
+	&.featured-image {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		min-height: 90vh;
+
+		.site-branding-container {
+			margin-bottom: auto;
+		}
+	}
 
 	@include media(tablet) {
 		margin: 0;
 		padding: 3rem 0;
 
 		&.featured-image {
-			display: flex;
 			min-height: 100vh;
-			flex-direction: column;
-			justify-content: space-between;
 			margin-bottom: 3rem;
-
-			.site-branding-container {
-				margin-bottom: auto;
-			}
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1755,6 +1755,7 @@ body.page .main-navigation {
 }
 
 .site-header.featured-image .site-featured-image .entry-header {
+  margin-top: calc( 4 * 1rem);
   margin-bottom: 0;
   margin-right: 0;
   margin-left: 0;
@@ -3479,6 +3480,7 @@ body.page .main-navigation {
 .entry-content .wp-block-separator.is-style-dots,
 .entry-content hr.is-style-dots {
   max-width: calc(100vw - (2 * 1rem));
+  text-align: center;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -134,8 +134,7 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -558,18 +557,14 @@ h6 {
 .error-404 .page-title,
 .comments-title,
 blockquote {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
   word-break: break-word;
 }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    -webkit-hyphens: none;
-        -ms-hyphens: none;
-            hyphens: none;
+    hyphens: none;
   }
 }
 
@@ -983,8 +978,6 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
-    width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
     max-width: calc(3 * (100vw / 12));
   }
@@ -1072,8 +1065,6 @@ body.page .main-navigation {
     padding-right: 0;
     position: absolute;
     right: 100%;
-    width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
     top: 0;
   }
@@ -1100,8 +1091,6 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
-    width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
     transform: none;
     animation: fade_in 0.1s forwards;
@@ -1280,10 +1269,7 @@ body.page .main-navigation {
 
 .post-navigation .nav-links a .meta-nav {
   color: #767676;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
@@ -1295,9 +1281,7 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a .post-title {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
 }
 
 .post-navigation .nav-links a:hover {
@@ -1437,8 +1421,7 @@ body.page .main-navigation {
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
-  -webkit-clip-path: inset(50%);
-          clip-path: inset(50%);
+  clip-path: inset(50%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -1454,8 +1437,7 @@ body.page .main-navigation {
   border-radius: 3px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
   clip: auto !important;
-  -webkit-clip-path: none;
-          clip-path: none;
+  clip-path: none;
   color: #21759b;
   display: block;
   font-size: 14px;
@@ -1540,20 +1522,25 @@ body.page .main-navigation {
   padding: 1em;
 }
 
+.site-header.featured-image {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 90vh;
+}
+
+.site-header.featured-image .site-branding-container {
+  margin-bottom: auto;
+}
+
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
     padding: 3rem 0;
   }
   .site-header.featured-image {
-    display: flex;
     min-height: 100vh;
-    flex-direction: column;
-    justify-content: space-between;
     margin-bottom: 3rem;
-  }
-  .site-header.featured-image .site-branding-container {
-    margin-bottom: auto;
   }
 }
 
@@ -1751,6 +1738,7 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
+  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 

--- a/style.css
+++ b/style.css
@@ -1757,6 +1757,7 @@ body.page .main-navigation {
 }
 
 .site-header.featured-image .site-featured-image .entry-header {
+  margin-top: calc( 4 * 1rem);
   margin-bottom: 0;
   margin-left: 0;
   margin-right: 0;

--- a/style.css
+++ b/style.css
@@ -1542,20 +1542,25 @@ body.page .main-navigation {
   padding: 1em;
 }
 
+.site-header.featured-image {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 90vh;
+}
+
+.site-header.featured-image .site-branding-container {
+  margin-bottom: auto;
+}
+
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
     padding: 3rem 0;
   }
   .site-header.featured-image {
-    display: flex;
     min-height: 100vh;
-    flex-direction: column;
-    justify-content: space-between;
     margin-bottom: 3rem;
-  }
-  .site-header.featured-image .site-branding-container {
-    margin-bottom: auto;
   }
 }
 


### PR DESCRIPTION
Improves header area on small screens. This introduces a visual break between the menu and the page header text, and sets the header area to be a minimum of `90vh` on small screens. This aligns closer to [the original comps](https://wp.invisionapp.com/share/8COLBCNTZM4#/screens) than our current implementation. Should have no impact on larger screens, or on posts/pages with no featured image.

---

**Before:**

<img width="322" alt="screen shot 2018-11-02 at 9 06 51 am" src="https://user-images.githubusercontent.com/1202812/47917112-dc6a4e00-de7e-11e8-9ca8-b82183db51e5.png">

<img width="375" alt="screen shot 2018-11-02 at 9 06 42 am" src="https://user-images.githubusercontent.com/1202812/47917121-de341180-de7e-11e8-9f5e-6cb7ab81f844.png">

<img width="414" alt="screen shot 2018-11-02 at 9 07 05 am" src="https://user-images.githubusercontent.com/1202812/47917123-dffdd500-de7e-11e8-9ef4-c4c0c806bb33.png">

---

**After:** 

<img width="320" alt="screen shot 2018-11-02 at 9 04 46 am" src="https://user-images.githubusercontent.com/1202812/47917148-f60b9580-de7e-11e8-9a8a-f6354e8fdde2.png">

<img width="376" alt="screen shot 2018-11-02 at 9 04 10 am" src="https://user-images.githubusercontent.com/1202812/47917154-f9068600-de7e-11e8-8569-2f7e507d6290.png">

<img width="414" alt="screen shot 2018-11-02 at 9 04 21 am" src="https://user-images.githubusercontent.com/1202812/47917162-fad04980-de7e-11e8-99e6-b319666f4de3.png">

