### PR TITLE
Disable xdebug to speed up Travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ env:
 # e.g. copy database configurations, environment variables, etc.
 # Failures in this section will result in build status 'errored'.
 before_script:
+    # Speed up build time by disabling Xdebug.
+    - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     - echo $WP_VERSION
     - echo $WP_MULTISITE
     - echo $LINT


### PR DESCRIPTION
Xdebug is only needed when generating code coverage reports, but, when, not needed, it really slows things down. Disabling it will speed up the build time.

As suggested in : https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
And in : https://twitter.com/kelunik/status/954242454676475904