### PR TITLE
Decrease font size for widgets and widget-based blocks.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -193,7 +193,7 @@
 		li {
 			color: $color__text-light;
 			font-family: $font__heading;
-			font-size: calc(#{$font__size_base} * #{$font__size-lg / 1em} );
+			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
 			line-height: $font__line-height-heading;
 

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -28,7 +28,7 @@
 		li {
 			color: $color__text-light;
 			font-family: $font__heading;
-			font-size: calc(#{$font__size_base} * #{$font__size-lg / 1em} );
+			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
 			line-height: $font__line-height-heading;
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -488,7 +488,7 @@ ul.wp-block-archives li,
 .wp-block-categories li,
 .wp-block-latest-posts li {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1.6875em;
+  font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -502,7 +502,7 @@ ul.wp-block-archives,
 
 	li {
 		font-family: $font__heading;
-		font-size: $font__size-lg;
+		font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 		font-weight: bold;
 		line-height: $font__line-height-heading;
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -134,8 +134,7 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -558,18 +557,14 @@ h6 {
 .error-404 .page-title,
 .comments-title,
 blockquote {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
   word-break: break-word;
 }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    -webkit-hyphens: none;
-        -ms-hyphens: none;
-            hyphens: none;
+    hyphens: none;
   }
 }
 
@@ -983,8 +978,6 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
-    width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
     max-width: calc(3 * (100vw / 12));
   }
@@ -1072,8 +1065,6 @@ body.page .main-navigation {
     padding-right: 0;
     position: absolute;
     right: 100%;
-    width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
     top: 0;
   }
@@ -1100,8 +1091,6 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
-    width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
     transform: none;
     animation: fade_in 0.1s forwards;
@@ -1280,10 +1269,7 @@ body.page .main-navigation {
 
 .post-navigation .nav-links a .meta-nav {
   color: #767676;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
@@ -1295,9 +1281,7 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a .post-title {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
 }
 
 .post-navigation .nav-links a:hover {
@@ -1437,8 +1421,7 @@ body.page .main-navigation {
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
-  -webkit-clip-path: inset(50%);
-          clip-path: inset(50%);
+  clip-path: inset(50%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -1454,8 +1437,7 @@ body.page .main-navigation {
   border-radius: 3px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
   clip: auto !important;
-  -webkit-clip-path: none;
-          clip-path: none;
+  clip-path: none;
   color: #21759b;
   display: block;
   font-size: 14px;
@@ -1751,6 +1733,7 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
+  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 
@@ -2860,7 +2843,7 @@ body.page .main-navigation {
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.6875);
+  font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
 }
@@ -3120,7 +3103,7 @@ body.page .main-navigation {
 .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.6875);
+  font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
 }

--- a/style.css
+++ b/style.css
@@ -2862,7 +2862,7 @@ body.page .main-navigation {
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.6875);
+  font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
 }
@@ -3122,7 +3122,7 @@ body.page .main-navigation {
 .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.6875);
+  font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
 }


### PR DESCRIPTION
This PR aligns the font size for widget and widget-based blocks with the size we're using for the page header and pagination. The previous large size was unweildy in the context of long lists (like archives & category lists, etc.)

Before:
<img width="458" alt="screen shot 2018-11-02 at 3 25 17 pm" src="https://user-images.githubusercontent.com/1202812/47936296-9ed3e800-deb3-11e8-8b0b-03cf6efa5a37.png">

After:
<img width="402" alt="screen shot 2018-11-02 at 3 19 46 pm" src="https://user-images.githubusercontent.com/1202812/47936299-a1364200-deb3-11e8-9eb2-cac5c211b5da.png">
