### PR TITLE
Removes hover states for edit-links for better a11y

### DIFF
--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -175,13 +175,6 @@
 		}
 	}
 
-	&:hover > .comment-body > .comment-meta > .comment-metadata {
-		> .edit-link-sep,
-		> .edit-link {
-			opacity: 1;
-		}
-	}
-
 	.comment-body {
 		margin: calc(2 * #{$size__spacing-unit}) 0;
 	}
@@ -290,15 +283,11 @@
 		.edit-link-sep {
 			color: $color__text-light;
 			margin: 0 0.2em;
-			opacity: 0;
-			transition: opacity 200ms ease-in-out;
 			vertical-align: baseline;
 		}
 
 		.edit-link {
 			color: $color__text-light;
-			transition: opacity 200ms ease-in-out;
-			opacity: 0;
 
 			svg {
 				transform: scale(0.8);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2458,11 +2458,6 @@ body.page .main-navigation {
   }
 }
 
-.comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link-sep,
-.comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link {
-  opacity: 1;
-}
-
 .comment .comment-body {
   margin: calc(2 * 1rem) 0;
 }
@@ -2580,15 +2575,11 @@ body.page .main-navigation {
 .comment .comment-metadata .edit-link-sep {
   color: #767676;
   margin: 0 0.2em;
-  opacity: 0;
-  transition: opacity 200ms ease-in-out;
   vertical-align: baseline;
 }
 
 .comment .comment-metadata .edit-link {
   color: #767676;
-  transition: opacity 200ms ease-in-out;
-  opacity: 0;
 }
 
 .comment .comment-metadata .edit-link svg {

--- a/style.css
+++ b/style.css
@@ -2460,11 +2460,6 @@ body.page .main-navigation {
   }
 }
 
-.comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link-sep,
-.comment:hover > .comment-body > .comment-meta > .comment-metadata > .edit-link {
-  opacity: 1;
-}
-
 .comment .comment-body {
   margin: calc(2 * 1rem) 0;
 }
@@ -2582,15 +2577,11 @@ body.page .main-navigation {
 .comment .comment-metadata .edit-link-sep {
   color: #767676;
   margin: 0 0.2em;
-  opacity: 0;
-  transition: opacity 200ms ease-in-out;
   vertical-align: baseline;
 }
 
 .comment .comment-metadata .edit-link {
   color: #767676;
-  transition: opacity 200ms ease-in-out;
-  opacity: 0;
 }
 
 .comment .comment-metadata .edit-link svg {


### PR DESCRIPTION
Removes the `:hover` state from edit links so that they are always visible for better accessibility. 