### PR TITLE
Fix handle used for exporting twentynineteenScreenReaderText variable

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -166,9 +166,6 @@ function twentynineteen_scripts() {
 
 	if ( has_nav_menu( 'menu-1' ) ) {
 		wp_enqueue_script( 'twentynineteen-touch-navigation', get_theme_file_uri( '/js/touch-navigation.js' ), array(), '1.0', true );
-		$l10n_skip_link_focus_fix['expand']   = __( 'Expand child menu', 'twentynineteen' );
-		$l10n_skip_link_focus_fix['collapse'] = __( 'Collapse child menu', 'twentynineteen' );
-		wp_localize_script( 'twentynineteen-touch-navigation', 'twentynineteenScreenReaderText', $l10n_skip_link_focus_fix );
 	}
 
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );

--- a/functions.php
+++ b/functions.php
@@ -168,7 +168,7 @@ function twentynineteen_scripts() {
 		wp_enqueue_script( 'twentynineteen-touch-navigation', get_theme_file_uri( '/js/touch-navigation.js' ), array(), '1.0', true );
 		$l10n_skip_link_focus_fix['expand']   = __( 'Expand child menu', 'twentynineteen' );
 		$l10n_skip_link_focus_fix['collapse'] = __( 'Collapse child menu', 'twentynineteen' );
-		wp_localize_script( 'twentynineteen-skip-link-focus-fix', 'twentynineteenScreenReaderText', $l10n_skip_link_focus_fix );
+		wp_localize_script( 'twentynineteen-touch-navigation', 'twentynineteenScreenReaderText', $l10n_skip_link_focus_fix );
 	}
 
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );


### PR DESCRIPTION
It appears that the `twentynineteenScreenReaderText` variable is being localized for the wrong script handle. This fixes that problem. Nevertheless, the `twentynineteenScreenReaderText` variable is not being used in the theme at all so should it not be eliminated entirely?

See also #405, #403. #337.