### PR TITLE
Simplify nav submenu markup and improve no-JS behavior

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -154,8 +154,8 @@ function twentynineteen_custom_colors_css() {
 		.main-navigation .sub-menu > li > a:focus,
 		.main-navigation .sub-menu > li > a:hover:after,
 		.main-navigation .sub-menu > li > a:focus:after,
-		.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):hover,
-		.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):focus {
+		.main-navigation .sub-menu > li > a:hover,
+		.main-navigation .sub-menu > li > a:focus {
 			background: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_hover . ' ); /* base: #005177; */
 		}';
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -216,10 +216,7 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 		// Inject the keyboard_arrow_left SVG inside the parent nav menu item, and let the item link to the parent item.
 		// @todo Only do this for nested submenus? If on a first-level submenu, then really the link could be "#" since the desire is to remove the target entirely.
 		$link = sprintf(
-			'<a class="menu-item-link-return" id="%1$s" href="%2$s" onclick="%3$s" tabindex="-1">%4$s',
-			esc_attr( "menu-item-link-return-{$item->original_id}" ),
-			esc_attr( "#menu-item-link-{$item->original_id}" ),
-			esc_attr( 'event.preventDefault();' ),
+			'<span class="menu-item-link-return" tabindex="-1">%s',
 			twentynineteen_get_icon_svg( 'chevron_left', 24 )
 		);
 
@@ -230,9 +227,6 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 			1 // Limit.
 		);
 	} elseif ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-		// Add an ID to the link element itself to facilitate navigation from submenu back to parent.
-		$output = preg_replace( '/(?<=<a\s)/', sprintf( ' id="%s" ', esc_attr( "menu-item-link-{$item->ID}" ) ), $output );
-
 		// Add SVG icon to parent items.
 		if ( 0 === $depth ) {
 			$icon = twentynineteen_get_icon_svg( 'keyboard_arrow_down', 24 );
@@ -240,7 +234,10 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 			$icon = twentynineteen_get_icon_svg( 'chevron_right', 24 );
 		}
 
-		$output .= "<span class='submenu-expand' tabindex='-1'>$icon</span>";
+		$output .= sprintf(
+			'<span class="submenu-expand" tabindex="-1">%s</span>',
+			$icon
+		);
 	}
 
 	return $output;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -240,13 +240,7 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 			$icon = twentynineteen_get_icon_svg( 'chevron_right', 24 );
 		}
 
-		$link = sprintf(
-			'<span class="mobile-submenu-expand" tabindex="-1">%s</span>',
-			$icon
-		);
-
-		$output .= $link;
-		$output .= "<span class='desktop-submenu-expand'>$icon</span>";
+		$output .= "<span class='submenu-expand' tabindex='-1'>$icon</span>";
 	}
 
 	return $output;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -240,11 +240,8 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 			$icon = twentynineteen_get_icon_svg( 'chevron_right', 24 );
 		}
 
-		// @todo We might as well just go back to using the SVG element if the link approach is not suitable for no-JS environments.
 		$link = sprintf(
-			'<a class="mobile-submenu-expand" href="%s" onclick="%s" tabindex="-1">%s</a>',
-			esc_attr( "#menu-item-link-return-{$item->ID}" ),
-			esc_attr( 'event.preventDefault();' ),
+			'<span class="mobile-submenu-expand" tabindex="-1">%s</span>',
 			$icon
 		);
 

--- a/js/touch-navigation.js
+++ b/js/touch-navigation.js
@@ -32,7 +32,7 @@
 		'use strict';
 
 		var siteNavigation = document.querySelector('.main-navigation > div > ul');
-		var subMenuExpand  = document.querySelectorAll('.mobile-submenu-expand');
+		var subMenuExpand  = document.querySelectorAll('.submenu-expand');
 		var subMenuReturn  = document.querySelectorAll('.menu-item-link-return');
 		var parentMenuLink = siteNavigation.querySelectorAll('.menu-item-has-children a[aria-expanded]');
 		var i;

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -61,14 +61,12 @@
 					}
 				}
 
-				.mobile-submenu-expand svg,
-				.desktop-submenu-expand svg {
+				.submenu-expand svg {
 					position: relative;
 					top: 0.2rem;
 				}
 
-				.mobile-submenu-expand,
-				.desktop-submenu-expand {
+				.submenu-expand {
 					margin-right: #{0.5 * $size__spacing-unit};
 				}
 			}
@@ -108,8 +106,7 @@
 
 			&.menu-item-has-children {
 
-				.mobile-submenu-expand,
-				.desktop-submenu-expand {
+				.submenu-expand {
 					position: absolute;
 					width: calc( 24px + #{$size__spacing-unit} );
 					right: 0;
@@ -124,8 +121,7 @@
 					}
 				}
 
-				.mobile-submenu-expand,
-				.desktop-submenu-expand {
+				.submenu-expand {
 					margin-right: 0;
 				}
 
@@ -249,23 +245,6 @@
 
 		> .mobile-parent-nav-menu-item {
 			display: inline-block;
-		}
-	}
-
-	/* Only show one submenu expand button at a time (desktop vs mobile) */
-	.desktop-submenu-expand {
-		display: none;
-
-		@include media(tablet) {
-			display: inline-block;
-		}
-	}
-
-	.mobile-submenu-expand {
-		display: inline-block;
-
-		@include media(tablet) {
-			display: none;
 		}
 	}
 

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -139,7 +139,7 @@
 				}
 			}
 
-			> a:not(.mobile-submenu-expand) {
+			> a {
 				color: $color__background-body;
 				display: block;
 				line-height: $font__line-height-heading;

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -135,7 +135,8 @@
 				}
 			}
 
-			> a {
+			> a,
+			> .menu-item-link-return {
 				color: $color__background-body;
 				display: block;
 				line-height: $font__line-height-heading;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1026,18 +1026,18 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand) {
+.main-navigation .sub-menu > li > a {
   color: #fff;
   display: block;
   line-height: 1.2;
   padding: calc( .5 * 1rem) 1rem calc( .5 * 1rem) calc( 24px + 1rem);
 }
 
-.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):hover, .main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):focus {
+.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus {
   background: #005177;
 }
 
-.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):hover:after, .main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):focus:after {
+.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after {
   background: #005177;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -896,7 +896,6 @@ a:focus {
 	 * :focus-within needs its own selector so other similar
 	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
-  /* Only show one submenu expand button at a time (desktop vs mobile) */
 }
 
 body.page .main-navigation {
@@ -953,14 +952,12 @@ body.page .main-navigation {
   display: none;
 }
 
-.main-navigation .main-menu > li.menu-item-has-children .mobile-submenu-expand svg,
-.main-navigation .main-menu > li.menu-item-has-children .desktop-submenu-expand svg {
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
 }
 
-.main-navigation .main-menu > li.menu-item-has-children .mobile-submenu-expand,
-.main-navigation .main-menu > li.menu-item-has-children .desktop-submenu-expand {
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
   margin-left: 0.5rem;
 }
 
@@ -998,8 +995,7 @@ body.page .main-navigation {
   word-break: break-word;
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand,
-.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand {
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   position: absolute;
   width: calc( 24px + 1rem);
   left: 0;
@@ -1010,13 +1006,11 @@ body.page .main-navigation {
   padding: calc( .5 * 1rem);
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand svg,
-.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand svg {
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand svg {
   top: 0;
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand,
-.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand {
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   margin-left: 0;
 }
 
@@ -1142,26 +1136,6 @@ body.page .main-navigation {
 
 .main-navigation .main-menu .menu-item-has-children.focus .sub-menu.expanded-true > .mobile-parent-nav-menu-item {
   display: inline-block;
-}
-
-.main-navigation .desktop-submenu-expand {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation .desktop-submenu-expand {
-    display: inline-block;
-  }
-}
-
-.main-navigation .mobile-submenu-expand {
-  display: inline-block;
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation .mobile-submenu-expand {
-    display: none;
-  }
 }
 
 /* Menu Animation */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1020,18 +1020,23 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .sub-menu > li > a {
+.main-navigation .sub-menu > li > a,
+.main-navigation .sub-menu > li > .menu-item-link-return {
   color: #fff;
   display: block;
   line-height: 1.2;
   padding: calc( .5 * 1rem) 1rem calc( .5 * 1rem) calc( 24px + 1rem);
 }
 
-.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus {
+.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
+.main-navigation .sub-menu > li > .menu-item-link-return:hover,
+.main-navigation .sub-menu > li > .menu-item-link-return:focus {
   background: #005177;
 }
 
-.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after {
+.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
+.main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
+.main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
   background: #005177;
 }
 

--- a/style.css
+++ b/style.css
@@ -1020,18 +1020,23 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .sub-menu > li > a {
+.main-navigation .sub-menu > li > a,
+.main-navigation .sub-menu > li > .menu-item-link-return {
   color: #fff;
   display: block;
   line-height: 1.2;
   padding: calc( .5 * 1rem) calc( 24px + 1rem) calc( .5 * 1rem) 1rem;
 }
 
-.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus {
+.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
+.main-navigation .sub-menu > li > .menu-item-link-return:hover,
+.main-navigation .sub-menu > li > .menu-item-link-return:focus {
   background: #005177;
 }
 
-.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after {
+.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
+.main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
+.main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
   background: #005177;
 }
 

--- a/style.css
+++ b/style.css
@@ -896,7 +896,6 @@ a:focus {
 	 * :focus-within needs its own selector so other similar
 	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
-  /* Only show one submenu expand button at a time (desktop vs mobile) */
 }
 
 body.page .main-navigation {
@@ -953,14 +952,12 @@ body.page .main-navigation {
   display: none;
 }
 
-.main-navigation .main-menu > li.menu-item-has-children .mobile-submenu-expand svg,
-.main-navigation .main-menu > li.menu-item-has-children .desktop-submenu-expand svg {
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
 }
 
-.main-navigation .main-menu > li.menu-item-has-children .mobile-submenu-expand,
-.main-navigation .main-menu > li.menu-item-has-children .desktop-submenu-expand {
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
   margin-right: 0.5rem;
 }
 
@@ -998,8 +995,7 @@ body.page .main-navigation {
   word-break: break-word;
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand,
-.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand {
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   position: absolute;
   width: calc( 24px + 1rem);
   right: 0;
@@ -1010,13 +1006,11 @@ body.page .main-navigation {
   padding: calc( .5 * 1rem);
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand svg,
-.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand svg {
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand svg {
   top: 0;
 }
 
-.main-navigation .sub-menu > li.menu-item-has-children .mobile-submenu-expand,
-.main-navigation .sub-menu > li.menu-item-has-children .desktop-submenu-expand {
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   margin-right: 0;
 }
 
@@ -1142,26 +1136,6 @@ body.page .main-navigation {
 
 .main-navigation .main-menu .menu-item-has-children.focus .sub-menu.expanded-true > .mobile-parent-nav-menu-item {
   display: inline-block;
-}
-
-.main-navigation .desktop-submenu-expand {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation .desktop-submenu-expand {
-    display: inline-block;
-  }
-}
-
-.main-navigation .mobile-submenu-expand {
-  display: inline-block;
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation .mobile-submenu-expand {
-    display: none;
-  }
 }
 
 /* Menu Animation */

--- a/style.css
+++ b/style.css
@@ -1026,18 +1026,18 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand) {
+.main-navigation .sub-menu > li > a {
   color: #fff;
   display: block;
   line-height: 1.2;
   padding: calc( .5 * 1rem) calc( 24px + 1rem) calc( .5 * 1rem) 1rem;
 }
 
-.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):hover, .main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):focus {
+.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus {
   background: #005177;
 }
 
-.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):hover:after, .main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):focus:after {
+.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after {
   background: #005177;
 }
 


### PR DESCRIPTION
Follow up on #337.

* Eliminate unnecessary duplication of submenu-expand elements (one for desktop and one for mobile).
* Eliminate unnecessary use of link for mobile submenu-expand and menu-item-link-return elements, along with its unnecessary `onclick` attribute.
* Reduce number of CSS rules due to simplified markup.

👉 These changes improve the nav menu experience when JavaScript is turned off in the browser.