### PR TITLE
Add additional rtl:ignore rules

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -50,12 +50,14 @@
 	}
 
 	&.alignleft {
+		/*rtl:ignore*/
 		float: left;
 		max-width: calc(5 * (100vw / 12));
 		margin-top: 0;
 
 		@include media(tablet) {
 			max-width: calc(4 * (100vw / 12));
+			/*rtl:ignore*/
 			margin-right: calc(2 * #{$size__spacing-unit});
 		}
 
@@ -65,15 +67,18 @@
 	}
 
 	&.alignright {
+		/*rtl:ignore*/
 		float: right;
 		max-width: calc(5 * (100vw / 12));
 		margin-top: 0;
+		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
 		margin-right: $size__spacing-unit;
 
 		@include media(tablet) {
 			max-width: calc(4 * (100vw / 12));
 			margin-left: calc(2 * #{$size__spacing-unit});
+			/*rtl:ignore*/
 			margin-right: calc(2 * (100vw / 12));
 		}
 	}

--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -7,6 +7,7 @@
 .alignright {
 	/*rtl:ignore*/
 	float: right;
+	/*rtl:ignore*/
 	margin-left: $size__spacing-unit;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1485,7 +1485,7 @@ body.page .main-navigation {
 
 .alignright {
   float: right;
-  margin-right: 1rem;
+  margin-left: 1rem;
 }
 
 .aligncenter {
@@ -2995,7 +2995,7 @@ body.page .main-navigation {
 
 .entry-content > *.alignleft,
 .entry-summary > *.alignleft {
-  float: right;
+  float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
 }
@@ -3004,7 +3004,7 @@ body.page .main-navigation {
   .entry-content > *.alignleft,
   .entry-summary > *.alignleft {
     max-width: calc(4 * (100vw / 12));
-    margin-left: calc(2 * 1rem);
+    margin-right: calc(2 * 1rem);
   }
 }
 
@@ -3017,10 +3017,10 @@ body.page .main-navigation {
 
 .entry-content > *.alignright,
 .entry-summary > *.alignright {
-  float: left;
+  float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
-  margin-right: 1rem;
+  margin-left: 1rem;
   margin-left: 1rem;
 }
 
@@ -3029,7 +3029,7 @@ body.page .main-navigation {
   .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-right: calc(2 * 1rem);
-    margin-left: calc(2 * (100vw / 12));
+    margin-right: calc(2 * (100vw / 12));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1487,6 +1487,7 @@ body.page .main-navigation {
 .alignright {
   /*rtl:ignore*/
   float: right;
+  /*rtl:ignore*/
   margin-left: 1rem;
 }
 
@@ -2997,6 +2998,7 @@ body.page .main-navigation {
 
 .entry-content > *.alignleft,
 .entry-summary > *.alignleft {
+  /*rtl:ignore*/
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3006,6 +3008,7 @@ body.page .main-navigation {
   .entry-content > *.alignleft,
   .entry-summary > *.alignleft {
     max-width: calc(4 * (100vw / 12));
+    /*rtl:ignore*/
     margin-right: calc(2 * 1rem);
   }
 }
@@ -3019,9 +3022,11 @@ body.page .main-navigation {
 
 .entry-content > *.alignright,
 .entry-summary > *.alignright {
+  /*rtl:ignore*/
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
+  /*rtl:ignore*/
   margin-left: 1rem;
   margin-right: 1rem;
 }
@@ -3031,6 +3036,7 @@ body.page .main-navigation {
   .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-left: calc(2 * 1rem);
+    /*rtl:ignore*/
     margin-right: calc(2 * (100vw / 12));
   }
 }


### PR DESCRIPTION
Fixes #325.

This PR adds a few more `/*rtl:ignore*/` comments to our stylesheet, to preserve expected floating behavior when using RTL languages. 

Fixes the following issues as described in the ticket. When using an RTL language:

- Right-alined items were missing appropriate left margin. 
- Captioned left-aligned images were appearing on the right.
- Captioned right-aligned images were appearing on the left.

Two things to note: 

- Inline floated images do not extend beyond the text column because they are no direct children of `entry-content` or  `entry-summary`: they are housed within a paragraph. Floated captioned images are not within a paragraph, so they do float out beyond the text column. This PR does not aim to address this inconsistency. 
- This could use another set of 👀 from someone with more experience with the [RTLCSS control directives](https://rtlcss.com/learn/usage-guide/control-directives/). 

---

**RTL Screenshot:** 
![twentynineteen test__page_id 1133](https://user-images.githubusercontent.com/1202812/48013979-a41f7580-e0f3-11e8-93c9-9e767407d344.png)

**LTR Screenshot for reference:**
![twentynineteen test__page_id 1133 copy](https://user-images.githubusercontent.com/1202812/48013997-ada8dd80-e0f3-11e8-9e46-3e9166c63414.png)