### PR TITLE
Extra Semicolon cause fatal error.

### DIFF
--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -56,7 +56,7 @@ function twentynineteen_customize() {
 		'',
 		array(
 			'back_link' => true,
-		),
+		)
 	);
 }
 add_action( 'load-customize.php', 'twentynineteen_customize' );


### PR DESCRIPTION
The extra semicolon indicates that the function will accept the 3rd parameter and it's generating the fatal error.