### PR TITLE
Minor: Move site logo closer to the title/menu.

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -48,7 +48,7 @@
 	@include media(tablet) {
 		margin-bottom: 0;
 		position: absolute;
-		right: calc(100% + (0.5 * 100vw / 12));
+		right: calc(100% + (1.25 * #{$size__spacing-unit}));
 		top: 4px; // Accounts for box-shadow widths
 		z-index: 999;
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1670,7 +1670,7 @@ body.page .main-navigation {
   .site-logo {
     margin-bottom: 0;
     position: absolute;
-    left: calc(100% + (0.5 * 100vw / 12));
+    left: calc(100% + (1.25 * 1rem ));
     top: 4px;
     z-index: 999;
   }

--- a/style.css
+++ b/style.css
@@ -1672,7 +1672,7 @@ body.page .main-navigation {
   .site-logo {
     margin-bottom: 0;
     position: absolute;
-    right: calc(100% + (0.5 * 100vw / 12));
+    right: calc(100% + (1.25 * 1rem));
     top: 4px;
     z-index: 999;
   }


### PR DESCRIPTION
The site logo is located to the left of the site title and menu. Currently, the exact position is determined by the site grid, but it varies depending on the size of the screen. On many larger breakpoints, this leaves the icon sitting a little farther away from the text than I feel is comfortable.

This update moves the site title just a little bit closer to the text.

Before:
<img width="1140" alt="screen shot 2018-11-06 at 11 56 54 am" src="https://user-images.githubusercontent.com/1202812/48080507-d09ec480-e1bb-11e8-852c-c4b6c0348cbd.png">

After:
<img width="1141" alt="screen shot 2018-11-06 at 11 57 06 am" src="https://user-images.githubusercontent.com/1202812/48080516-d399b500-e1bb-11e8-9c47-7667a9ae2a4a.png">
