### PR TITLE
Fix editor style for bold text in Cover Image block

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -223,6 +223,11 @@ figcaption,
   line-height: 1.4;
 }
 
+.wp-block-cover h2 strong,
+.wp-block-cover .wp-block-cover-text strong {
+  font-weight: bolder;
+}
+
 .wp-block-cover.has-left-content h2,
 .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1em;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -220,6 +220,9 @@ figcaption,
 		font-size: $font__size-xl;
 		font-weight: bold;
 		line-height: 1.4;
+		strong {
+			font-weight: bolder;
+		}
 	}
 
 	&.has-left-content {


### PR DESCRIPTION
Fixes issue #440

Currently, when you Bold the text in the cover image block, it doesn't have any additional bold styles applied in the editor-styles.css, it remains the default `font-weight: bold`.

On the frontend, however, it gets the `font-weight: bolder` applied.

This patch makes sure that the editor styles match the frontend presentation for the font weight of the Cover Image block.

Previously, the backend would look like this:
![screen shot 2018-11-06 at 11 40 10 am](https://user-images.githubusercontent.com/3220162/48089214-c16a4780-e1b8-11e8-8d9f-28d35e4ba3cd.png)

Now here is the backend:
![screen shot 2018-11-06 at 11 38 16 am](https://user-images.githubusercontent.com/3220162/48089100-8700aa80-e1b8-11e8-8205-b4a819a678ba.png)

The frontend matches now!
![screen shot 2018-11-06 at 11 39 38 am](https://user-images.githubusercontent.com/3220162/48089169-a8fa2d00-e1b8-11e8-9c58-aa9007104bdc.png)

WordPress.org Username:  [mikeyarce](https://profiles.wordpress.org/mikeyarce)
