### PR TITLE
Fix headihng block editor styles for bold text

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -205,6 +205,11 @@ figcaption,
   font-size: 22px;
 }
 
+/** === Heading === */
+.wp-block-heading strong {
+  font-weight: bolder;
+}
+
 /** === Paragraph === */
 .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -197,6 +197,13 @@ figcaption,
 	font-size: $font__size_base;
 }
 
+/** === Heading === */
+
+.wp-block-heading {
+	strong {
+		font-weight: bolder;
+	}
+}
 /** === Paragraph === */
 
 .wp-block-paragraph {


### PR DESCRIPTION
Fixes #441 

Currently, if Headings are bold, there are no editor styles that show that.

Here's what they look like in the Editor:
![screen shot 2018-11-06 at 11 46 36 am](https://user-images.githubusercontent.com/3220162/48089681-e9a67600-e1b9-11e8-9081-7104413f6b01.png)

On the frontend:
![screen shot 2018-11-06 at 11 46 42 am](https://user-images.githubusercontent.com/3220162/48089707-f75bfb80-e1b9-11e8-8a4f-9248d99aec32.png)

This patch adds the `font-weight: bolder` to the bold Headings to match the frontend display.

WordPress.org Username: [mikeyarce](https://profiles.wordpress.org/mikeyarce)