### PR TITLE
Update front end margins to match the editor on desktop screens

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -56,12 +56,12 @@ function twentynineteen_custom_colors_css() {
 		.sticky-post,
 		.entry-content .wp-block-button .wp-block-button__link,
 		.button, button, input[type="button"], input[type="reset"], input[type="submit"],
-		.entry-content > .has-primary-background-color,
-		.entry-content > *[class^="wp-block-"].has-primary-background-color,
-		.entry-content > *[class^="wp-block-"] .has-primary-background-color,
-		.entry-content > *[class^="wp-block-"].is-style-solid-color,
-		.entry-content > *[class^="wp-block-"].is-style-solid-color .has-primary-background-color,
-		.entry-content .wp-block-file .wp-block-file__button {
+		.entry .entry-content > .has-primary-background-color,
+		.entry .entry-content > *[class^="wp-block-"].has-primary-background-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-primary-background-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color .has-primary-background-color,
+		.entry .entry-content .wp-block-file .wp-block-file__button {
 			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' ); /* base: #0073a8; */
 		}
 
@@ -92,11 +92,11 @@ function twentynineteen_custom_colors_css() {
 		.comment .comment-metadata .comment-edit-link:hover,
 		#colophon .site-info a:hover,
 		.widget a,
-		.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-		.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-		.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-		.entry-content > *[class^="wp-block-"] .has-primary-color,
-		.entry-content > *[class^="wp-block-"].is-style-solid-color .has-primary-color {
+		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+		.entry .entry-content > *[class^="wp-block-"] .has-primary-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color .has-primary-color {
 			color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' ); /* base: #0073a8; */
 		}
 
@@ -104,9 +104,9 @@ function twentynineteen_custom_colors_css() {
 		 * Set left border color for:
 		 * wp block quote
 		 */
-		.entry-content blockquote,
-		.entry-content .wp-block-quote:not(.is-large),
-		.entry-content .wp-block-quote:not(.is-style-large) {
+		.entry .entry-content blockquote,
+		.entry .entry-content .wp-block-quote:not(.is-large),
+		.entry .entry-content .wp-block-quote:not(.is-style-large) {
 			border-left-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' ); /* base: #0073a8; */
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -380,8 +380,8 @@
 
 		&.is-large,
 		&.is-style-large {
-			padding: $size__spacing-unit 0 ($size__spacing-unit) ($size__spacing-unit * 2);
-			margin: $size__spacing-unit 0;
+			margin: $size__spacing-unit;
+			padding: 0;
 			border-left: none;
 
 			p {
@@ -396,9 +396,8 @@
 			}
 
 			@include media(tablet) {
-
-				margin: $size__spacing-unit calc(2 * (100vw / 12));
-				max-width: calc(6 * (100vw / 12));
+				margin: $size__spacing-unit 0;
+				padding: $size__spacing-unit 0;
 
 				p {
 					font-size: $font__size-lg;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1,17 +1,7 @@
 /* !Block styles */
 
-.entry-content,
-.entry-summary {
-
-	@include media(tablet) {
-		max-width: 80%;
-		margin: 0 10%;
-		padding: 0 60px;
-	}
-}
-
-.entry-content > *,
-.entry-summary > * {
+.entry .entry-content > *,
+.entry .entry-summary > * {
 	margin: 32px $size__spacing-unit;
 	max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
 
@@ -100,7 +90,7 @@
 	}
 }
 
-.entry-content {
+.entry .entry-content {
 
 	//! Audio
 	.wp-block-audio {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -467,11 +467,6 @@
 			}
 		}
 
-		&.aligncenter {
-			margin: 32px calc(2 * (100vw / 12));
-			max-width: calc(6 * (100vw / 12));
-		}
-
 		&.has-left-content {
 			justify-content: center;
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1,5 +1,15 @@
 /* !Block styles */
 
+.entry-content,
+.entry-summary {
+
+	@include media(tablet) {
+		max-width: 80%;
+		margin: 0 10%;
+		padding: 0 60px;
+	}
+}
+
 .entry-content > *,
 .entry-summary > * {
 	@include postContentMaxWidth();
@@ -7,7 +17,7 @@
 	margin: 32px $size__spacing-unit;
 
 	@include media(tablet) {
-		margin: 32px calc(2 * (100vw / 12));
+		margin: 32px 0;
 	}
 /*
 	// Set top margins for headings
@@ -35,18 +45,18 @@
 		margin-right: auto;
 
 		@include media(tablet) {
-			margin-left: calc(2 * (100vw / 12));
-			margin-right: calc(2 * (100vw / 12));
-			max-width: calc(8 * (100vw / 12));
+			width: 100%;
+			max-width: 100%;
 		}
 	}
 
 	&.alignfull {
 		margin-top: calc(2 * #{$size__spacing-unit});
-		margin-right: 0;
 		margin-bottom: calc(2 * #{$size__spacing-unit});
-		margin-left: 0;
-		max-width: 100%;
+		position: relative;
+		left: calc( -12.5% - 75px );
+		width: calc( 125% + 150px );
+		max-width: calc( 125% + 150px );
 	}
 
 	&.alignleft {
@@ -73,22 +83,21 @@
 
 		@include media(tablet) {
 			max-width: calc(4 * (100vw / 12));
-			margin-left: calc(2 * #{$size__spacing-unit});
-			margin-right: calc(2 * (100vw / 12));
+			margin-right: 0;
 		}
 	}
 	&.aligncenter {
-
 		margin-left: auto;
 		margin-right: auto;
 
+		@include media(tablet) {
+			margin-left: 0;
+			margin-right: 0;
+			max-width: $size__site-tablet-content;
+		}
+
 		@include media(desktop) {
-			margin-left: calc(2 * (100vw / 12));
-			margin-right: calc(2 * (100vw / 12));
-			max-width: calc(10 * (100vw / 12));
-			position: relative;
-			left: 25%;
-			transform: translate(-50%);
+			max-width: $size__site-desktop-content;
 		}
 	}
 }
@@ -433,13 +442,13 @@
 
 			@include media(tablet) {
 				font-size: $font__size-xl;
-				width: calc(8 * (100vw / 12));
-				max-width: calc(8 * (100vw / 12));
+				width: $size__site-tablet-content;
+				max-width: $size__site-tablet-content;
 			}
 
 			@include media(desktop) {
-				width: calc(6 * (100vw / 12 ));
-				max-width: calc(6 * (100vw / 12 ));
+				width: $size__site-desktop-content;
+				max-width: $size__site-desktop-content;
 			}
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -12,9 +12,10 @@
 
 .entry-content > *,
 .entry-summary > * {
-	@include postContentMaxWidth();
-
 	margin: 32px $size__spacing-unit;
+	max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
+
+	@include postContentMaxWidth();
 
 	@include media(tablet) {
 		margin: 32px 0;
@@ -90,14 +91,11 @@
 		margin-left: auto;
 		margin-right: auto;
 
+		@include postContentMaxWidth();
+
 		@include media(tablet) {
 			margin-left: 0;
 			margin-right: 0;
-			max-width: $size__site-tablet-content;
-		}
-
-		@include media(desktop) {
-			max-width: $size__site-desktop-content;
 		}
 	}
 }
@@ -439,15 +437,15 @@
 			width: calc(100vw - (2 * #{ $size__spacing-unit }));
 			max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
 
+			@include postContentMaxWidth();
+
 			@include media(tablet) {
 				font-size: $font__size-xl;
 				width: $size__site-tablet-content;
-				max-width: $size__site-tablet-content;
 			}
 
 			@include media(desktop) {
 				width: $size__site-desktop-content;
-				max-width: $size__site-desktop-content;
 			}
 		}
 

--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -1,5 +1,18 @@
 .wp-caption {
 	margin-bottom: calc(1.5 * #{$size__spacing-unit});
+
+	&.aligncenter {
+
+		@include media(tablet) {
+			position: relative;
+			left: calc( #{$size__site-tablet-content} / 2 );
+			transform: translateX( -50% );
+		}
+
+		@include media(desktop) {
+			left: calc( #{$size__site-desktop-content} / 2 );
+		}
+	}
 }
 
 .wp-caption img[class*="wp-image-"] {

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -177,7 +177,6 @@
 
 /* Calculates maximum width for post content */
 @mixin postContentMaxWidth() {
-	max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
 
 	@include media(tablet) {
 		max-width: $size__site-tablet-content;

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -180,11 +180,11 @@
 	max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
 
 	@include media(tablet) {
-		max-width: calc(8 * (100vw / 12));
+		max-width: $size__site-tablet-content;
 	}
 
 	@include media(desktop) {
-		max-width: calc(6 * (100vw / 12));
+		max-width: $size__site-desktop-content;
 	}
 }
 

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -6,7 +6,7 @@
 	margin: calc(3 * 1rem) 0;
 	
 	@include media(tablet) {
-		margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+		margin: calc(3 * 1rem) $size__site-margins;
 		max-width: calc(6 * (100vw / 12));
 	}
 	
@@ -28,8 +28,8 @@
 
 		@include media(desktop) {
 			flex-direction: row;
-			margin: 0 calc(2 * (100vw / 12));
-			max-width: calc(8 * (100vw / 12));
+			margin: 0 $size__site-margins;
+			max-width: $size__site-desktop-content;
 		}
 
 		a {
@@ -130,7 +130,7 @@
 
 		@include media(tablet) {
 
-			margin-left: calc(2 * (100vw / 12) );
+			margin-left: $size__site-margins;
 			padding: 0;
 
 			.prev,
@@ -158,8 +158,8 @@
 		margin: 0 $size__spacing-unit;
 
 		@include media(desktop) {
-			margin: 0 calc(2 * (100vw / 12));
-			max-width: calc(8 * (100vw / 12));
+			margin: 0 $size__site-margins;
+			max-width: $size__site-tablet-content;
 		}
 	}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -8,7 +8,6 @@
 
 		@include media(tablet) {
 			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
-			max-width: $size__site-tablet-content;
 		}
 
 		.imprint {

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -8,8 +8,8 @@
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
 
 		@include media(tablet) {
-			margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12));
-			max-width: calc(8 * (100vw / 12));
+			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
+			max-width: $size__site-tablet-content;
 		}
 
 		.imprint {

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -4,7 +4,6 @@
 
 	.widget-area,
 	.site-info {
-
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
 
 		@include media(tablet) {

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -101,8 +101,8 @@
 
 			@include media (tablet) {
 
-				margin-left: calc(2 * (100vw / 12));
-				margin-right: calc(2 * (100vw / 12));
+				margin-left: $size__site-margins;
+				margin-right: $size__site-margins;
 			}
 
 			.entry-title {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -33,7 +33,7 @@
 	position: relative;
 
 	@include media(tablet) {
-		margin: 0 calc(2 * (100vw / 12));
+		margin: 0 $size__site-margins;
 	}
 }
 

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -5,8 +5,8 @@
 	margin: $size__spacing-unit $size__spacing-unit calc(3 * #{$size__spacing-unit});
 
 	@include media(tablet) {
-		margin: 0 calc(2 * (100vw / 12)) calc(3 * #{$size__spacing-unit});
-		max-width: calc(8 * (100vw / 12));
+		margin: 0 calc(2 * (100vw / 12)) $size__site-margins;
+		max-width: $size__site-tablet-content;
 	}
 
 	.page-title {
@@ -42,7 +42,7 @@
 .hfeed .entry .entry-header {
 
 	@include media(tablet) {
-		margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12)) calc(#{ $size__spacing-unit } / 2);
+		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins calc(#{ $size__spacing-unit } / 2);
 	}
 }
 
@@ -56,7 +56,7 @@
 		margin: calc(3 * #{$size__spacing-unit}) #{$size__spacing-unit};
 
 		@include media(tablet) {
-			margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12)) calc(#{ $size__spacing-unit } / 2);
+			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins calc(#{ $size__spacing-unit } / 2);
 		}
 	}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -154,9 +154,12 @@
 }
 
 .comment-reply {
-	left: calc(#{$size__spacing-unit} + 100%);
-	bottom: 0;
-	position: absolute;
+
+	@include media(desktop) {
+		left: 100%;
+		bottom: 0;
+		position: absolute;
+	}
 
 	#respond + & {
 		display: none;
@@ -180,8 +183,13 @@
 	}
 
 	.comment-body {
-		margin: calc(2 * #{$size__spacing-unit}) 0;
+		margin: calc(2 * #{$size__spacing-unit}) 0 0;
+		
+		@include media(desktop) {
+			margin: calc(2 * #{$size__spacing-unit}) 0;
+		}
 	}
+
 
 	.comment-meta {
 		position: relative;
@@ -261,6 +269,7 @@
 			margin-left: $size__spacing-unit;
 			position: relative;
 			vertical-align: baseline;
+			line-height: 2.25;
 		}
 
 		> a,
@@ -315,6 +324,10 @@
 	.comment-content {
 
 		margin: $size__spacing-unit 0;
+
+		@include media(desktop) {
+			padding-right: $size__spacing-unit;
+		}
 
 		> *:first-child {
 			margin-top: 0;

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -22,13 +22,10 @@
 	.no-comments {
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
 
+		@include postContentMaxWidth();
+		
 		@include media(tablet) {
 			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
-			max-width: $size__site-tablet-content;
-		}
-
-		@include media(desktop) {
-			max-width: $size__site-desktop-content;
 		}
 	}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -23,8 +23,12 @@
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
 
 		@include media(tablet) {
-			margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12));
-			max-width: calc(6 * (100vw / 12));
+			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
+			max-width: $size__site-tablet-content;
+		}
+
+		@include media(desktop) {
+			max-width: $size__site-desktop-content;
 		}
 	}
 
@@ -36,8 +40,8 @@
 			align-items: baseline;
 			display: flex;
 			justify-content: space-between;
-			margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12));
-			max-width: calc(8 * (100vw / 12));
+			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
+			max-width: $size__site-tablet-content;
 		}
 
 		.comments-title {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -239,17 +239,16 @@
 /* Author description */
 
 .author-bio {
-
 	margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
+
+	@include postContentMaxWidth();
 
 	@include media(tablet) {
 		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
-		max-width: $size__site-tablet-content;
 	}
 
 	@include media(desktop) {
 		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
-		max-width: $size__site-desktop-content;
 	}
 
 	.author-title {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -38,7 +38,7 @@
 		position: relative;
 
 		@include media(tablet) {
-			margin: calc(3 * #{ $size__spacing-unit}) calc(2 * (100vw / 12 ) ) $size__spacing-unit;
+			margin: calc(3 * #{ $size__spacing-unit}) $size__site-margins $size__spacing-unit;
 		}
 	}
 
@@ -100,12 +100,12 @@
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
 
 		@include media(tablet) {
-			margin: $size__spacing-unit calc(2 * (100vw / 12)) calc(3 * #{$size__spacing-unit});
-			max-width: calc(8 * (100vw / 12));
+			margin: $size__spacing-unit $size__site-margins calc(3 * #{$size__spacing-unit});
+			max-width: $size__site-tablet-content;
 		}
 
 		@include media(tablet) {
-			max-width: calc(6 * (100vw / 12));
+			max-width: $size__site-desktop-content;
 		}
 	}
 
@@ -114,7 +114,7 @@
 		margin: $size__spacing-unit;
 
 		@include media(tablet) {
-			margin: $size__spacing-unit calc(2 * (100vw / 12));
+			margin: $size__spacing-unit $size__site-margins;
 		}
 
 		&:focus {
@@ -212,12 +212,12 @@
 			max-width: calc(100vw - (2 * #{ $size__spacing-unit })) !important;
 
 			@include media(tablet) {
-				margin: 32px calc(2 * (100vw / 12)) !important;
-				max-width: calc(8 * (100vw / 12)) !important;
+				margin: 32px 0 !important;
+				max-width: $size__site-tablet-content !important;
 			}
 
 			@include media(desktop) {
-				max-width: calc(6 * (100vw / 12)) !important;
+				max-width: $size__site-desktop-content !important;
 			}
 		}
 
@@ -226,11 +226,11 @@
 			max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
 
 			@include media(tablet) {
-				max-width: calc(8 * (100vw / 12));
+				max-width: $size__site-tablet-content;
 			}
 
 			@include media(desktop) {
-				max-width: calc(6 * (100vw / 12));
+				max-width: $size__site-desktop-content;
 			}
 		}
 	}
@@ -243,12 +243,13 @@
 	margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
 
 	@include media(tablet) {
-		margin: calc(3 * #{$size__spacing-unit}) calc(2 * (100vw / 12));
-		max-width: calc(8 * (100vw / 12));
+		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
+		max-width: $size__site-tablet-content;
 	}
 
-	@include media(tablet) {
-		max-width: calc(6 * (100vw / 12));
+	@include media(desktop) {
+		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
+		max-width: $size__site-desktop-content;
 	}
 
 	.author-title {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -175,6 +175,16 @@
 		}
 	}
 
+	.entry-content,
+	.entry-summary {
+
+		@include media(tablet) {
+			max-width: 80%;
+			margin: 0 10%;
+			padding: 0 60px;
+		}
+	}
+
 	.entry-content {
 
 		p {

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -3,6 +3,9 @@
 $size__spacing-unit: 1rem;
 $size__site-main: 100%;
 $size__site-sidebar: 25%;
+$size__site-margins: calc(10% + 60px);
+$size__site-tablet-content: calc(8 * (100vw / 12) - 28px);
+$size__site-desktop-content: calc(6 * (100vw / 12) - 28px);
 
 // Responsive widths.
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3428,8 +3428,8 @@ body.page .main-navigation {
 }
 
 .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
-  padding: 1rem 2rem 1rem 0;
-  margin: 1rem 0;
+  margin: 1rem;
+  padding: 0;
   border-right: none;
 }
 
@@ -3447,8 +3447,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
-    margin: 1rem calc(2 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
+    padding: 1rem 0;
+    margin: 1rem 0;
   }
   .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
@@ -3775,6 +3775,20 @@ svg {
 --------------------------------------------------------------*/
 .wp-caption {
   margin-bottom: calc(1.5 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .wp-caption.aligncenter {
+    position: relative;
+    right: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    transform: translateX(50%);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .wp-caption.aligncenter {
+    right: calc( calc(6 * (100vw / 12) - 28px) / 2);
+  }
 }
 
 .wp-caption img[class*="wp-image-"] {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2550,10 +2550,12 @@ body.page .main-navigation {
   font-weight: 500;
 }
 
-.comment-reply {
-  right: calc(1rem + 100%);
-  bottom: 0;
-  position: absolute;
+@media only screen and (min-width: 1168px) {
+  .comment-reply {
+    right: 100%;
+    bottom: 0;
+    position: absolute;
+  }
 }
 
 #respond + .comment-reply {
@@ -2579,7 +2581,13 @@ body.page .main-navigation {
 }
 
 .comment .comment-body {
-  margin: calc(2 * 1rem) 0;
+  margin: calc(2 * 1rem) 0 0;
+}
+
+@media only screen and (min-width: 1168px) {
+  .comment .comment-body {
+    margin: calc(2 * 1rem) 0;
+  }
 }
 
 .comment .comment-meta {
@@ -2666,6 +2674,7 @@ body.page .main-navigation {
     margin-right: 1rem;
     position: relative;
     vertical-align: baseline;
+    line-height: 2.25;
   }
 }
 
@@ -2721,6 +2730,12 @@ body.page .main-navigation {
 
 .comment .comment-content {
   margin: 1rem 0;
+}
+
+@media only screen and (min-width: 1168px) {
+  .comment .comment-content {
+    padding-left: 1rem;
+  }
 }
 
 .comment .comment-content > *:first-child {
@@ -3447,8 +3462,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
-    padding: 1rem 0;
     margin: 1rem 0;
+    padding: 1rem 0;
   }
   .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2410,7 +2410,6 @@ body.page .main-navigation {
   .comments-area > .comment-respond,
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
-    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -2422,6 +2421,16 @@ body.page .main-navigation {
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comment-list,
+  .comments-area .comment-navigation,
+  .comments-area > .comment-respond,
+  .comments-area .comment-form-flex,
+  .comments-area .no-comments {
+    margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
 
@@ -3045,8 +3054,8 @@ body.page .main-navigation {
 
 .entry-content > *,
 .entry-summary > * {
-  max-width: calc(100vw - (2 * 1rem));
   margin: 32px 1rem;
+  max-width: calc(100vw - (2 * 1rem));
   /*
 	// Set top margins for headings
 	& + h1:before,
@@ -3163,8 +3172,6 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *.aligncenter,
   .entry-summary > *.aligncenter {
-    margin-right: 0;
-    margin-left: 0;
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3173,6 +3180,14 @@ body.page .main-navigation {
   .entry-content > *.aligncenter,
   .entry-summary > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-content > *.aligncenter,
+  .entry-summary > *.aligncenter {
+    margin-right: 0;
+    margin-left: 0;
   }
 }
 
@@ -3504,8 +3519,6 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
-    font-size: 2.25em;
-    width: calc(8 * (100vw / 12) - 28px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3517,8 +3530,30 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
-    width: calc(6 * (100vw / 12) - 28px);
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
+    font-size: 2.25em;
+    width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
+    width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -3622,7 +3657,6 @@ body.page .main-navigation {
 
 .entry-content .wp-block-separator.is-style-dots,
 .entry-content hr.is-style-dots {
-  max-width: calc(100vw - (2 * 1rem));
   text-align: center;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1130,12 +1130,26 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1145,6 +1159,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -2244,6 +2265,15 @@ body.page .main-navigation {
   }
 }
 
+@media only screen and (min-width: 768px) {
+  .entry .entry-content,
+  .entry .entry-summary {
+    max-width: 80%;
+    margin: 0 10%;
+    padding: 0 60px;
+  }
+}
+
 .entry .entry-content p {
   word-wrap: break-word;
 }
@@ -3031,17 +3061,8 @@ body.page .main-navigation {
 
 /* Blocks */
 /* !Block styles */
-@media only screen and (min-width: 768px) {
-  .entry-content,
-  .entry-summary {
-    max-width: 80%;
-    margin: 0 10%;
-    padding: 0 60px;
-  }
-}
-
-.entry-content > *,
-.entry-summary > * {
+.entry .entry-content > *,
+.entry .entry-summary > * {
   margin: 32px 1rem;
   max-width: calc(100vw - (2 * 1rem));
   /*
@@ -3058,52 +3079,52 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *,
-  .entry-summary > * {
+  .entry .entry-content > *,
+  .entry .entry-summary > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content > *,
-  .entry-summary > * {
+  .entry .entry-content > *,
+  .entry .entry-summary > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *,
-  .entry-summary > * {
+  .entry .entry-content > *,
+  .entry .entry-summary > * {
     margin: 32px 0;
   }
 }
 
-.entry-content > * > *:first-child,
-.entry-summary > * > *:first-child {
+.entry .entry-content > * > *:first-child,
+.entry .entry-summary > * > *:first-child {
   margin-top: 0;
 }
 
-.entry-content > * > *:last-child,
-.entry-summary > * > *:last-child {
+.entry .entry-content > * > *:last-child,
+.entry .entry-summary > * > *:last-child {
   margin-bottom: 0;
 }
 
-.entry-content > *.alignwide,
-.entry-summary > *.alignwide {
+.entry .entry-content > *.alignwide,
+.entry .entry-summary > *.alignwide {
   margin-right: auto;
   margin-left: auto;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.alignwide,
-  .entry-summary > *.alignwide {
+  .entry .entry-content > *.alignwide,
+  .entry .entry-summary > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
 }
 
-.entry-content > *.alignfull,
-.entry-summary > *.alignfull {
+.entry .entry-content > *.alignfull,
+.entry .entry-summary > *.alignfull {
   margin-top: calc(2 * 1rem);
   margin-bottom: calc(2 * 1rem);
   position: relative;
@@ -3112,30 +3133,30 @@ body.page .main-navigation {
   max-width: calc( 125% + 150px);
 }
 
-.entry-content > *.alignleft,
-.entry-summary > *.alignleft {
+.entry .entry-content > *.alignleft,
+.entry .entry-summary > *.alignleft {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.alignleft,
-  .entry-summary > *.alignleft {
+  .entry .entry-content > *.alignleft,
+  .entry .entry-summary > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     margin-left: calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content > *.alignleft,
-  .entry-summary > *.alignleft {
+  .entry .entry-content > *.alignleft,
+  .entry .entry-summary > *.alignleft {
     max-width: calc(3 * (100vw / 12));
   }
 }
 
-.entry-content > *.alignright,
-.entry-summary > *.alignright {
+.entry .entry-content > *.alignright,
+.entry .entry-summary > *.alignright {
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3144,78 +3165,78 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.alignright,
-  .entry-summary > *.alignright {
+  .entry .entry-content > *.alignright,
+  .entry .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-left: 0;
   }
 }
 
-.entry-content > *.aligncenter,
-.entry-summary > *.aligncenter {
+.entry .entry-content > *.aligncenter,
+.entry .entry-summary > *.aligncenter {
   margin-right: auto;
   margin-left: auto;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.aligncenter,
-  .entry-summary > *.aligncenter {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content > *.aligncenter,
-  .entry-summary > *.aligncenter {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.aligncenter,
-  .entry-summary > *.aligncenter {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
     margin-right: 0;
     margin-left: 0;
   }
 }
 
-.entry-content .wp-block-audio {
+.entry .entry-content .wp-block-audio {
   width: 100%;
 }
 
-.entry-content .wp-block-audio audio {
+.entry .entry-content .wp-block-audio audio {
   width: 100%;
 }
 
-.entry-content .wp-block-audio.alignleft audio,
-.entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignleft audio,
+.entry .entry-content .wp-block-audio.alignright audio {
   max-width: 190px;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-audio.alignleft audio,
-  .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 
 @media only screen and (min-width: 1379px) {
-  .entry-content .wp-block-audio.alignleft audio,
-  .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
 
-.entry-content .wp-block-audio.aligncenter {
+.entry .entry-content .wp-block-audio.aligncenter {
   margin: 32px calc(2 * (100vw / 12));
   max-width: calc(6 * (100vw / 12));
 }
 
-.entry-content .wp-block-video video {
+.entry .entry-content .wp-block-video video {
   width: 100%;
 }
 
-.entry-content .wp-block-button .wp-block-button__link {
+.entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   background: #0073aa;
@@ -3231,46 +3252,46 @@ body.page .main-navigation {
   outline: none;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover {
   cursor: pointer;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover, .entry .entry-content .wp-block-button .wp-block-button__link:focus {
   background: #111;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
 
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   background: transparent;
   border: 2px solid currentColor;
   color: #0073aa;
 }
 
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: #111;
 }
 
-.entry-content .wp-block-archives,
-.entry-content .wp-block-categories,
-.entry-content .wp-block-latest-posts {
+.entry .entry-content .wp-block-archives,
+.entry .entry-content .wp-block-categories,
+.entry .entry-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
 
-.entry-content .wp-block-archives li,
-.entry-content .wp-block-categories li,
-.entry-content .wp-block-latest-posts li {
+.entry .entry-content .wp-block-archives li,
+.entry .entry-content .wp-block-categories li,
+.entry .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
@@ -3278,55 +3299,55 @@ body.page .main-navigation {
   line-height: 1.2;
 }
 
-.entry-content .wp-block-archives li:not(.menu-item-has-children),
-.entry-content .wp-block-categories li:not(.menu-item-has-children),
-.entry-content .wp-block-latest-posts li:not(.menu-item-has-children) {
+.entry .entry-content .wp-block-archives li:not(.menu-item-has-children),
+.entry .entry-content .wp-block-categories li:not(.menu-item-has-children),
+.entry .entry-content .wp-block-latest-posts li:not(.menu-item-has-children) {
   padding-bottom: 0.75rem;
 }
 
-.entry-content .wp-block-archives li a,
-.entry-content .wp-block-categories li a,
-.entry-content .wp-block-latest-posts li a {
+.entry .entry-content .wp-block-archives li a,
+.entry .entry-content .wp-block-categories li a,
+.entry .entry-content .wp-block-latest-posts li a {
   text-decoration: none;
 }
 
-.entry-content .wp-block-archives li ul,
-.entry-content .wp-block-categories li ul,
-.entry-content .wp-block-latest-posts li ul {
+.entry .entry-content .wp-block-archives li ul,
+.entry .entry-content .wp-block-categories li ul,
+.entry .entry-content .wp-block-latest-posts li ul {
   padding-right: 1rem;
 }
 
-.entry-content .wp-block-latest-posts.is-grid li {
+.entry .entry-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 2rem;
 }
 
-.entry-content .wp-block-latest-posts.is-grid li a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after {
   content: '';
 }
 
-.entry-content .wp-block-latest-posts.is-grid li:last-child {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
 
-.entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
   content: '';
 }
 
-.entry-content .wp-block-preformatted {
+.entry .entry-content .wp-block-preformatted {
   font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
 
-.entry-content .wp-block-verse {
+.entry .entry-content .wp-block-verse {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-size: 22px;
   line-height: 1.8;
 }
 
-.entry-content .has-drop-cap:not(:focus):first-letter {
+.entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
@@ -3334,19 +3355,19 @@ body.page .main-navigation {
   margin: 0 0 0 0.25em;
 }
 
-.entry-content .wp-block-pullquote {
+.entry .entry-content .wp-block-pullquote {
   border: none;
   padding: 1rem;
 }
 
-.entry-content .wp-block-pullquote blockquote {
+.entry .entry-content .wp-block-pullquote blockquote {
   color: #111;
   border: none;
   padding-bottom: calc(2 * 1rem);
   margin-left: 0;
 }
 
-.entry-content .wp-block-pullquote p {
+.entry .entry-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
@@ -3354,17 +3375,17 @@ body.page .main-navigation {
   margin-top: 0.5em;
 }
 
-.entry-content .wp-block-pullquote p em {
+.entry .entry-content .wp-block-pullquote p em {
   font-style: normal;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-pullquote p {
+  .entry .entry-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
 
-.entry-content .wp-block-pullquote cite {
+.entry .entry-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.71111em;
@@ -3372,22 +3393,22 @@ body.page .main-navigation {
   text-transform: none;
 }
 
-.entry-content .wp-block-pullquote.alignleft, .entry-content .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
   padding: 0;
 }
 
-.entry-content .wp-block-pullquote.alignleft blockquote, .entry-content .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
   margin-right: 0;
   padding: 0;
   text-align: right;
   max-width: 100%;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color {
   background-color: #0073aa;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -3395,104 +3416,104 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-pullquote.is-style-solid-color p {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color a {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   color: #fff;
   margin: 0 auto;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
   background-color: #0073aa;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
   padding: 1rem 1rem 0;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
   padding: 0 0 calc( 1.5 * 1rem);
   margin-right: 0;
   margin-top: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
     padding: calc( 2 * 1rem) calc( 2 * 1rem) 1rem;
   }
 }
 
-.entry-content .wp-block-quote:not(.is-large), .entry-content .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-right: 2px solid #0073aa;
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.entry-content .wp-block-quote p {
+.entry .entry-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
 
-.entry-content .wp-block-quote cite {
+.entry .entry-content .wp-block-quote cite {
   font-size: 0.71111em;
 }
 
-.entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
   margin: 1rem;
   padding: 0;
   border-right: none;
 }
 
-.entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
 
-.entry-content .wp-block-quote.is-large cite,
-.entry-content .wp-block-quote.is-large footer, .entry-content .wp-block-quote.is-style-large cite,
-.entry-content .wp-block-quote.is-style-large footer {
+.entry .entry-content .wp-block-quote.is-large cite,
+.entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
+.entry .entry-content .wp-block-quote.is-style-large footer {
   font-size: 0.71111em;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
     margin: 1rem 0;
     padding: 1rem 0;
   }
-  .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
 
-.entry-content .wp-block-image img {
+.entry .entry-content .wp-block-image img {
   display: block;
 }
 
-.entry-content .wp-block-image.alignleft, .entry-content .wp-block-image.alignright {
+.entry .entry-content .wp-block-image.alignleft, .entry .entry-content .wp-block-image.alignright {
   max-width: 100%;
 }
 
-.entry-content .wp-block-image.alignfull img {
+.entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
   margin-right: auto;
   margin-left: auto;
 }
 
-.entry-content .wp-block-cover-image .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image .wp-block-cover-text,
-.entry-content .wp-block-cover-image h2,
-.entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry-content .wp-block-cover .wp-block-cover-text,
-.entry-content .wp-block-cover h2 {
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry .entry-content .wp-block-cover-image h2,
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover .wp-block-cover-text,
+.entry .entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1.6875em;
   font-weight: bold;
@@ -3501,66 +3522,66 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry-content .wp-block-cover-image.alignleft h2,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry-content .wp-block-cover-image.alignright h2,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry-content .wp-block-cover-image.aligncenter h2,
-.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
-.entry-content .wp-block-cover.alignleft h2,
-.entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
-.entry-content .wp-block-cover.alignleft .wp-block-cover-text,
-.entry-content .wp-block-cover.alignright h2,
-.entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
-.entry-content .wp-block-cover.alignright .wp-block-cover-text,
-.entry-content .wp-block-cover.aligncenter h2,
-.entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
-.entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
+.entry .entry-content .wp-block-cover-image.alignleft h2,
+.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.alignright h2,
+.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.aligncenter h2,
+.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.alignleft h2,
+.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.alignright h2,
+.entry .entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.alignright .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.aligncenter h2,
+.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
   width: 100%;
   z-index: 1;
   right: 50%;
@@ -3569,44 +3590,44 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry-content .wp-block-cover-image.has-left-content,
-.entry-content .wp-block-cover.has-left-content {
+.entry .entry-content .wp-block-cover-image.has-left-content,
+.entry .entry-content .wp-block-cover.has-left-content {
   justify-content: center;
 }
 
-.entry-content .wp-block-cover-image.has-left-content h2,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
-.entry-content .wp-block-cover.has-left-content h2,
-.entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
+.entry .entry-content .wp-block-cover-image.has-left-content h2,
+.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.has-left-content h2,
+.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1rem;
 }
 
-.entry-content .wp-block-cover-image.has-right-content,
-.entry-content .wp-block-cover.has-right-content {
+.entry .entry-content .wp-block-cover-image.has-right-content,
+.entry .entry-content .wp-block-cover.has-right-content {
   justify-content: center;
 }
 
-.entry-content .wp-block-cover-image.has-right-content h2,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
-.entry-content .wp-block-cover.has-right-content h2,
-.entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
+.entry .entry-content .wp-block-cover-image.has-right-content h2,
+.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.has-right-content h2,
+.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1rem;
 }
 
-.entry-content .wp-block-gallery .blocks-gallery-image:last-child,
-.entry-content .wp-block-gallery .blocks-gallery-item:last-child {
+.entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
 
-.entry-content .wp-block-audio figcaption,
-.entry-content .wp-block-video figcaption,
-.entry-content .wp-block-image figcaption,
-.entry-content .wp-block-gallery .blocks-gallery-image figcaption,
-.entry-content .wp-block-gallery .blocks-gallery-item figcaption {
+.entry .entry-content .wp-block-audio figcaption,
+.entry .entry-content .wp-block-video figcaption,
+.entry .entry-content .wp-block-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.71111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -3615,8 +3636,8 @@ body.page .main-navigation {
   text-align: center;
 }
 
-.entry-content .wp-block-separator,
-.entry-content hr {
+.entry .entry-content .wp-block-separator,
+.entry .entry-content hr {
   margin-bottom: 2rem;
   margin-top: 2rem;
   text-align: right;
@@ -3624,65 +3645,65 @@ body.page .main-navigation {
 		 * is followed by an H1, or H2 */
 }
 
-.entry-content .wp-block-separator:not(.is-style-dots),
-.entry-content hr:not(.is-style-dots) {
+.entry .entry-content .wp-block-separator:not(.is-style-dots),
+.entry .entry-content hr:not(.is-style-dots) {
   background-color: #767676;
   border: 0;
   height: 2px;
 }
 
-.entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
-.entry-content hr:not(.is-style-wide):not(.is-style-dots) {
+.entry .entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
+.entry .entry-content hr:not(.is-style-wide):not(.is-style-dots) {
   max-width: 2.25em;
 }
 
-.entry-content .wp-block-separator + h1:before,
-.entry-content .wp-block-separator + h2:before,
-.entry-content hr + h1:before,
-.entry-content hr + h2:before {
+.entry .entry-content .wp-block-separator + h1:before,
+.entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content hr + h1:before,
+.entry .entry-content hr + h2:before {
   display: none;
 }
 
-.entry-content .wp-block-separator.is-style-dots,
-.entry-content hr.is-style-dots {
+.entry .entry-content .wp-block-separator.is-style-dots,
+.entry .entry-content hr.is-style-dots {
   text-align: center;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-separator.is-style-dots,
-  .entry-content hr.is-style-dots {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-separator.is-style-dots,
-  .entry-content hr.is-style-dots {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry-content .wp-block-separator.is-style-dots:before,
-.entry-content hr.is-style-dots:before {
+.entry .entry-content .wp-block-separator.is-style-dots:before,
+.entry .entry-content hr.is-style-dots:before {
   color: #767676;
   font-size: 1.6875em;
   letter-spacing: 0.88889em;
   padding-right: 0.88889em;
 }
 
-.entry-content .wp-block-embed-twitter {
+.entry .entry-content .wp-block-embed-twitter {
   overflow: hidden;
 }
 
-.entry-content .wp-block-table td, .entry-content .wp-block-table th {
+.entry .entry-content .wp-block-table td, .entry .entry-content .wp-block-table th {
   border-color: #767676;
 }
 
-.entry-content .wp-block-file {
+.entry .entry-content .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.entry-content .wp-block-file .wp-block-file__button {
+.entry .entry-content .wp-block-file .wp-block-file__button {
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
@@ -3695,82 +3716,82 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-file .wp-block-file__button {
+  .entry .entry-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
 
-.entry-content .wp-block-file .wp-block-file__button:hover {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover {
   cursor: pointer;
 }
 
-.entry-content .wp-block-file .wp-block-file__button:hover, .entry-content .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover, .entry .entry-content .wp-block-file .wp-block-file__button:focus {
   background: #111;
 }
 
-.entry-content .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry-content .wp-block-code {
+.entry .entry-content .wp-block-code {
   border-radius: 0;
 }
 
-.entry-content .wp-block-code code {
+.entry .entry-content .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.entry-content .wp-block-columns .wp-block-column > *:first-child {
+.entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
   margin-top: 0;
 }
 
-.entry-content .wp-block-columns .wp-block-column > *:last-child {
+.entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
   margin-bottom: 0;
 }
 
-.entry-content .wp-block-columns[class*='has-'] > * {
+.entry .entry-content .wp-block-columns[class*='has-'] > * {
   margin-left: 1rem;
 }
 
-.entry-content .wp-block-columns[class*='has-'] > *:last-child {
+.entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
   margin-left: 0;
 }
 
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;
 }
 
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: normal;
 }
 
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
 
-.entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
 }
 
-.entry-content .has-primary-background-color {
+.entry .entry-content .has-primary-background-color {
   background-color: #0073aa;
 }
 
-.entry-content .has-primary-background-color p,
-.entry-content .has-primary-background-color h1,
-.entry-content .has-primary-background-color h2,
-.entry-content .has-primary-background-color h3,
-.entry-content .has-primary-background-color h4,
-.entry-content .has-primary-background-color h5,
-.entry-content .has-primary-background-color h6,
-.entry-content .has-primary-background-color a {
+.entry .entry-content .has-primary-background-color p,
+.entry .entry-content .has-primary-background-color h1,
+.entry .entry-content .has-primary-background-color h2,
+.entry .entry-content .has-primary-background-color h3,
+.entry .entry-content .has-primary-background-color h4,
+.entry .entry-content .has-primary-background-color h5,
+.entry .entry-content .has-primary-background-color h6,
+.entry .entry-content .has-primary-background-color a {
   color: #fff;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1130,26 +1130,12 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1159,13 +1145,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -1339,7 +1318,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .post-navigation {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(6 * (100vw / 12));
   }
 }
@@ -1367,8 +1346,8 @@ body.page .main-navigation {
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
-    margin: 0 calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: 0 calc(10% + 60px);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -1458,7 +1437,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
-    margin-right: calc(2 * (100vw / 12));
+    margin-right: calc(10% + 60px);
     padding: 0;
   }
   .pagination .nav-links .prev > *,
@@ -1479,8 +1458,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 1168px) {
   .comment-navigation .nav-links {
-    margin: 0 calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: 0 calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -1656,7 +1635,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-branding {
-    margin: 0 calc(2 * (100vw / 12));
+    margin: 0 calc(10% + 60px);
   }
 }
 
@@ -1670,7 +1649,7 @@ body.page .main-navigation {
   .site-logo {
     margin-bottom: 0;
     position: absolute;
-    left: calc(100% + (1.25 * 1rem ));
+    left: calc(100% + (1.25 * 1rem));
     top: 4px;
     z-index: 999;
   }
@@ -1891,8 +1870,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
-    margin-right: calc(2 * (100vw / 12));
-    margin-left: calc(2 * (100vw / 12));
+    margin-right: calc(10% + 60px);
+    margin-left: calc(10% + 60px);
   }
 }
 
@@ -2098,7 +2077,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12 )) 1rem;
+    margin: calc(3 * 1rem) calc(10% + 60px) 1rem;
   }
 }
 
@@ -2170,14 +2149,14 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    margin: 1rem calc(2 * (100vw / 12)) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12));
+    margin: 1rem calc(10% + 60px) calc(3 * 1rem);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2187,7 +2166,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .post-thumbnail {
-    margin: 1rem calc(2 * (100vw / 12));
+    margin: 1rem calc(10% + 60px);
   }
 }
 
@@ -2300,14 +2279,14 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    margin: 32px calc(2 * (100vw / 12)) !important;
-    max-width: calc(8 * (100vw / 12)) !important;
+    margin: 32px 0 !important;
+    max-width: calc(8 * (100vw / 12) - 28px) !important;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(6 * (100vw / 12)) !important;
+    max-width: calc(6 * (100vw / 12) - 28px) !important;
   }
 }
 
@@ -2317,13 +2296,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(8 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2334,14 +2313,15 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .author-bio {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1168px) {
   .author-bio {
-    max-width: calc(6 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2409,8 +2389,18 @@ body.page .main-navigation {
   .comments-area > .comment-respond,
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .comments-area .comment-list,
+  .comments-area .comment-navigation,
+  .comments-area > .comment-respond,
+  .comments-area .comment-form-flex,
+  .comments-area .no-comments {
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2423,8 +2413,8 @@ body.page .main-navigation {
     align-items: baseline;
     display: flex;
     justify-content: space-between;
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -2811,8 +2801,8 @@ body.page .main-navigation {
   .archive .page-header,
   .search .page-header,
   .error404 .page-header {
-    margin: 0 calc(2 * (100vw / 12)) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12));
+    margin: 0 calc(2 * (100vw / 12)) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -2859,7 +2849,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .hfeed .entry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2);
+    margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
   }
 }
 
@@ -2872,7 +2862,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .error-404.not-found .page-content,
   .no-results.not-found .page-content {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2);
+    margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
   }
 }
 
@@ -2899,8 +2889,8 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -3008,6 +2998,15 @@ body.page .main-navigation {
 
 /* Blocks */
 /* !Block styles */
+@media only screen and (min-width: 768px) {
+  .entry-content,
+  .entry-summary {
+    max-width: 80%;
+    margin: 0 10%;
+    padding: 0 60px;
+  }
+}
+
 .entry-content > *,
 .entry-summary > * {
   max-width: calc(100vw - (2 * 1rem));
@@ -3028,21 +3027,21 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *,
   .entry-summary > * {
-    max-width: calc(8 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry-content > *,
   .entry-summary > * {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry-content > *,
   .entry-summary > * {
-    margin: 32px calc(2 * (100vw / 12));
+    margin: 32px 0;
   }
 }
 
@@ -3065,19 +3064,19 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignwide,
   .entry-summary > *.alignwide {
-    margin-right: calc(2 * (100vw / 12));
-    margin-left: calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    width: 100%;
+    max-width: 100%;
   }
 }
 
 .entry-content > *.alignfull,
 .entry-summary > *.alignfull {
   margin-top: calc(2 * 1rem);
-  margin-left: 0;
   margin-bottom: calc(2 * 1rem);
-  margin-right: 0;
-  max-width: 100%;
+  position: relative;
+  right: calc( -12.5% - 75px);
+  width: calc( 125% + 150px);
+  max-width: calc( 125% + 150px);
 }
 
 .entry-content > *.alignleft,
@@ -3115,8 +3114,7 @@ body.page .main-navigation {
   .entry-content > *.alignright,
   .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
-    margin-right: calc(2 * 1rem);
-    margin-left: calc(2 * (100vw / 12));
+    margin-left: 0;
   }
 }
 
@@ -3126,15 +3124,19 @@ body.page .main-navigation {
   margin-left: auto;
 }
 
+@media only screen and (min-width: 768px) {
+  .entry-content > *.aligncenter,
+  .entry-summary > *.aligncenter {
+    margin-right: 0;
+    margin-left: 0;
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
 @media only screen and (min-width: 1168px) {
   .entry-content > *.aligncenter,
   .entry-summary > *.aligncenter {
-    margin-right: calc(2 * (100vw / 12));
-    margin-left: calc(2 * (100vw / 12));
-    max-width: calc(10 * (100vw / 12));
-    position: relative;
-    right: 25%;
-    transform: translate(50%);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -3467,8 +3469,8 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    width: calc(8 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -3479,8 +3481,8 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
-    width: calc(6 * (100vw / 12 ));
-    max-width: calc(6 * (100vw / 12 ));
+    width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -3597,14 +3599,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-separator.is-style-dots,
   .entry-content hr.is-style-dots {
-    max-width: calc(8 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry-content .wp-block-separator.is-style-dots,
   .entry-content hr.is-style-dots {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1130,26 +1130,12 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1159,13 +1145,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -2334,15 +2313,25 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .author-bio {
-    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .author-bio {
-    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .author-bio {
+    margin: calc(3 * 1rem) calc(10% + 60px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .author-bio {
+    margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
 
@@ -2935,7 +2924,6 @@ body.page .main-navigation {
   #colophon .widget-area,
   #colophon .site-info {
     margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1130,12 +1130,26 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1145,6 +1159,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3508,12 +3529,6 @@ body.page .main-navigation {
   position: absolute;
   transform: translate(50%, -50%);
   top: 50%;
-}
-
-.entry-content .wp-block-cover-image.aligncenter,
-.entry-content .wp-block-cover.aligncenter {
-  margin: 32px calc(2 * (100vw / 12));
-  max-width: calc(6 * (100vw / 12));
 }
 
 .entry-content .wp-block-cover-image.has-left-content,

--- a/style.css
+++ b/style.css
@@ -1138,12 +1138,26 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  left: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1159,6 +1173,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-left: 0;
+    position: absolute;
+    left: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;
@@ -1339,7 +1360,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .post-navigation {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(6 * (100vw / 12));
   }
 }
@@ -1367,8 +1388,8 @@ body.page .main-navigation {
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
-    margin: 0 calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: 0 calc(10% + 60px);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -1458,7 +1479,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
-    margin-left: calc(2 * (100vw / 12));
+    margin-left: calc(10% + 60px);
     padding: 0;
   }
   .pagination .nav-links .prev > *,
@@ -1479,8 +1500,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 1168px) {
   .comment-navigation .nav-links {
-    margin: 0 calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: 0 calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -1658,7 +1679,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-branding {
-    margin: 0 calc(2 * (100vw / 12));
+    margin: 0 calc(10% + 60px);
   }
 }
 
@@ -1893,8 +1914,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
-    margin-left: calc(2 * (100vw / 12));
-    margin-right: calc(2 * (100vw / 12));
+    margin-left: calc(10% + 60px);
+    margin-right: calc(10% + 60px);
   }
 }
 
@@ -2100,7 +2121,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12 )) 1rem;
+    margin: calc(3 * 1rem) calc(10% + 60px) 1rem;
   }
 }
 
@@ -2172,14 +2193,14 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    margin: 1rem calc(2 * (100vw / 12)) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12));
+    margin: 1rem calc(10% + 60px) calc(3 * 1rem);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2189,7 +2210,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .post-thumbnail {
-    margin: 1rem calc(2 * (100vw / 12));
+    margin: 1rem calc(10% + 60px);
   }
 }
 
@@ -2302,14 +2323,14 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    margin: 32px calc(2 * (100vw / 12)) !important;
-    max-width: calc(8 * (100vw / 12)) !important;
+    margin: 32px 0 !important;
+    max-width: calc(8 * (100vw / 12) - 28px) !important;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(6 * (100vw / 12)) !important;
+    max-width: calc(6 * (100vw / 12) - 28px) !important;
   }
 }
 
@@ -2319,13 +2340,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(8 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2336,14 +2357,15 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .author-bio {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1168px) {
   .author-bio {
-    max-width: calc(6 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2411,8 +2433,18 @@ body.page .main-navigation {
   .comments-area > .comment-respond,
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .comments-area .comment-list,
+  .comments-area .comment-navigation,
+  .comments-area > .comment-respond,
+  .comments-area .comment-form-flex,
+  .comments-area .no-comments {
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -2425,8 +2457,8 @@ body.page .main-navigation {
     align-items: baseline;
     display: flex;
     justify-content: space-between;
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -2813,8 +2845,8 @@ body.page .main-navigation {
   .archive .page-header,
   .search .page-header,
   .error404 .page-header {
-    margin: 0 calc(2 * (100vw / 12)) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12));
+    margin: 0 calc(2 * (100vw / 12)) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -2861,7 +2893,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .hfeed .entry .entry-header {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2);
+    margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
   }
 }
 
@@ -2874,7 +2906,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .error-404.not-found .page-content,
   .no-results.not-found .page-content {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12)) calc(1rem / 2);
+    margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
   }
 }
 
@@ -2901,8 +2933,8 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    margin: calc(3 * 1rem) calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    margin: calc(3 * 1rem) calc(10% + 60px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -3010,6 +3042,15 @@ body.page .main-navigation {
 
 /* Blocks */
 /* !Block styles */
+@media only screen and (min-width: 768px) {
+  .entry-content,
+  .entry-summary {
+    max-width: 80%;
+    margin: 0 10%;
+    padding: 0 60px;
+  }
+}
+
 .entry-content > *,
 .entry-summary > * {
   max-width: calc(100vw - (2 * 1rem));
@@ -3030,21 +3071,21 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *,
   .entry-summary > * {
-    max-width: calc(8 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry-content > *,
   .entry-summary > * {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry-content > *,
   .entry-summary > * {
-    margin: 32px calc(2 * (100vw / 12));
+    margin: 32px 0;
   }
 }
 
@@ -3067,19 +3108,19 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *.alignwide,
   .entry-summary > *.alignwide {
-    margin-left: calc(2 * (100vw / 12));
-    margin-right: calc(2 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    width: 100%;
+    max-width: 100%;
   }
 }
 
 .entry-content > *.alignfull,
 .entry-summary > *.alignfull {
   margin-top: calc(2 * 1rem);
-  margin-right: 0;
   margin-bottom: calc(2 * 1rem);
-  margin-left: 0;
-  max-width: 100%;
+  position: relative;
+  left: calc( -12.5% - 75px);
+  width: calc( 125% + 150px);
+  max-width: calc( 125% + 150px);
 }
 
 .entry-content > *.alignleft,
@@ -3117,8 +3158,7 @@ body.page .main-navigation {
   .entry-content > *.alignright,
   .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
-    margin-left: calc(2 * 1rem);
-    margin-right: calc(2 * (100vw / 12));
+    margin-right: 0;
   }
 }
 
@@ -3128,15 +3168,19 @@ body.page .main-navigation {
   margin-right: auto;
 }
 
+@media only screen and (min-width: 768px) {
+  .entry-content > *.aligncenter,
+  .entry-summary > *.aligncenter {
+    margin-left: 0;
+    margin-right: 0;
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
 @media only screen and (min-width: 1168px) {
   .entry-content > *.aligncenter,
   .entry-summary > *.aligncenter {
-    margin-left: calc(2 * (100vw / 12));
-    margin-right: calc(2 * (100vw / 12));
-    max-width: calc(10 * (100vw / 12));
-    position: relative;
-    left: 25%;
-    transform: translate(-50%);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -3469,8 +3513,8 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    width: calc(8 * (100vw / 12));
-    max-width: calc(8 * (100vw / 12));
+    width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
@@ -3481,8 +3525,8 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
-    width: calc(6 * (100vw / 12 ));
-    max-width: calc(6 * (100vw / 12 ));
+    width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -3599,14 +3643,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-separator.is-style-dots,
   .entry-content hr.is-style-dots {
-    max-width: calc(8 * (100vw / 12));
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry-content .wp-block-separator.is-style-dots,
   .entry-content hr.is-style-dots {
-    max-width: calc(6 * (100vw / 12));
+    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2552,10 +2552,12 @@ body.page .main-navigation {
   font-weight: 500;
 }
 
-.comment-reply {
-  left: calc(1rem + 100%);
-  bottom: 0;
-  position: absolute;
+@media only screen and (min-width: 1168px) {
+  .comment-reply {
+    left: 100%;
+    bottom: 0;
+    position: absolute;
+  }
 }
 
 #respond + .comment-reply {
@@ -2581,7 +2583,13 @@ body.page .main-navigation {
 }
 
 .comment .comment-body {
-  margin: calc(2 * 1rem) 0;
+  margin: calc(2 * 1rem) 0 0;
+}
+
+@media only screen and (min-width: 1168px) {
+  .comment .comment-body {
+    margin: calc(2 * 1rem) 0;
+  }
 }
 
 .comment .comment-meta {
@@ -2668,6 +2676,7 @@ body.page .main-navigation {
     margin-left: 1rem;
     position: relative;
     vertical-align: baseline;
+    line-height: 2.25;
   }
 }
 
@@ -2723,6 +2732,12 @@ body.page .main-navigation {
 
 .comment .comment-content {
   margin: 1rem 0;
+}
+
+@media only screen and (min-width: 1168px) {
+  .comment .comment-content {
+    padding-right: 1rem;
+  }
 }
 
 .comment .comment-content > *:first-child {

--- a/style.css
+++ b/style.css
@@ -2336,15 +2336,25 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .author-bio {
-    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .author-bio {
-    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .author-bio {
+    margin: calc(3 * 1rem) calc(10% + 60px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .author-bio {
+    margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
 
@@ -2412,7 +2422,6 @@ body.page .main-navigation {
   .comments-area > .comment-respond,
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
-    margin: calc(3 * 1rem) calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -2424,6 +2433,16 @@ body.page .main-navigation {
   .comments-area .comment-form-flex,
   .comments-area .no-comments {
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comment-list,
+  .comments-area .comment-navigation,
+  .comments-area > .comment-respond,
+  .comments-area .comment-form-flex,
+  .comments-area .no-comments {
+    margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
 
@@ -3047,8 +3066,8 @@ body.page .main-navigation {
 
 .entry-content > *,
 .entry-summary > * {
-  max-width: calc(100vw - (2 * 1rem));
   margin: 32px 1rem;
+  max-width: calc(100vw - (2 * 1rem));
   /*
 	// Set top margins for headings
 	& + h1:before,
@@ -3165,8 +3184,6 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry-content > *.aligncenter,
   .entry-summary > *.aligncenter {
-    margin-left: 0;
-    margin-right: 0;
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3175,6 +3192,14 @@ body.page .main-navigation {
   .entry-content > *.aligncenter,
   .entry-summary > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-content > *.aligncenter,
+  .entry-summary > *.aligncenter {
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 
@@ -3506,8 +3531,6 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
-    font-size: 2.25em;
-    width: calc(8 * (100vw / 12) - 28px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3519,8 +3542,30 @@ body.page .main-navigation {
   .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry-content .wp-block-cover .wp-block-cover-text,
   .entry-content .wp-block-cover h2 {
-    width: calc(6 * (100vw / 12) - 28px);
     max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
+    font-size: 2.25em;
+    width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry-content .wp-block-cover-image h2,
+  .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry-content .wp-block-cover h2 {
+    width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -3624,7 +3669,6 @@ body.page .main-navigation {
 
 .entry-content .wp-block-separator.is-style-dots,
 .entry-content hr.is-style-dots {
-  max-width: calc(100vw - (2 * 1rem));
   text-align: center;
 }
 

--- a/style.css
+++ b/style.css
@@ -2267,6 +2267,15 @@ body.page .main-navigation {
   }
 }
 
+@media only screen and (min-width: 768px) {
+  .entry .entry-content,
+  .entry .entry-summary {
+    max-width: 80%;
+    margin: 0 10%;
+    padding: 0 60px;
+  }
+}
+
 .entry .entry-content p {
   word-wrap: break-word;
 }
@@ -3054,17 +3063,8 @@ body.page .main-navigation {
 
 /* Blocks */
 /* !Block styles */
-@media only screen and (min-width: 768px) {
-  .entry-content,
-  .entry-summary {
-    max-width: 80%;
-    margin: 0 10%;
-    padding: 0 60px;
-  }
-}
-
-.entry-content > *,
-.entry-summary > * {
+.entry .entry-content > *,
+.entry .entry-summary > * {
   margin: 32px 1rem;
   max-width: calc(100vw - (2 * 1rem));
   /*
@@ -3081,52 +3081,52 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *,
-  .entry-summary > * {
+  .entry .entry-content > *,
+  .entry .entry-summary > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content > *,
-  .entry-summary > * {
+  .entry .entry-content > *,
+  .entry .entry-summary > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *,
-  .entry-summary > * {
+  .entry .entry-content > *,
+  .entry .entry-summary > * {
     margin: 32px 0;
   }
 }
 
-.entry-content > * > *:first-child,
-.entry-summary > * > *:first-child {
+.entry .entry-content > * > *:first-child,
+.entry .entry-summary > * > *:first-child {
   margin-top: 0;
 }
 
-.entry-content > * > *:last-child,
-.entry-summary > * > *:last-child {
+.entry .entry-content > * > *:last-child,
+.entry .entry-summary > * > *:last-child {
   margin-bottom: 0;
 }
 
-.entry-content > *.alignwide,
-.entry-summary > *.alignwide {
+.entry .entry-content > *.alignwide,
+.entry .entry-summary > *.alignwide {
   margin-left: auto;
   margin-right: auto;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.alignwide,
-  .entry-summary > *.alignwide {
+  .entry .entry-content > *.alignwide,
+  .entry .entry-summary > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
 }
 
-.entry-content > *.alignfull,
-.entry-summary > *.alignfull {
+.entry .entry-content > *.alignfull,
+.entry .entry-summary > *.alignfull {
   margin-top: calc(2 * 1rem);
   margin-bottom: calc(2 * 1rem);
   position: relative;
@@ -3135,30 +3135,30 @@ body.page .main-navigation {
   max-width: calc( 125% + 150px);
 }
 
-.entry-content > *.alignleft,
-.entry-summary > *.alignleft {
+.entry .entry-content > *.alignleft,
+.entry .entry-summary > *.alignleft {
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.alignleft,
-  .entry-summary > *.alignleft {
+  .entry .entry-content > *.alignleft,
+  .entry .entry-summary > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     margin-right: calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content > *.alignleft,
-  .entry-summary > *.alignleft {
+  .entry .entry-content > *.alignleft,
+  .entry .entry-summary > *.alignleft {
     max-width: calc(3 * (100vw / 12));
   }
 }
 
-.entry-content > *.alignright,
-.entry-summary > *.alignright {
+.entry .entry-content > *.alignright,
+.entry .entry-summary > *.alignright {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3167,78 +3167,78 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.alignright,
-  .entry-summary > *.alignright {
+  .entry .entry-content > *.alignright,
+  .entry .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-right: 0;
   }
 }
 
-.entry-content > *.aligncenter,
-.entry-summary > *.aligncenter {
+.entry .entry-content > *.aligncenter,
+.entry .entry-summary > *.aligncenter {
   margin-left: auto;
   margin-right: auto;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.aligncenter,
-  .entry-summary > *.aligncenter {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content > *.aligncenter,
-  .entry-summary > *.aligncenter {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content > *.aligncenter,
-  .entry-summary > *.aligncenter {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
-.entry-content .wp-block-audio {
+.entry .entry-content .wp-block-audio {
   width: 100%;
 }
 
-.entry-content .wp-block-audio audio {
+.entry .entry-content .wp-block-audio audio {
   width: 100%;
 }
 
-.entry-content .wp-block-audio.alignleft audio,
-.entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignleft audio,
+.entry .entry-content .wp-block-audio.alignright audio {
   max-width: 190px;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-audio.alignleft audio,
-  .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 
 @media only screen and (min-width: 1379px) {
-  .entry-content .wp-block-audio.alignleft audio,
-  .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
 
-.entry-content .wp-block-audio.aligncenter {
+.entry .entry-content .wp-block-audio.aligncenter {
   margin: 32px calc(2 * (100vw / 12));
   max-width: calc(6 * (100vw / 12));
 }
 
-.entry-content .wp-block-video video {
+.entry .entry-content .wp-block-video video {
   width: 100%;
 }
 
-.entry-content .wp-block-button .wp-block-button__link {
+.entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   background: #0073aa;
@@ -3254,46 +3254,46 @@ body.page .main-navigation {
   outline: none;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover {
   cursor: pointer;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover, .entry .entry-content .wp-block-button .wp-block-button__link:focus {
   background: #111;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
 
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   background: transparent;
   border: 2px solid currentColor;
   color: #0073aa;
 }
 
-.entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: #111;
 }
 
-.entry-content .wp-block-archives,
-.entry-content .wp-block-categories,
-.entry-content .wp-block-latest-posts {
+.entry .entry-content .wp-block-archives,
+.entry .entry-content .wp-block-categories,
+.entry .entry-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
 
-.entry-content .wp-block-archives li,
-.entry-content .wp-block-categories li,
-.entry-content .wp-block-latest-posts li {
+.entry .entry-content .wp-block-archives li,
+.entry .entry-content .wp-block-categories li,
+.entry .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
@@ -3301,55 +3301,55 @@ body.page .main-navigation {
   line-height: 1.2;
 }
 
-.entry-content .wp-block-archives li:not(.menu-item-has-children),
-.entry-content .wp-block-categories li:not(.menu-item-has-children),
-.entry-content .wp-block-latest-posts li:not(.menu-item-has-children) {
+.entry .entry-content .wp-block-archives li:not(.menu-item-has-children),
+.entry .entry-content .wp-block-categories li:not(.menu-item-has-children),
+.entry .entry-content .wp-block-latest-posts li:not(.menu-item-has-children) {
   padding-bottom: 0.75rem;
 }
 
-.entry-content .wp-block-archives li a,
-.entry-content .wp-block-categories li a,
-.entry-content .wp-block-latest-posts li a {
+.entry .entry-content .wp-block-archives li a,
+.entry .entry-content .wp-block-categories li a,
+.entry .entry-content .wp-block-latest-posts li a {
   text-decoration: none;
 }
 
-.entry-content .wp-block-archives li ul,
-.entry-content .wp-block-categories li ul,
-.entry-content .wp-block-latest-posts li ul {
+.entry .entry-content .wp-block-archives li ul,
+.entry .entry-content .wp-block-categories li ul,
+.entry .entry-content .wp-block-latest-posts li ul {
   padding-left: 1rem;
 }
 
-.entry-content .wp-block-latest-posts.is-grid li {
+.entry .entry-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 2rem;
 }
 
-.entry-content .wp-block-latest-posts.is-grid li a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after {
   content: '';
 }
 
-.entry-content .wp-block-latest-posts.is-grid li:last-child {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
 
-.entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
   content: '';
 }
 
-.entry-content .wp-block-preformatted {
+.entry .entry-content .wp-block-preformatted {
   font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
 
-.entry-content .wp-block-verse {
+.entry .entry-content .wp-block-verse {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-size: 22px;
   line-height: 1.8;
 }
 
-.entry-content .has-drop-cap:not(:focus):first-letter {
+.entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
@@ -3357,19 +3357,19 @@ body.page .main-navigation {
   margin: 0 0.25em 0 0;
 }
 
-.entry-content .wp-block-pullquote {
+.entry .entry-content .wp-block-pullquote {
   border: none;
   padding: 1rem;
 }
 
-.entry-content .wp-block-pullquote blockquote {
+.entry .entry-content .wp-block-pullquote blockquote {
   color: #111;
   border: none;
   padding-bottom: calc(2 * 1rem);
   margin-right: 0;
 }
 
-.entry-content .wp-block-pullquote p {
+.entry .entry-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
@@ -3377,17 +3377,17 @@ body.page .main-navigation {
   margin-top: 0.5em;
 }
 
-.entry-content .wp-block-pullquote p em {
+.entry .entry-content .wp-block-pullquote p em {
   font-style: normal;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-pullquote p {
+  .entry .entry-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
 
-.entry-content .wp-block-pullquote cite {
+.entry .entry-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.71111em;
@@ -3395,22 +3395,22 @@ body.page .main-navigation {
   text-transform: none;
 }
 
-.entry-content .wp-block-pullquote.alignleft, .entry-content .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
   padding: 0;
 }
 
-.entry-content .wp-block-pullquote.alignleft blockquote, .entry-content .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
   margin-left: 0;
   padding: 0;
   text-align: left;
   max-width: 100%;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color {
   background-color: #0073aa;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -3418,104 +3418,104 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-pullquote.is-style-solid-color p {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color a {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   color: #fff;
   margin: 0 auto;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
   background-color: #0073aa;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
   padding: 1rem 1rem 0;
 }
 
-.entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
   padding: 0 0 calc( 1.5 * 1rem);
   margin-left: 0;
   margin-top: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
     padding: calc( 2 * 1rem) calc( 2 * 1rem) 1rem;
   }
 }
 
-.entry-content .wp-block-quote:not(.is-large), .entry-content .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-left: 2px solid #0073aa;
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.entry-content .wp-block-quote p {
+.entry .entry-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
 
-.entry-content .wp-block-quote cite {
+.entry .entry-content .wp-block-quote cite {
   font-size: 0.71111em;
 }
 
-.entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
   margin: 1rem;
   padding: 0;
   border-left: none;
 }
 
-.entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
 
-.entry-content .wp-block-quote.is-large cite,
-.entry-content .wp-block-quote.is-large footer, .entry-content .wp-block-quote.is-style-large cite,
-.entry-content .wp-block-quote.is-style-large footer {
+.entry .entry-content .wp-block-quote.is-large cite,
+.entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
+.entry .entry-content .wp-block-quote.is-style-large footer {
   font-size: 0.71111em;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
     margin: 1rem 0;
     padding: 1rem 0;
   }
-  .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
 
-.entry-content .wp-block-image img {
+.entry .entry-content .wp-block-image img {
   display: block;
 }
 
-.entry-content .wp-block-image.alignleft, .entry-content .wp-block-image.alignright {
+.entry .entry-content .wp-block-image.alignleft, .entry .entry-content .wp-block-image.alignright {
   max-width: 100%;
 }
 
-.entry-content .wp-block-image.alignfull img {
+.entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
   margin-left: auto;
   margin-right: auto;
 }
 
-.entry-content .wp-block-cover-image .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image .wp-block-cover-text,
-.entry-content .wp-block-cover-image h2,
-.entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry-content .wp-block-cover .wp-block-cover-text,
-.entry-content .wp-block-cover h2 {
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry .entry-content .wp-block-cover-image h2,
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover .wp-block-cover-text,
+.entry .entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1.6875em;
   font-weight: bold;
@@ -3524,66 +3524,66 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry-content .wp-block-cover-image h2,
-  .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
     width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry-content .wp-block-cover-image.alignleft h2,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry-content .wp-block-cover-image.alignright h2,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry-content .wp-block-cover-image.aligncenter h2,
-.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
-.entry-content .wp-block-cover.alignleft h2,
-.entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
-.entry-content .wp-block-cover.alignleft .wp-block-cover-text,
-.entry-content .wp-block-cover.alignright h2,
-.entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
-.entry-content .wp-block-cover.alignright .wp-block-cover-text,
-.entry-content .wp-block-cover.aligncenter h2,
-.entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
-.entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
+.entry .entry-content .wp-block-cover-image.alignleft h2,
+.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.alignright h2,
+.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.aligncenter h2,
+.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.alignleft h2,
+.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.alignright h2,
+.entry .entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.alignright .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.aligncenter h2,
+.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
   width: 100%;
   z-index: 1;
   left: 50%;
@@ -3592,44 +3592,44 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry-content .wp-block-cover-image.has-left-content,
-.entry-content .wp-block-cover.has-left-content {
+.entry .entry-content .wp-block-cover-image.has-left-content,
+.entry .entry-content .wp-block-cover.has-left-content {
   justify-content: center;
 }
 
-.entry-content .wp-block-cover-image.has-left-content h2,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
-.entry-content .wp-block-cover.has-left-content h2,
-.entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
+.entry .entry-content .wp-block-cover-image.has-left-content h2,
+.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.has-left-content h2,
+.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
   padding: 1rem;
 }
 
-.entry-content .wp-block-cover-image.has-right-content,
-.entry-content .wp-block-cover.has-right-content {
+.entry .entry-content .wp-block-cover-image.has-right-content,
+.entry .entry-content .wp-block-cover.has-right-content {
   justify-content: center;
 }
 
-.entry-content .wp-block-cover-image.has-right-content h2,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
-.entry-content .wp-block-cover.has-right-content h2,
-.entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
-.entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
+.entry .entry-content .wp-block-cover-image.has-right-content h2,
+.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
+.entry .entry-content .wp-block-cover.has-right-content h2,
+.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1rem;
 }
 
-.entry-content .wp-block-gallery .blocks-gallery-image:last-child,
-.entry-content .wp-block-gallery .blocks-gallery-item:last-child {
+.entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
 
-.entry-content .wp-block-audio figcaption,
-.entry-content .wp-block-video figcaption,
-.entry-content .wp-block-image figcaption,
-.entry-content .wp-block-gallery .blocks-gallery-image figcaption,
-.entry-content .wp-block-gallery .blocks-gallery-item figcaption {
+.entry .entry-content .wp-block-audio figcaption,
+.entry .entry-content .wp-block-video figcaption,
+.entry .entry-content .wp-block-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.71111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -3638,8 +3638,8 @@ body.page .main-navigation {
   text-align: center;
 }
 
-.entry-content .wp-block-separator,
-.entry-content hr {
+.entry .entry-content .wp-block-separator,
+.entry .entry-content hr {
   margin-bottom: 2rem;
   margin-top: 2rem;
   text-align: left;
@@ -3647,65 +3647,65 @@ body.page .main-navigation {
 		 * is followed by an H1, or H2 */
 }
 
-.entry-content .wp-block-separator:not(.is-style-dots),
-.entry-content hr:not(.is-style-dots) {
+.entry .entry-content .wp-block-separator:not(.is-style-dots),
+.entry .entry-content hr:not(.is-style-dots) {
   background-color: #767676;
   border: 0;
   height: 2px;
 }
 
-.entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
-.entry-content hr:not(.is-style-wide):not(.is-style-dots) {
+.entry .entry-content .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
+.entry .entry-content hr:not(.is-style-wide):not(.is-style-dots) {
   max-width: 2.25em;
 }
 
-.entry-content .wp-block-separator + h1:before,
-.entry-content .wp-block-separator + h2:before,
-.entry-content hr + h1:before,
-.entry-content hr + h2:before {
+.entry .entry-content .wp-block-separator + h1:before,
+.entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content hr + h1:before,
+.entry .entry-content hr + h2:before {
   display: none;
 }
 
-.entry-content .wp-block-separator.is-style-dots,
-.entry-content hr.is-style-dots {
+.entry .entry-content .wp-block-separator.is-style-dots,
+.entry .entry-content hr.is-style-dots {
   text-align: center;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry-content .wp-block-separator.is-style-dots,
-  .entry-content hr.is-style-dots {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-separator.is-style-dots,
-  .entry-content hr.is-style-dots {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry-content .wp-block-separator.is-style-dots:before,
-.entry-content hr.is-style-dots:before {
+.entry .entry-content .wp-block-separator.is-style-dots:before,
+.entry .entry-content hr.is-style-dots:before {
   color: #767676;
   font-size: 1.6875em;
   letter-spacing: 0.88889em;
   padding-left: 0.88889em;
 }
 
-.entry-content .wp-block-embed-twitter {
+.entry .entry-content .wp-block-embed-twitter {
   overflow: hidden;
 }
 
-.entry-content .wp-block-table td, .entry-content .wp-block-table th {
+.entry .entry-content .wp-block-table td, .entry .entry-content .wp-block-table th {
   border-color: #767676;
 }
 
-.entry-content .wp-block-file {
+.entry .entry-content .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.entry-content .wp-block-file .wp-block-file__button {
+.entry .entry-content .wp-block-file .wp-block-file__button {
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
@@ -3718,82 +3718,82 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry-content .wp-block-file .wp-block-file__button {
+  .entry .entry-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
 
-.entry-content .wp-block-file .wp-block-file__button:hover {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover {
   cursor: pointer;
 }
 
-.entry-content .wp-block-file .wp-block-file__button:hover, .entry-content .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover, .entry .entry-content .wp-block-file .wp-block-file__button:focus {
   background: #111;
 }
 
-.entry-content .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:focus {
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry-content .wp-block-code {
+.entry .entry-content .wp-block-code {
   border-radius: 0;
 }
 
-.entry-content .wp-block-code code {
+.entry .entry-content .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.entry-content .wp-block-columns .wp-block-column > *:first-child {
+.entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
   margin-top: 0;
 }
 
-.entry-content .wp-block-columns .wp-block-column > *:last-child {
+.entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
   margin-bottom: 0;
 }
 
-.entry-content .wp-block-columns[class*='has-'] > * {
+.entry .entry-content .wp-block-columns[class*='has-'] > * {
   margin-right: 1rem;
 }
 
-.entry-content .wp-block-columns[class*='has-'] > *:last-child {
+.entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
   margin-right: 0;
 }
 
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;
 }
 
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: normal;
 }
 
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
 
-.entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
 }
 
-.entry-content .has-primary-background-color {
+.entry .entry-content .has-primary-background-color {
   background-color: #0073aa;
 }
 
-.entry-content .has-primary-background-color p,
-.entry-content .has-primary-background-color h1,
-.entry-content .has-primary-background-color h2,
-.entry-content .has-primary-background-color h3,
-.entry-content .has-primary-background-color h4,
-.entry-content .has-primary-background-color h5,
-.entry-content .has-primary-background-color h6,
-.entry-content .has-primary-background-color a {
+.entry .entry-content .has-primary-background-color p,
+.entry .entry-content .has-primary-background-color h1,
+.entry .entry-content .has-primary-background-color h2,
+.entry .entry-content .has-primary-background-color h3,
+.entry .entry-content .has-primary-background-color h4,
+.entry .entry-content .has-primary-background-color h5,
+.entry .entry-content .has-primary-background-color h6,
+.entry .entry-content .has-primary-background-color a {
   color: #fff;
 }
 

--- a/style.css
+++ b/style.css
@@ -3554,12 +3554,6 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry-content .wp-block-cover-image.aligncenter,
-.entry-content .wp-block-cover.aligncenter {
-  margin: 32px calc(2 * (100vw / 12));
-  max-width: calc(6 * (100vw / 12));
-}
-
 .entry-content .wp-block-cover-image.has-left-content,
 .entry-content .wp-block-cover.has-left-content {
   justify-content: center;
@@ -3804,6 +3798,20 @@ svg {
 --------------------------------------------------------------*/
 .wp-caption {
   margin-bottom: calc(1.5 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .wp-caption.aligncenter {
+    position: relative;
+    left: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    transform: translateX(-50%);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .wp-caption.aligncenter {
+    left: calc( calc(6 * (100vw / 12) - 28px) / 2);
+  }
 }
 
 .wp-caption img[class*="wp-image-"] {

--- a/style.css
+++ b/style.css
@@ -1138,26 +1138,12 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  left: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1173,13 +1159,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-left: 0;
-    position: absolute;
-    left: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;
@@ -3451,8 +3430,8 @@ body.page .main-navigation {
 }
 
 .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
-  padding: 1rem 0 1rem 2rem;
-  margin: 1rem 0;
+  margin: 1rem;
+  padding: 0;
   border-left: none;
 }
 
@@ -3470,8 +3449,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry-content .wp-block-quote.is-large, .entry-content .wp-block-quote.is-style-large {
-    margin: 1rem calc(2 * (100vw / 12));
-    max-width: calc(6 * (100vw / 12));
+    margin: 1rem 0;
+    padding: 1rem 0;
   }
   .entry-content .wp-block-quote.is-large p, .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;

--- a/style.css
+++ b/style.css
@@ -2947,7 +2947,6 @@ body.page .main-navigation {
   #colophon .widget-area,
   #colophon .site-info {
     margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 


### PR DESCRIPTION
Partially resolves #236

Moves our tablet + desktop margins around a bit so that there's greater alignment between our front and back end. Basically: if you're in full-screen mode in Gutenberg (on a screen above `768px` wide), you should see _nearly_ the exact same margins/grid for your post content when you switch to the front end. 

- This is based on [the margins/spacing that are built into `style-editor.css`](https://github.com/WordPress/twentynineteen/blob/fac38ef358fc7ab6794a5ef7a516a0b530f28c53/style-editor.scss#L23-L53), so starts by adding `10%` left/right margins to `.entry-content`. There are a few extra pixels added to sync up with Gutenberg's block/container padding. From there, it just modifies the existing margins + max-widths of blocks (and other non-block post elements) so that they fit the new grid.
- When possible, I switched to using mixins/variables for some of our common body content max-width specs. 
- While I was adjusting the comment margins, I also made it so that our comment reply links don't disappear on small screens. 😉

I ran through my entire test site (including all the theme unit test posts), and things looked fairly solid. 

*In order to fully resolve #236, we'll need another PR that syncs up the margins between `600px` and `768px` viewports.

**GIF:**

![margins](https://user-images.githubusercontent.com/1202812/48106446-74629180-e209-11e8-9411-fa301ac2176e.gif)