### PR TITLE
Change the way the EM Dash is added to tagline

### DIFF
--- a/style.css
+++ b/style.css
@@ -1744,11 +1744,6 @@ body.page .main-navigation {
   }
 }
 
-.site-title:not(:empty) + .site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
-}
-
 .site-description {
   display: inline;
   color: #767676;

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -26,6 +26,7 @@
 	if ( $description || is_customize_preview() ) :
 		?>
 			<p class="site-description">
+				<span>&nbsp;&#8212;&nbsp;</span>
 				<?php echo $description; ?>
 			</p>
 	<?php endif; ?>


### PR DESCRIPTION
This PR is a possible solution to the problem of the EM Dash character showing in the customizer, even when the Tagline is empty. It works, but may need some refinement.

Fixes #451 