### PR TITLE
Update the colorscheme function to set the hue correctly 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,3 +67,4 @@ Version 1.0:
 | @whizbangik | @imonly_ik |
 | @yingles | @yingling017 |
 | @tlxo | @tlxo |
+| @brentswisher | |

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -11,15 +11,23 @@
 	// Default color.
 	wp.customize( 'colorscheme', function( value ) {
 		value.bind( function( to ) {
-
 			// Update custom color CSS.
 			var style = $( '#custom-theme-colors' ),
 				hue = style.data( 'hue' ),
-				css = style.html();
+				css = style.html(),
+				color;
+
+			if( to  === 'custom' ){
+				//If a "custom" color option is selected, use the currently set colorscheme_primary_hue
+				color = wp.customize.get().colorscheme_primary_hue;
+			} else {
+				//If the "default" option is selected, get the default primary_hue
+				color = wp.customize.settings.values.colorscheme_primary_hue
+			}
 
 			// Equivalent to css.replaceAll, with hue followed by comma to prevent values with units from being changed.
-			css = css.split( hue + ',' ).join( to + ',' );
-			style.html( css ).data( 'hue', to );
+			css = css.split( hue + ',' ).join( color + ',' );
+			style.html( css ).data( 'hue', color );
 		});
 	});
 

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -22,7 +22,7 @@
 				color = wp.customize.get().colorscheme_primary_hue;
 			} else {
 				//If the "default" option is selected, get the default primary_hue
-				color = wp.customize.settings.values.colorscheme_primary_hue
+				color = 199;
 			}
 
 			// Equivalent to css.replaceAll, with hue followed by comma to prevent values with units from being changed.


### PR DESCRIPTION
The color scheme customizer function currently takes in a string, either "default" or "custom" as it's 'to' argument, but tries to set the hue to that actual value. This PR updates that to grab the current custom hue or use the default hue instead based on the to value passed in, fixes #468

Ideally, we could pull the default hue from somewhere without hardcoding it, but I couldn't find anywhere that it was stored. I thought "wp.customize.settings.values.colorscheme_primary_hue" might work, but that was just the last saved value, not the true default, so I hard coded it.

(Wordpress.org username is also brentswisher)

![rwx2ioaeo3](https://user-images.githubusercontent.com/6653970/48179141-a0564380-e2eb-11e8-9863-55d785ccc7f6.gif)