### PR TITLE
Fix margins + certain instances of alignfull blocks on small screens

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -110,7 +110,7 @@
 		&.alignleft audio,
 		&.alignright audio {
 
-			max-width: (0.5 * $mobile_width);
+			max-width: (0.33 * $mobile_width);
 
 			@include media(tablet) {
 				max-width: (0.5 * $tablet_width);

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -44,7 +44,7 @@
 	&.alignfull {
 		position: relative;
 		left: -#{$size__spacing-unit };
-		width: calc( 100vw + (2 * #{$size__spacing-unit}));
+		width: 100%;
 		max-width: calc( 100vw + (2 * #{$size__spacing-unit}));
 
 		@include media(tablet) {
@@ -469,14 +469,6 @@
 			}
 		}
 
-		&.alignfull {
-			width: 100%;
-
-			@include media(tablet) {
-				width: calc( 125% + 150px );
-			}
-		}
-
 		&.has-left-content {
 			justify-content: center;
 
@@ -499,9 +491,12 @@
 	}
 
 	//! Galleries
-	.wp-block-gallery .blocks-gallery-image:last-child,
-	.wp-block-gallery .blocks-gallery-item:last-child {
-		margin-bottom: 16px;
+	.wp-block-gallery {
+
+		.blocks-gallery-image:last-child,
+		.blocks-gallery-item:last-child {
+			margin-bottom: 16px;
+		}
 	}
 
 	//! Captions
@@ -620,22 +615,24 @@
 	//! Columns
 	.wp-block-columns {
 
-		.wp-block-column > * {
+		@include media(tablet) {
+			.wp-block-column > * {
 
-			&:first-child {
-				margin-top: 0;
+				&:first-child {
+					margin-top: 0;
+				}
+
+				&:last-child {
+					margin-bottom: 0;
+				}
 			}
 
-			&:last-child {
-				margin-bottom: 0;
-			}
-		}
+			&[class*='has-'] > * {
+				margin-right: $size__spacing-unit;
 
-		&[class*='has-'] > * {
-			margin-right: $size__spacing-unit;
-
-			&:last-child {
-				margin-right: 0;
+				&:last-child {
+					margin-right: 0;
+				}
 			}
 		}
 	}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -3,7 +3,7 @@
 .entry .entry-content > *,
 .entry .entry-summary > * {
 	margin: 32px $size__spacing-unit;
-	max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
+	max-width: calc(100% - (2 * #{ $size__spacing-unit }));
 
 	@include postContentMaxWidth();
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -42,12 +42,18 @@
 	}
 
 	&.alignfull {
-		margin-top: calc(2 * #{$size__spacing-unit});
-		margin-bottom: calc(2 * #{$size__spacing-unit});
 		position: relative;
-		left: calc( -12.5% - 75px );
-		width: calc( 125% + 150px );
-		max-width: calc( 125% + 150px );
+		left: -#{$size__spacing-unit };
+		width: calc( 100vw + (2 * #{$size__spacing-unit}));
+		max-width: calc( 100vw + (2 * #{$size__spacing-unit}));
+
+		@include media(tablet) {
+			margin-top: calc(2 * #{$size__spacing-unit});
+			margin-bottom: calc(2 * #{$size__spacing-unit});
+			left: calc( -12.5% - 75px );
+			width: calc( 125% + 150px );
+			max-width: calc( 125% + 150px );
+		}
 	}
 
 	&.alignleft {
@@ -414,8 +420,11 @@
 
 		&.alignfull img {
 			width: 100vw;
-			margin-left: auto;
-			margin-right: auto;
+			
+			@include media(tablet) {
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 	}
 
@@ -457,6 +466,14 @@
 				position: absolute;
 				transform: translate(-50%, -50%);
 				top: 50%;
+			}
+		}
+
+		&.alignfull {
+			width: 100%;
+
+			@include media(tablet) {
+				width: calc( 125% + 150px );
 			}
 		}
 

--- a/sass/mixins/_utilities.scss
+++ b/sass/mixins/_utilities.scss
@@ -1,10 +1,17 @@
 
 @mixin media( $res ) {
+	@if mobile == $res {
+		@media only screen and (min-width: $mobile_width) {
+			@content;
+		}
+	}
+
 	@if tablet == $res {
 		@media only screen and (min-width: $tablet_width) {
 			@content;
 		}
 	}
+
 	@if desktop == $res {
 		@media only screen and (min-width: $desktop_width) {
 			@content;

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -9,7 +9,7 @@ $size__site-desktop-content: calc(6 * (100vw / 12) - 28px);
 
 // Responsive widths.
 
-$mobile_width: 380px;
+$mobile_width: 600px;
 $tablet_width: 768px;
 $desktop_width: 1168px;
 $wide_width: 1379px;

--- a/style-editor.css
+++ b/style-editor.css
@@ -8,16 +8,30 @@ Twenty Nineteen Editor Styles
 /* Fallback for non-latin fonts */
 /* Calculates maximum width for post content */
 /** === Editor Frame === */
-@media screen and (min-width: 600px) {
+body .wp-block[data-align="full"] {
+  width: 100%;
+}
+
+@media only screen and (min-width: 600px) {
+  body {
+    overflow-x: hidden;
+  }
+  body .editor-block-list__layout,
+  body .editor-post-title {
+    padding-left: 0;
+    padding-right: 0;
+  }
   body .wp-block[data-align="full"] {
-    width: calc( 100% + 90px);
-    max-width: calc( 100% + 90px);
+    position: relative;
+    left: 45px;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  body {
-    overflow-x: hidden;
+  body .editor-block-list__layout,
+  body .editor-post-title {
+    padding-left: 46px;
+    padding-right: 46px;
   }
   body .editor-writing-flow {
     max-width: 80%;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -12,16 +12,32 @@ Twenty Nineteen Editor Styles
 
 body {
 
-	// Non-standard media query necessary to override a Gutenberg breakpoint style. 
-	@media screen and (min-width: 600px) {
+	.wp-block[data-align="full"] {
+		width: 100%;
+	}
+
+	@include media(mobile) {
+		overflow-x: hidden;
+
+		.editor-block-list__layout,
+		.editor-post-title {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
 		.wp-block[data-align="full"] {
-			width: calc( 100% + 90px );
-			max-width: calc( 100% + 90px );
+			position: relative;
+			left: 45px;
 		}
 	}
 
 	@include media(tablet) {
-		overflow-x: hidden;
+
+		.editor-block-list__layout,
+		.editor-post-title {
+			padding-left: 46px;
+			padding-right: 46px;
+		}
 
 		.editor-writing-flow {
 			max-width: 80%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1130,26 +1130,12 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1159,13 +1145,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3168,7 +3147,8 @@ body.page .main-navigation {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
-    margin-right: 0;
+    margin-left: calc(2 * 1rem);
+    margin-left: 0;
   }
 }
 
@@ -3210,7 +3190,7 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-audio.alignleft audio,
 .entry .entry-content .wp-block-audio.alignright audio {
-  max-width: 190px;
+  max-width: 198px;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3106,7 +3106,7 @@ body.page .main-navigation {
 .entry .entry-summary > *.alignfull {
   position: relative;
   right: -1rem;
-  width: calc( 100vw + (2 * 1rem));
+  width: 100%;
   max-width: calc( 100vw + (2 * 1rem));
 }
 
@@ -3584,18 +3584,6 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry .entry-content .wp-block-cover-image.alignfull,
-.entry .entry-content .wp-block-cover.alignfull {
-  width: 100%;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull {
-    width: calc( 125% + 150px);
-  }
-}
-
 .entry .entry-content .wp-block-cover-image.has-left-content,
 .entry .entry-content .wp-block-cover.has-left-content {
   justify-content: center;
@@ -3751,20 +3739,19 @@ body.page .main-navigation {
   word-break: break-word;
 }
 
-.entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
-  margin-top: 0;
-}
-
-.entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
-  margin-bottom: 0;
-}
-
-.entry .entry-content .wp-block-columns[class*='has-'] > * {
-  margin-left: 1rem;
-}
-
-.entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
-  margin-left: 0;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
+    margin-top: 0;
+  }
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
+    margin-bottom: 0;
+  }
+  .entry .entry-content .wp-block-columns[class*='has-'] > * {
+    margin-left: 1rem;
+  }
+  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
+    margin-left: 0;
+  }
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3104,12 +3104,21 @@ body.page .main-navigation {
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull {
-  margin-top: calc(2 * 1rem);
-  margin-bottom: calc(2 * 1rem);
   position: relative;
-  right: calc( -12.5% - 75px);
-  width: calc( 125% + 150px);
-  max-width: calc( 125% + 150px);
+  right: -1rem;
+  width: calc( 100vw + (2 * 1rem));
+  max-width: calc( 100vw + (2 * 1rem));
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.alignfull,
+  .entry .entry-summary > *.alignfull {
+    margin-top: calc(2 * 1rem);
+    margin-bottom: calc(2 * 1rem);
+    right: calc( -12.5% - 75px);
+    width: calc( 125% + 150px);
+    max-width: calc( 125% + 150px);
+  }
 }
 
 .entry .entry-content > *.alignleft,
@@ -3484,8 +3493,13 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
-  margin-right: auto;
-  margin-left: auto;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image.alignfull img {
+    margin-right: auto;
+    margin-left: auto;
+  }
 }
 
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
@@ -3568,6 +3582,18 @@ body.page .main-navigation {
   position: absolute;
   transform: translate(50%, -50%);
   top: 50%;
+}
+
+.entry .entry-content .wp-block-cover-image.alignfull,
+.entry .entry-content .wp-block-cover.alignfull {
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull,
+  .entry .entry-content .wp-block-cover.alignfull {
+    width: calc( 125% + 150px);
+  }
 }
 
 .entry .entry-content .wp-block-cover-image.has-left-content,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1130,12 +1130,26 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1145,6 +1159,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3043,7 +3064,7 @@ body.page .main-navigation {
 .entry .entry-content > *,
 .entry .entry-summary > * {
   margin: 32px 1rem;
-  max-width: calc(100vw - (2 * 1rem));
+  max-width: calc(100% - (2 * 1rem));
   /*
 	// Set top margins for headings
 	& + h1:before,

--- a/style.css
+++ b/style.css
@@ -1138,26 +1138,12 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  left: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1173,13 +1159,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-left: 0;
-    position: absolute;
-    left: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;
@@ -3149,12 +3128,21 @@ body.page .main-navigation {
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull {
-  margin-top: calc(2 * 1rem);
-  margin-bottom: calc(2 * 1rem);
   position: relative;
-  left: calc( -12.5% - 75px);
-  width: calc( 125% + 150px);
-  max-width: calc( 125% + 150px);
+  left: -1rem;
+  width: calc( 100vw + (2 * 1rem));
+  max-width: calc( 100vw + (2 * 1rem));
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.alignfull,
+  .entry .entry-summary > *.alignfull {
+    margin-top: calc(2 * 1rem);
+    margin-bottom: calc(2 * 1rem);
+    left: calc( -12.5% - 75px);
+    width: calc( 125% + 150px);
+    max-width: calc( 125% + 150px);
+  }
 }
 
 .entry .entry-content > *.alignleft,
@@ -3534,8 +3522,13 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
-  margin-left: auto;
-  margin-right: auto;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image.alignfull img {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
@@ -3618,6 +3611,18 @@ body.page .main-navigation {
   position: absolute;
   transform: translate(-50%, -50%);
   top: 50%;
+}
+
+.entry .entry-content .wp-block-cover-image.alignfull,
+.entry .entry-content .wp-block-cover.alignfull {
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull,
+  .entry .entry-content .wp-block-cover.alignfull {
+    width: calc( 125% + 150px);
+  }
 }
 
 .entry .entry-content .wp-block-cover-image.has-left-content,

--- a/style.css
+++ b/style.css
@@ -3067,7 +3067,7 @@ body.page .main-navigation {
 .entry .entry-content > *,
 .entry .entry-summary > * {
   margin: 32px 1rem;
-  max-width: calc(100vw - (2 * 1rem));
+  max-width: calc(100% - (2 * 1rem));
   /*
 	// Set top margins for headings
 	& + h1:before,

--- a/style.css
+++ b/style.css
@@ -3130,7 +3130,7 @@ body.page .main-navigation {
 .entry .entry-summary > *.alignfull {
   position: relative;
   left: -1rem;
-  width: calc( 100vw + (2 * 1rem));
+  width: 100%;
   max-width: calc( 100vw + (2 * 1rem));
 }
 
@@ -3613,18 +3613,6 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry .entry-content .wp-block-cover-image.alignfull,
-.entry .entry-content .wp-block-cover.alignfull {
-  width: 100%;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull {
-    width: calc( 125% + 150px);
-  }
-}
-
 .entry .entry-content .wp-block-cover-image.has-left-content,
 .entry .entry-content .wp-block-cover.has-left-content {
   justify-content: center;
@@ -3780,20 +3768,19 @@ body.page .main-navigation {
   word-break: break-word;
 }
 
-.entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
-  margin-top: 0;
-}
-
-.entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
-  margin-bottom: 0;
-}
-
-.entry .entry-content .wp-block-columns[class*='has-'] > * {
-  margin-right: 1rem;
-}
-
-.entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
-  margin-right: 0;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
+    margin-top: 0;
+  }
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
+    margin-bottom: 0;
+  }
+  .entry .entry-content .wp-block-columns[class*='has-'] > * {
+    margin-right: 1rem;
+  }
+  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
+    margin-right: 0;
+  }
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {

--- a/style.css
+++ b/style.css
@@ -1138,12 +1138,26 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  left: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1159,6 +1173,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-left: 0;
+    position: absolute;
+    left: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;
@@ -3219,7 +3240,7 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-audio.alignleft audio,
 .entry .entry-content .wp-block-audio.alignright audio {
-  max-width: 190px;
+  max-width: 198px;
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
Switches to using `vw` to percent for our width calculations for all blocks on small screens. This prevents uneven spacing due to scrollbars (if they appear).

Also, cleans up small screen display of some alignfull blocks that suffered a visual regression recently (images, columns, media + text). 

**Before:**
![screen shot 2018-11-08 at 11 05 56 am](https://user-images.githubusercontent.com/1202812/48210912-58183f00-e346-11e8-94f0-fe675060cc4f.png)
![screen shot 2018-11-08 at 11 05 44 am](https://user-images.githubusercontent.com/1202812/48210914-58183f00-e346-11e8-92c6-ea28e729b485.png)
![screen shot 2018-11-08 at 11 04 42 am](https://user-images.githubusercontent.com/1202812/48210915-58183f00-e346-11e8-8f60-30440611b7b7.png)


**After:**
![screen shot 2018-11-08 at 11 02 56 am](https://user-images.githubusercontent.com/1202812/48210928-5fd7e380-e346-11e8-998c-bb716469335f.png)
![screen shot 2018-11-08 at 11 02 35 am](https://user-images.githubusercontent.com/1202812/48210933-61a1a700-e346-11e8-9b69-cbe2a6d644d1.png)
![screen shot 2018-11-08 at 11 04 16 am](https://user-images.githubusercontent.com/1202812/48210922-5e0e2000-e346-11e8-8f01-9dbb44792727.png)

