### PR TITLE
Update post title font weight in the editor

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -211,6 +211,7 @@ figcaption,
 .editor-post-title__block .editor-post-title__input {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 2.8125em;
+  font-weight: 700;
 }
 
 /** === Default Appender === */

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -203,6 +203,7 @@ figcaption,
 	.editor-post-title__input {
 		font-family: $font__heading;
 		font-size: $font__size-xxl;
+		font-weight: 700;
 	}
 }
 


### PR DESCRIPTION
To match the weight used on the front end.

As noted in https://github.com/WordPress/twentynineteen/pull/515#pullrequestreview-173108870

**Before:**
![screen shot 2018-11-08 at 3 51 51 pm](https://user-images.githubusercontent.com/1202812/48226643-4480ce80-e36e-11e8-81e3-3c531f169cc5.png)

**After:**
![screen shot 2018-11-08 at 3 51 42 pm](https://user-images.githubusercontent.com/1202812/48226646-46e32880-e36e-11e8-88fd-d99f14fbfbfc.png)
