### PR TITLE
[In Progress] Improve Gutenberg fallback styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -104,6 +104,11 @@
 
 .entry .entry-content {
 
+	//! Paragraphs
+	p.has-background {
+		padding: 20px 30px;
+	}
+
 	//! Audio
 	.wp-block-audio {
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -492,6 +492,8 @@
 
 	//! Galleries
 	.wp-block-gallery {
+		list-style-type: none;
+		padding-left: 0;
 
 		.blocks-gallery-image:last-child,
 		.blocks-gallery-item:last-child {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -303,6 +303,7 @@
 			font-family: $font__heading;
 			line-height: 1.6;
 			text-transform: none;
+			color: $color__text-light;
 			
 			/* 
 			 * This requires a rem-based font size calculation instead of our normal em-based one, 
@@ -340,6 +341,10 @@
 
 			a {
 				color: $color__background-body;
+			}
+
+			cite {
+				color: inherit;
 			}
 
 			blockquote {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -301,9 +301,14 @@
 		cite {
 			display: inline-block;
 			font-family: $font__heading;
-			font-size: $font__size-xs;
 			line-height: 1.6;
 			text-transform: none;
+			
+			/* 
+			 * This requires a rem-based font size calculation instead of our normal em-based one, 
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+			 */
+			font-size: calc(1rem / (1.25 * #{$font__size-ratio}));
 		}
 
 		&.alignleft,
@@ -380,7 +385,11 @@
 		}
 
 		cite {
-			font-size: $font__size-xs;
+			/* 
+			 * This requires a rem-based font size calculation instead of our normal em-based one, 
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+			 */
+			font-size: calc(1rem / (1.25 * #{$font__size-ratio}));
 		}
 
 		&.is-large,
@@ -397,7 +406,11 @@
 
 			cite,
 			footer {
-				font-size: $font__size-xs;
+				/* 
+				 * This requires a rem-based font size calculation instead of our normal em-based one, 
+				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+				 */
+				font-size: calc(1rem / (1.25 * #{$font__size-ratio}));
 			}
 
 			@include media(tablet) {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -585,8 +585,10 @@
 			font-size: $font__size-base;
 			font-family: $font__heading;
 			line-height: $font__line-height-heading;
+			text-decoration: none;
 			font-weight: bold;
 			padding: ($size__spacing-unit * .75) $size__spacing-unit;
+			color: #fff;
 
 			@include media(desktop) {
 				font-size: $font__size-base;
@@ -605,6 +607,10 @@
 				outline: thin dotted;
 				outline-offset: -4px;
 			}
+		}
+
+		* + .wp-block-file__button {
+			margin-left: ($size__spacing-unit * .75);
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -454,6 +454,7 @@
 	//! Cover Image
 	.wp-block-cover-image,
 	.wp-block-cover {
+		position: relative;
 		min-height: 430px;
 
 		.wp-block-cover-image-text,
@@ -494,6 +495,11 @@
 				transform: translate(-50%, -50%);
 				top: 50%;
 			}
+		}
+
+		&.alignleft,
+		&.alignright {
+			width: 100%;
 		}
 
 		&.has-left-content,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -454,6 +454,7 @@
 	//! Cover Image
 	.wp-block-cover-image,
 	.wp-block-cover {
+		min-height: 430px;
 
 		.wp-block-cover-image-text,
 		.wp-block-cover-text,
@@ -461,6 +462,9 @@
 			font-family: $font__heading;
 			font-size: $font__size-lg;
 			font-weight: bold;
+			line-height: 1.25;
+			padding: $size__spacing-unit;
+			color: #fff;
 
 			width: calc(100vw - (2 * #{ $size__spacing-unit }));
 			max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
@@ -492,24 +496,9 @@
 			}
 		}
 
-		&.has-left-content {
-			justify-content: center;
-
-			h2,
-			.wp-block-cover-image-text,
-			.wp-block-cover-text {
-				padding: $size__spacing-unit;
-			}
-		}
-
+		&.has-left-content,
 		&.has-right-content {
 			justify-content: center;
-
-			h2,
-			.wp-block-cover-image-text,
-			.wp-block-cover-text {
-				padding: $size__spacing-unit;
-			}
 		}
 	}
 

--- a/sass/elements/_tables.scss
+++ b/sass/elements/_tables.scss
@@ -1,8 +1,11 @@
 table {
 	margin: 0 0 $size__spacing-unit;
+	border-collapse: collapse;
 	width: 100%;
 
 	td, th {
-		border-color: $color__text-light;
+		padding: 0.5em;
+		border: 1px solid $color__text-light;
+		word-break: break-all;
 	}
 }

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -58,6 +58,11 @@
 .widget_calendar .calendar_wrap {
 	text-align: center;
 	font-family: $font__heading;
+
+	table td, 
+	table th {
+		border: none;
+	}
 	
 	a {
 		text-decoration: underline;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3416,10 +3416,10 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   text-transform: none;
+  color: #767676;
   /* 
 			 * This requires a rem-based font size calculation instead of our normal em-based one, 
-			 * because the cite tag sometimes gets wrapped in a p tag. 
-			 * This is equivalent to $font-size_xs. 
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
 			 */
   font-size: calc(1rem / (1.25 * 1.125));
 }
@@ -3454,6 +3454,10 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
+  color: inherit;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
@@ -3494,6 +3498,10 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-quote cite {
+  /* 
+			 * This requires a rem-based font size calculation instead of our normal em-based one, 
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+			 */
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
@@ -3512,6 +3520,10 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
+  /* 
+				 * This requires a rem-based font size calculation instead of our normal em-based one, 
+				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+				 */
   font-size: calc(1rem / (1.25 * 1.125));
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3414,9 +3414,14 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
   line-height: 1.6;
   text-transform: none;
+  /* 
+			 * This requires a rem-based font size calculation instead of our normal em-based one, 
+			 * because the cite tag sometimes gets wrapped in a p tag. 
+			 * This is equivalent to $font-size_xs. 
+			 */
+  font-size: calc(1rem / (1.25 * 1.125));
 }
 
 .entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
@@ -3489,7 +3494,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-quote cite {
-  font-size: 0.71111em;
+  font-size: calc(1rem / (1.25 * 1.125));
 }
 
 .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
@@ -3507,7 +3512,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
-  font-size: 0.71111em;
+  font-size: calc(1rem / (1.25 * 1.125));
 }
 
 @media only screen and (min-width: 768px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3222,6 +3222,10 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content p.has-background {
+  padding: 20px 30px;
+}
+
 .entry .entry-content .wp-block-audio {
   width: 100%;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -830,7 +830,7 @@ table {
 }
 
 table td, table th {
-  border-color: #767676;
+  border: 1px solid #767676;
 }
 
 /* Forms */
@@ -3059,12 +3059,12 @@ body.page .main-navigation {
   margin-top: 1rem;
 }
 
-.widget_calendar {
+.widget_calendar .calendar_wrap {
   text-align: center;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.widget_calendar a {
+.widget_calendar .calendar_wrap a {
   text-decoration: underline;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3067,6 +3067,11 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+.widget_calendar .calendar_wrap table td,
+.widget_calendar .calendar_wrap table th {
+  border: none;
+}
+
 .widget_calendar .calendar_wrap a {
   text-decoration: underline;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3747,8 +3747,10 @@ body.page .main-navigation {
   font-size: 22px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.2;
+  text-decoration: none;
   font-weight: bold;
   padding: 0.75rem 1rem;
+  color: #fff;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -3769,6 +3771,10 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-file .wp-block-file__button:focus {
   outline: thin dotted;
   outline-offset: -4px;
+}
+
+.entry .entry-content .wp-block-file * + .wp-block-file__button {
+  margin-right: 0.75rem;
 }
 
 .entry .entry-content .wp-block-code {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3558,6 +3558,7 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-cover-image,
 .entry .entry-content .wp-block-cover {
+  position: relative;
   min-height: 430px;
 }
 
@@ -3644,6 +3645,12 @@ body.page .main-navigation {
   position: absolute;
   transform: translate(50%, -50%);
   top: 50%;
+}
+
+.entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+.entry .entry-content .wp-block-cover.alignleft,
+.entry .entry-content .wp-block-cover.alignright {
+  width: 100%;
 }
 
 .entry .entry-content .wp-block-cover-image.has-left-content, .entry .entry-content .wp-block-cover-image.has-right-content,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -826,11 +826,14 @@ blockquote cite {
 
 table {
   margin: 0 0 1rem;
+  border-collapse: collapse;
   width: 100%;
 }
 
 table td, table th {
+  padding: 0.5em;
   border: 1px solid #767676;
+  word-break: break-all;
 }
 
 /* Forms */
@@ -3640,6 +3643,11 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
   padding: 1rem;
+}
+
+.entry .entry-content .wp-block-gallery {
+  list-style-type: none;
+  padding-right: 0;
 }
 
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3556,6 +3556,11 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content .wp-block-cover-image,
+.entry .entry-content .wp-block-cover {
+  min-height: 430px;
+}
+
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover-image h2,
@@ -3565,6 +3570,9 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1.6875em;
   font-weight: bold;
+  line-height: 1.25;
+  padding: 1rem;
+  color: #fff;
   width: calc(100vw - (2 * 1rem));
   max-width: calc(100vw - (2 * 1rem));
 }
@@ -3638,32 +3646,10 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry .entry-content .wp-block-cover-image.has-left-content,
-.entry .entry-content .wp-block-cover.has-left-content {
-  justify-content: center;
-}
-
-.entry .entry-content .wp-block-cover-image.has-left-content h2,
-.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.has-left-content h2,
-.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
-  padding: 1rem;
-}
-
-.entry .entry-content .wp-block-cover-image.has-right-content,
+.entry .entry-content .wp-block-cover-image.has-left-content, .entry .entry-content .wp-block-cover-image.has-right-content,
+.entry .entry-content .wp-block-cover.has-left-content,
 .entry .entry-content .wp-block-cover.has-right-content {
   justify-content: center;
-}
-
-.entry .entry-content .wp-block-cover-image.has-right-content h2,
-.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.has-right-content h2,
-.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
-  padding: 1rem;
 }
 
 .entry .entry-content .wp-block-gallery {

--- a/style.css
+++ b/style.css
@@ -3564,6 +3564,11 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content .wp-block-cover-image,
+.entry .entry-content .wp-block-cover {
+  min-height: 430px;
+}
+
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover-image h2,
@@ -3573,6 +3578,9 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1.6875em;
   font-weight: bold;
+  line-height: 1.25;
+  padding: 1rem;
+  color: #fff;
   width: calc(100vw - (2 * 1rem));
   max-width: calc(100vw - (2 * 1rem));
 }
@@ -3646,32 +3654,10 @@ body.page .main-navigation {
   top: 50%;
 }
 
-.entry .entry-content .wp-block-cover-image.has-left-content,
-.entry .entry-content .wp-block-cover.has-left-content {
-  justify-content: center;
-}
-
-.entry .entry-content .wp-block-cover-image.has-left-content h2,
-.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.has-left-content .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.has-left-content h2,
-.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.has-left-content .wp-block-cover-text {
-  padding: 1rem;
-}
-
-.entry .entry-content .wp-block-cover-image.has-right-content,
+.entry .entry-content .wp-block-cover-image.has-left-content, .entry .entry-content .wp-block-cover-image.has-right-content,
+.entry .entry-content .wp-block-cover.has-left-content,
 .entry .entry-content .wp-block-cover.has-right-content {
   justify-content: center;
-}
-
-.entry .entry-content .wp-block-cover-image.has-right-content h2,
-.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.has-right-content .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.has-right-content h2,
-.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.has-right-content .wp-block-cover-text {
-  padding: 1rem;
 }
 
 .entry .entry-content .wp-block-gallery {

--- a/style.css
+++ b/style.css
@@ -826,11 +826,14 @@ blockquote cite {
 
 table {
   margin: 0 0 1rem;
+  border-collapse: collapse;
   width: 100%;
 }
 
 table td, table th {
-  border-color: #767676;
+  padding: 0.5em;
+  border: 1px solid #767676;
+  word-break: break-all;
 }
 
 /* Forms */

--- a/style.css
+++ b/style.css
@@ -3424,6 +3424,7 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   text-transform: none;
+  color: #767676;
   /* 
 			 * This requires a rem-based font size calculation instead of our normal em-based one, 
 			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
@@ -3461,6 +3462,10 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
+  color: inherit;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {

--- a/style.css
+++ b/style.css
@@ -3653,6 +3653,11 @@ body.page .main-navigation {
   padding: 1rem;
 }
 
+.entry .entry-content .wp-block-gallery {
+  list-style-type: none;
+  padding-left: 0;
+}
+
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
 .entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;

--- a/style.css
+++ b/style.css
@@ -3566,6 +3566,7 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-cover-image,
 .entry .entry-content .wp-block-cover {
+  position: relative;
   min-height: 430px;
 }
 
@@ -3652,6 +3653,12 @@ body.page .main-navigation {
   position: absolute;
   transform: translate(-50%, -50%);
   top: 50%;
+}
+
+.entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+.entry .entry-content .wp-block-cover.alignleft,
+.entry .entry-content .wp-block-cover.alignright {
+  width: 100%;
 }
 
 .entry .entry-content .wp-block-cover-image.has-left-content, .entry .entry-content .wp-block-cover-image.has-right-content,

--- a/style.css
+++ b/style.css
@@ -3755,8 +3755,10 @@ body.page .main-navigation {
   font-size: 22px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.2;
+  text-decoration: none;
   font-weight: bold;
   padding: 0.75rem 1rem;
+  color: #fff;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -3777,6 +3779,10 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-file .wp-block-file__button:focus {
   outline: thin dotted;
   outline-offset: -4px;
+}
+
+.entry .entry-content .wp-block-file * + .wp-block-file__button {
+  margin-left: 0.75rem;
 }
 
 .entry .entry-content .wp-block-code {

--- a/style.css
+++ b/style.css
@@ -3070,6 +3070,11 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+.widget_calendar .calendar_wrap table td,
+.widget_calendar .calendar_wrap table th {
+  border: none;
+}
+
 .widget_calendar .calendar_wrap a {
   text-decoration: underline;
 }

--- a/style.css
+++ b/style.css
@@ -3230,6 +3230,10 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content p.has-background {
+  padding: 20px 30px;
+}
+
 .entry .entry-content .wp-block-audio {
   width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -3422,9 +3422,13 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
   line-height: 1.6;
   text-transform: none;
+  /* 
+			 * This requires a rem-based font size calculation instead of our normal em-based one, 
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+			 */
+  font-size: calc(1rem / (1.25 * 1.125));
 }
 
 .entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
@@ -3497,7 +3501,11 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-quote cite {
-  font-size: 0.71111em;
+  /* 
+			 * This requires a rem-based font size calculation instead of our normal em-based one, 
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+			 */
+  font-size: calc(1rem / (1.25 * 1.125));
 }
 
 .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
@@ -3515,7 +3523,11 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
-  font-size: 0.71111em;
+  /* 
+				 * This requires a rem-based font size calculation instead of our normal em-based one, 
+				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs. 
+				 */
+  font-size: calc(1rem / (1.25 * 1.125));
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
Addresses #503

Cleans up visual issues related to blocks that arise when a pre-5.0 user deactivates the Gutenberg plugin.

- [x] Tables lose their border colors. _This is a quick fix. We should take care of it._
- [x] Cover blocks lose their min-height, the positioning styles for their text and the background size/positioning styles for the image. _We should at least add the min-height._
- [x] Left/right aligned Cover blocks lose their `position: relative;` style, so the text inside them is in the wrong spot on the page. They also collapse completely. These are very broken. _We need to sort this out._
- [x] Columns are not arranged in columns anymore: they are stacked. _I think it's fine to keep them this way._
- [x] Galleries are not arranged in columns anymore: they're an unstyled list. _I suggest we add `list-style-type:none;` and leave them this way._
- [x] Dynamic blocks (Latest Posts, etc.) disappear completely. _This is expected and unavoidable._
- [x] Blockquote Size Large citation appears in a larger font size. _We can fix this._
- [x] Pullquote citations appear in a large font size. _We can fix this._
- [x] The citation in solid color Pullquotes is gray instead of white. _We can fix this._
- ~~Headline + text blocks stack vertically and have no padding. _We should at least add padding here._~~ (_Changing my mind on this one: Gutenberg doesn't give this block top/bottom padding by  default, so I'm not sure it makes sense to add it for our own purposes in this case._)
- [x] Paragraphs with background colors have no additional padding. _This is easy to add._
- [x] File block download buttons lose their white text, making them unreadable. _We should fix this._ 