### PR TITLE
Fixes margins on archive and search page-headers

### DIFF
--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -5,8 +5,7 @@
 	margin: $size__spacing-unit $size__spacing-unit calc(3 * #{$size__spacing-unit});
 
 	@include media(tablet) {
-		margin: 0 calc(2 * (100vw / 12)) $size__site-margins;
-		max-width: $size__site-tablet-content;
+		margin: 0 $size__site-margins $size__site-margins;
 	}
 
 	.page-title {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2339,7 +2339,7 @@ body.page .main-navigation {
   }
 }
 
-.entry .entry-content .page-links .post-page-numbers {
+.entry .entry-content .page-links a {
   margin: calc(0.5 * 1rem);
   text-decoration: none;
 }
@@ -2889,8 +2889,7 @@ body.page .main-navigation {
   .archive .page-header,
   .search .page-header,
   .error404 .page-header {
-    margin: 0 calc(2 * (100vw / 12)) calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
+    margin: 0 calc(10% + 60px) calc(10% + 60px);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2892,8 +2892,7 @@ body.page .main-navigation {
   .archive .page-header,
   .search .page-header,
   .error404 .page-header {
-    margin: 0 calc(2 * (100vw / 12)) calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
+    margin: 0 calc(10% + 60px) calc(10% + 60px);
   }
 }
 


### PR DESCRIPTION
With the new margin changes, archive page titles feel out of sync. This PR fixes that.

Before:
![image](https://user-images.githubusercontent.com/709581/48234660-7737c080-e388-11e8-8ac1-25640050e6b3.png)

After:
![image](https://user-images.githubusercontent.com/709581/48234677-8d458100-e388-11e8-95b0-ab10c996e441.png)
