### PR TITLE
Don’t escape translations

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -29,9 +29,9 @@ if ( post_password_required() ) {
 		<?php
 			if ( comments_open() ) {
 				if ( have_comments() ) {
-					esc_html_e( 'Join the Conversation', 'twentynineteen' );
+					_e( 'Join the Conversation', 'twentynineteen' );
 				} else {
-					esc_html_e( 'Leave a comment', 'twentynineteen' );
+					_e( 'Leave a comment', 'twentynineteen' );
 				}
 			} else {
 				$comments_number = get_comments_number();
@@ -102,9 +102,9 @@ if ( post_password_required() ) {
 		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
 			?>
 			<div class="comment-form-flex">
-				<span class="screen-reader-text"><?php esc_html_e( 'Leave a comment', 'twentynineteen' ); ?></span>
+				<span class="screen-reader-text"><?php _e( 'Leave a comment', 'twentynineteen' ); ?></span>
 				<?php twentynineteen_comment_form( 'asc' ); ?>
-				<h2 class="comments-title" aria-hidden="true"><?php esc_html_e( 'Leave a comment', 'twentynineteen' ); ?></h2>
+				<h2 class="comments-title" aria-hidden="true"><?php _e( 'Leave a comment', 'twentynineteen' ); ?></h2>
 			</div>
 			<?php
 		endif;
@@ -113,7 +113,7 @@ if ( post_password_required() ) {
 		if ( ! comments_open() ) :
 			?>
 			<p class="no-comments">
-				<?php esc_html_e( 'Comments are closed.', 'twentynineteen' ); ?>
+				<?php _e( 'Comments are closed.', 'twentynineteen' ); ?>
 			</p>
 			<?php
 		endif;

--- a/footer.php
+++ b/footer.php
@@ -25,7 +25,7 @@
 			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
 				<?php
 				/* translators: %s: WordPress. */
-				printf( esc_html__( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
+				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
 				?>
 			</a>
 			<?php

--- a/functions.php
+++ b/functions.php
@@ -56,7 +56,7 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(
-				'menu-1' => esc_html__( 'Primary', 'twentynineteen' ),
+				'menu-1' => __( 'Primary', 'twentynineteen' ),
 				'footer' => __( 'Footer Menu', 'twentynineteen' ),
 				'social' => __( 'Social Links Menu', 'twentynineteen' ),
 			)
@@ -112,7 +112,7 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 			'editor-color-palette',
 			array(
 				array(
-					'name'  => esc_html__( 'Primary Color', 'twentynineteen' ),
+					'name'  => __( 'Primary Color', 'twentynineteen' ),
 					'slug'  => 'primary',
 					'color' => twentynineteen_hsl_hex( 'default' === get_theme_mod( 'colorscheme' ) ? 199 : get_theme_mod( 'colorscheme_primary_hue', 199 ), 100, 33 ),
 				),

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'twentynineteen' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentynineteen' ); ?></a>
 
 		<header id="masthead" class="<?php echo is_singular() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header'; ?>">
 

--- a/image.php
+++ b/image.php
@@ -66,8 +66,8 @@ get_header();
 							$metadata = wp_get_attachment_metadata();
 							if ( $metadata ) {
 								printf(
-									'<span class="full-size-link"><span class="screen-reader-text">%1$s </span><a href="%2$s">%3$s &times; %4$s</a></span>',
-									esc_html_x( 'Full size', 'Used before full size attachment link.', 'twentynineteen' ),
+									'<span class="full-size-link"><span class="screen-reader-text">%1$s</span><a href="%2$s">%3$s &times; %4$s</a></span>',
+									_x( 'Full size', 'Used before full size attachment link.', 'twentynineteen' ),
 									esc_url( wp_get_attachment_url() ),
 									absint( $metadata['width'] ),
 									absint( $metadata['height'] )

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -71,25 +71,25 @@ add_filter( 'comment_form_defaults', 'twentynineteen_comment_form_defaults' );
  */
 function twentynineteen_get_the_archive_title() {
 	if ( is_category() ) {
-		$title = esc_html__( 'Category Archives: ', 'twentynineteen' ) . '<span class="page-description">' . single_term_title( '', false ) . '</span>';
+		$title = __( 'Category Archives: ', 'twentynineteen' ) . '<span class="page-description">' . single_term_title( '', false ) . '</span>';
 	} elseif ( is_tag() ) {
-		$title = esc_html__( 'Tag Archives: ', 'twentynineteen' ) . '<span class="page-description">' . single_term_title( '', false ) . '</span>';
+		$title = __( 'Tag Archives: ', 'twentynineteen' ) . '<span class="page-description">' . single_term_title( '', false ) . '</span>';
 	} elseif ( is_author() ) {
-		$title = esc_html__( 'Author Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_author_meta( 'display_name' ) . '</span>';
+		$title = __( 'Author Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_author_meta( 'display_name' ) . '</span>';
 	} elseif ( is_year() ) {
-		$title = esc_html__( 'Yearly Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_date( _x( 'Y', 'yearly archives date format', 'twentynineteen' ) ) . '</span>';
+		$title = __( 'Yearly Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_date( _x( 'Y', 'yearly archives date format', 'twentynineteen' ) ) . '</span>';
 	} elseif ( is_month() ) {
-		$title = esc_html__( 'Monthly Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_date( _x( 'F Y', 'monthly archives date format', 'twentynineteen' ) ) . '</span>';
+		$title = __( 'Monthly Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_date( _x( 'F Y', 'monthly archives date format', 'twentynineteen' ) ) . '</span>';
 	} elseif ( is_day() ) {
-		$title = esc_html__( 'Daily Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_date() . '</span>';
+		$title = __( 'Daily Archives: ', 'twentynineteen' ) . '<span class="page-description">' . get_the_date() . '</span>';
 	} elseif ( is_post_type_archive() ) {
-		$title = esc_html__( 'Post Type Archives: ', 'twentynineteen' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
+		$title = __( 'Post Type Archives: ', 'twentynineteen' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
 	} elseif ( is_tax() ) {
 		$tax = get_taxonomy( get_queried_object()->taxonomy );
 		/* translators: %s: Taxonomy singular name */
 		$title = sprintf( esc_html__( '%s Archives:', 'twentynineteen' ), $tax->labels->singular_name );
 	} else {
-		$title = esc_html__( 'Archives:', 'twentynineteen' );
+		$title = __( 'Archives:', 'twentynineteen' );
 	}
 	return $title;
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -43,7 +43,7 @@ if ( ! function_exists( 'twentynineteen_posted_by' ) ) :
 			'<span class="byline">%1$s<span class="screen-reader-text">%2$s</span><span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
 			/* translators: 1: SVG icon. 2: post author, only visible to screen readers. 3: author link. */
 			twentynineteen_get_icon_svg( 'person', 16 ),
-			esc_html__( 'Posted by', 'twentynineteen' ),
+			__( 'Posted by', 'twentynineteen' ),
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 			esc_html( get_the_author() )
 		);
@@ -83,25 +83,25 @@ if ( ! function_exists( 'twentynineteen_entry_footer' ) ) :
 			twentynineteen_posted_on();
 
 			/* translators: used between list items, there is a space after the comma. */
-			$categories_list = get_the_category_list( esc_html__( ', ', 'twentynineteen' ) );
+			$categories_list = get_the_category_list( __( ', ', 'twentynineteen' ) );
 			if ( $categories_list ) {
 				/* translators: 1: SVG icon. 2: posted in label, only visible to screen readers. 3: list of categories. */
 				printf(
 					'<span class="cat-links">%1$s<span class="screen-reader-text">%2$s</span>%3$s</span>',
 					twentynineteen_get_icon_svg( 'archive', 16 ),
-					esc_html__( 'Posted in', 'twentynineteen' ),
+					__( 'Posted in', 'twentynineteen' ),
 					$categories_list
 				); // WPCS: XSS OK.
 			}
 
 			/* translators: used between list items, there is a space after the comma. */
-			$tags_list = get_the_tag_list( '', esc_html__( ', ', 'twentynineteen' ) );
+			$tags_list = get_the_tag_list( '', __( ', ', 'twentynineteen' ) );
 			if ( $tags_list ) {
 				/* translators: 1: SVG icon. 2: posted in label, only visible to screen readers. 3: list of tags. */
 				printf(
 					'<span class="tags-links">%1$s<span class="screen-reader-text">%2$s </span>%3$s</span>',
 					twentynineteen_get_icon_svg( 'tag', 16 ),
-					esc_html__( 'Tags:', 'twentynineteen' ),
+					__( 'Tags:', 'twentynineteen' ),
 					$tags_list
 				); // WPCS: XSS OK.
 			}

--- a/search.php
+++ b/search.php
@@ -19,7 +19,7 @@ get_header();
 
 			<header class="page-header">
 				<h1 class="page-title">
-					<?php esc_html_e( 'Search results for:', 'twentynineteen' ); ?>
+					<?php _e( 'Search results for:', 'twentynineteen' ); ?>
 				</h1>
 				<div class="page-description"><?php echo get_search_query(); ?></div>
 			</header><!-- .page-header -->

--- a/template-parts/content/content-none.php
+++ b/template-parts/content/content-none.php
@@ -13,7 +13,7 @@
 
 <section class="no-results not-found">
 	<header class="page-header">
-		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'twentynineteen' ); ?></h1>
+		<h1 class="page-title"><?php _e( 'Nothing Found', 'twentynineteen' ); ?></h1>
 	</header><!-- .page-header -->
 
 	<div class="page-content">
@@ -36,14 +36,14 @@
 		elseif ( is_search() ) :
 			?>
 
-			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'twentynineteen' ); ?></p>
+			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'twentynineteen' ); ?></p>
 			<?php
 			get_search_form();
 
 		else :
 			?>
 
-			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'twentynineteen' ); ?></p>
+			<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'twentynineteen' ); ?></p>
 			<?php
 			get_search_form();
 

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -24,7 +24,7 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentynineteen' ),
+				'before' => '<div class="page-links">' . __( 'Pages:', 'twentynineteen' ),
 				'after'  => '</div>',
 			)
 		);

--- a/template-parts/content/content-single.php
+++ b/template-parts/content/content-single.php
@@ -37,7 +37,7 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentynineteen' ),
+				'before' => '<div class="page-links">' . __( 'Pages:', 'twentynineteen' ),
 				'after'  => '</div>',
 			)
 		);

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -46,7 +46,7 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'twentynineteen' ),
+				'before' => '<div class="page-links">' . __( 'Pages:', 'twentynineteen' ),
 				'after'  => '</div>',
 			)
 		);


### PR DESCRIPTION
The opposite of https://github.com/WordPress/twentynineteen/pull/285. If we aren't going to escape every translation, then I suppose we should essentially escape none (that hurts to say).

Removes `esc_html_e()`, `esc_html__()`, and `esc_html_x()` and replace with the non-escaping version.

I left one in use as it is also escaping a variable: https://github.com/WordPress/twentynineteen/blob/5e8fa546d5dacfa44fa33ccf152b556992bc53de/inc/template-functions.php#L90

Also removed a stray space in the markup in `image.php` that I came across.
_________


Just noting that I'm still quite opposed to this. Three reasons why I believe this is the wrong path (sorry, didn't know where else to post 🙂): 

1) Translation plugins are widely used and allow users to alter text strings from the admin. So you essentially have an admin setting that is then directly output on the frontend. In every other case, this would 100% need to be escaped.

2) Translations come from a separate and outside "database". I think the decision to not escape translations was made before the current translation system on wp.org. I'm not very experienced with it, but from what I know this could be an attack vector where the attacker only needs access to (or have their own) account that has permissions needed to approve translations. Only needs to happen once, and could have maximum impact in a theme like this.

3) It's much harder to add this escaping at a future date after release. If there were to be future reasons where we needed to go back and add escaping (perhaps the above 2 reasons or something else is revealed), then this is hard to do while keeping full backwards-compatibility. Inevitably some user somewhere is going to have HTML in a translation and will be upset when it stops working.

And lastly, to counter one of the counterpoints brought up in https://core.trac.wordpress.org/ticket/30724:

> That's simple. If we don't trust translations anymore we should do it directly in the function. `function __() { return esc_html(….`.

There are times where translations need to include html, seen recently in this project here https://github.com/WordPress/twentynineteen/pull/274. In these cases, you need `__()` as it is, and then `wp_kses()` around it to allow whichever tags you are using.