### PR TITLE
Update discussion meta

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -21,10 +21,11 @@ if ( post_password_required() ) {
 	return;
 }
 
+$discussion = twentynineteen_get_discussion_data();
 ?>
 
 <div id="comments" class="<?php echo comments_open() ? 'comments-area' : 'comments-area comments-closed'; ?>">
-	<div class="<?php echo twentynineteen_get_discussion_data()->responses > 0 ? 'comments-title-wrap' : 'comments-title-wrap no-responses'; ?>">
+	<div class="<?php echo $discussion->responses > 0 ? 'comments-title-wrap' : 'comments-title-wrap no-responses'; ?>">
 		<h2 class="comments-title">
 		<?php
 			if ( comments_open() ) {
@@ -34,8 +35,7 @@ if ( post_password_required() ) {
 					esc_html_e( 'Leave a comment', 'twentynineteen' );
 				}
 			} else {
-				$comments_number = get_comments_number();
-				if ( '1' === $comments_number ) {
+				if ( '1' == $discussion->responses ) {
 					/* translators: %s: post title */
 					printf( _x( 'One reply on &ldquo;%s&rdquo;', 'comments title', 'twentynineteen' ), get_the_title() );
 				} else {
@@ -44,11 +44,11 @@ if ( post_password_required() ) {
 						_nx(
 							'%1$s reply on &ldquo;%2$s&rdquo;',
 							'%1$s replies on &ldquo;%2$s&rdquo;',
-							$comments_number,
+							$discussion->responses,
 							'comments title',
 							'twentynineteen'
 						),
-						number_format_i18n( $comments_number ),
+						number_format_i18n( $discussion->responses ),
 						get_the_title()
 					);
 				}

--- a/header.php
+++ b/header.php
@@ -34,7 +34,7 @@
 					<?php twentynineteen_post_thumbnail(); ?>
 					<?php the_post(); ?>
 					<?php $discussion = ! is_page() && twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null; ?>
-					<div class="<?php echo ( ! empty( $discussion ) && count( $discussion->authors ) > 0 ) ? 'entry-header has-discussion' : 'entry-header'; ?>">
+					<div class="<?php echo ( ! empty( $discussion ) && count( $discussion->responses ) > 0 ) ? 'entry-header has-discussion' : 'entry-header'; ?>">
 						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 					</div><!-- .entry-header -->
 					<?php rewind_posts(); ?>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -144,6 +144,8 @@ function twentynineteen_get_discussion_data() {
 	$current_post_id = get_the_ID();
 	if ( $current_post_id === $post_id ) {
 		return $discussion; /* If we have discussion information for post ID, return cached object */
+	} else {
+		$post_id = $current_post_id;
 	}
 
 	$comments = get_comments(

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -163,8 +163,8 @@ function twentynineteen_get_discussion_data() {
 
 	$authors    = array_unique( $authors );
 	$discussion = (object) array(
-		'authors'    => array_slice( $authors, 0, 6 ),           /* Six unique authors commenting on the post. */
-		'responses'  => get_comments_number( $current_post_id ), /* Number of responses. */
+		'authors'   => array_slice( $authors, 0, 6 ),           /* Six unique authors commenting on the post. */
+		'responses' => get_comments_number( $current_post_id ), /* Number of responses. */
 	);
 
 	return $discussion;

--- a/template-parts/post/discussion-meta.php
+++ b/template-parts/post/discussion-meta.php
@@ -8,22 +8,12 @@
  */
 
 /* Get data from current discussion on post. */
-$discussion = twentynineteen_get_discussion_data();
-
-$comments_number = get_comments_number();
-$has_responses   = $discussion->responses > 0;
+$discussion    = twentynineteen_get_discussion_data();
+$has_responses = $discussion->responses > 0;
 
 if ( $has_responses ) {
-	/* translators: %1(X responses)$s from %2(X others)$s */
-	$meta_label = sprintf(
-		'%1$s from %2$s.',
-		sprintf( _n( '%d response', '%d responses', $discussion->responses, 'twentynineteen' ), $discussion->responses ),
-		sprintf( _n( '%d other', '%d others', $discussion->commenters, 'twentynineteen' ), $discussion->commenters )
-	);
-} elseif ( $comments_number > 0 ) {
-	/* Show comment count if not enough discussion information */
-
-	$meta_label = sprintf( _n( '%d Comment', '%d Comments', $comments_number, 'twentynineteen' ), $comments_number );
+	/* translators: %1(X comments)$s */
+	$meta_label = sprintf( _n( '%d Comment', '%d Comments', $discussion->responses, 'twentynineteen' ), $discussion->responses );
 } else {
 	$meta_label = __( 'No comments', 'twentynineteen' );
 }


### PR DESCRIPTION
Solves the issues raised in https://github.com/WordPress/twentynineteen/issues/238. Shows the full comment count and doesn't purposely exclude the current user's avatar.

Also solves what I believe was a bug introduced here: https://github.com/WordPress/twentynineteen/pull/367/files#diff-1cc0a2eb5e0be1a17d62b9ce5d17cf41R169

This is actually a big improvement from a scale standpoint. Running an unbounded query to get all the comments for the sole purpose of getting a count of unique commenters isn't worth it.

Some points that may need discussion:

1) I chose 20 comments in the query fairly randomly. We definitely don't want it to be unbounded, but welcome to any ideas / improvements. The goal is just a maximum of 6 unique authors.
2) Could use either the “%d responses” or “%d Comments” grammar. I went with the latter as it's purpose was for cases where there wasn't any $commenter data (though I'm fairly sure this was bugged and would have never worked as intended)