### PR TITLE
Fix additional issues with columns block.

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -16,7 +16,7 @@ body .wp-block[data-align="full"] {
   body {
     overflow-x: hidden;
   }
-  body .editor-block-list__layout,
+  body :not(.editor-inner-blocks) > .editor-block-list__layout,
   body .editor-post-title {
     padding-left: 0;
     padding-right: 0;
@@ -28,7 +28,7 @@ body .wp-block[data-align="full"] {
 }
 
 @media only screen and (min-width: 768px) {
-  body .editor-block-list__layout,
+  body :not(.editor-inner-blocks) > .editor-block-list__layout,
   body .editor-post-title {
     padding-left: 46px;
     padding-right: 46px;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -19,7 +19,7 @@ body {
 	@include media(mobile) {
 		overflow-x: hidden;
 
-		.editor-block-list__layout,
+		:not(.editor-inner-blocks) > .editor-block-list__layout, // Target only the top level layout element, or nested blocks will also be affected.
 		.editor-post-title {
 			padding-left: 0;
 			padding-right: 0;
@@ -33,7 +33,7 @@ body {
 
 	@include media(tablet) {
 
-		.editor-block-list__layout,
+		:not(.editor-inner-blocks) > .editor-block-list__layout, // Target only the top level layout element, or nested blocks will also be affected.
 		.editor-post-title {
 			padding-left: 46px;
 			padding-right: 46px;
@@ -82,6 +82,7 @@ body {
 		width: calc(6 * (100vw / 12 ));
 	}
 
+	// Only the top level blocks need specific widths, therefore override for every nested block.
 	.wp-block {
 		width: 100%;
 	}


### PR DESCRIPTION
The previous fix to nested blocks in general did not sufficiently address the cascading of properties. Recent refactors to the columns block in Gutenberg upstream made this visible.

This PR fixes those issues by increasing the specificity of a few of the rules that would also target any nested blocks.

Before:

![before](https://user-images.githubusercontent.com/1204802/48257595-3933ae80-e413-11e8-907b-a31ed6d1df94.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/48257607-3df86280-e413-11e8-92e3-1ec0a912a95c.gif)
