### PR TITLE
Fix comment area margins

### DIFF
--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -17,7 +17,6 @@
 
 	> * {
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
-
 		@include postContentMaxWidth();
 
 		@include media(tablet) {

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -15,15 +15,11 @@
 		margin-top: calc(3 * #{$size__spacing-unit});
 	}
 
-	.comment-list,
-	.comment-navigation,
-	> .comment-respond,
-	.comment-form-flex,
-	.no-comments {
+	> * {
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
 
 		@include postContentMaxWidth();
-		
+
 		@include media(tablet) {
 			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
 		}
@@ -31,14 +27,10 @@
 
 	.comments-title-wrap {
 
-		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
-
 		@include media(tablet) {
 			align-items: baseline;
 			display: flex;
 			justify-content: space-between;
-			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
-			max-width: $size__site-tablet-content;
 		}
 
 		.comments-title {
@@ -181,7 +173,7 @@
 
 	.comment-body {
 		margin: calc(2 * #{$size__spacing-unit}) 0 0;
-		
+
 		@include media(desktop) {
 			margin: calc(2 * #{$size__spacing-unit}) 0;
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2439,46 +2439,26 @@ body.page .main-navigation {
   margin-top: calc(3 * 1rem);
 }
 
-.comments-area .comment-list,
-.comments-area .comment-navigation,
-.comments-area > .comment-respond,
-.comments-area .comment-form-flex,
-.comments-area .no-comments {
+.comments-area > * {
   margin: calc(2 * 1rem) 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area .comment-list,
-  .comments-area .comment-navigation,
-  .comments-area > .comment-respond,
-  .comments-area .comment-form-flex,
-  .comments-area .no-comments {
+  .comments-area > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .comments-area .comment-list,
-  .comments-area .comment-navigation,
-  .comments-area > .comment-respond,
-  .comments-area .comment-form-flex,
-  .comments-area .no-comments {
+  .comments-area > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area .comment-list,
-  .comments-area .comment-navigation,
-  .comments-area > .comment-respond,
-  .comments-area .comment-form-flex,
-  .comments-area .no-comments {
+  .comments-area > * {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
-}
-
-.comments-area .comments-title-wrap {
-  margin: calc(2 * 1rem) 1rem;
 }
 
 @media only screen and (min-width: 768px) {
@@ -2486,8 +2466,6 @@ body.page .main-navigation {
     align-items: baseline;
     display: flex;
     justify-content: space-between;
-    margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2442,46 +2442,26 @@ body.page .main-navigation {
   margin-top: calc(3 * 1rem);
 }
 
-.comments-area .comment-list,
-.comments-area .comment-navigation,
-.comments-area > .comment-respond,
-.comments-area .comment-form-flex,
-.comments-area .no-comments {
+.comments-area > * {
   margin: calc(2 * 1rem) 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area .comment-list,
-  .comments-area .comment-navigation,
-  .comments-area > .comment-respond,
-  .comments-area .comment-form-flex,
-  .comments-area .no-comments {
+  .comments-area > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .comments-area .comment-list,
-  .comments-area .comment-navigation,
-  .comments-area > .comment-respond,
-  .comments-area .comment-form-flex,
-  .comments-area .no-comments {
+  .comments-area > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area .comment-list,
-  .comments-area .comment-navigation,
-  .comments-area > .comment-respond,
-  .comments-area .comment-form-flex,
-  .comments-area .no-comments {
+  .comments-area > * {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
-}
-
-.comments-area .comments-title-wrap {
-  margin: calc(2 * 1rem) 1rem;
 }
 
 @media only screen and (min-width: 768px) {
@@ -2489,8 +2469,6 @@ body.page .main-navigation {
     align-items: baseline;
     display: flex;
     justify-content: space-between;
-    margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 


### PR DESCRIPTION
Adds stricter margins to miscellaneous elements that may appear within the comments area. 

Plugins can sometimes use actions or filters to inject markup before or after modules in the comments area, and this PR makes sure they adopt the theme’s margins.

Screenshot: 
![image](https://user-images.githubusercontent.com/709581/48273250-7cd7e980-e40e-11e8-9d94-4bd14de0cf81.png)
