### PR TITLE
On small screens, move left/right margins to parent wrappers instead, minor comments area fixes.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -87,8 +87,7 @@ function twentynineteen_custom_colors_css() {
 		.entry .entry-footer a:hover,
 		.entry .entry-content .more-link:hover,
 		.main-navigation .main-menu > li > a + svg,
-		.comment-navigation .nav-previous a:hover,
-		.comment-navigation .nav-next a:hover,
+		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		#colophon .site-info a:hover,
 		.widget a,
@@ -104,6 +103,7 @@ function twentynineteen_custom_colors_css() {
 		 * Set left border color for:
 		 * wp block quote
 		 */
+		blockquote,
 		.entry .entry-content blockquote,
 		.entry .entry-content .wp-block-quote:not(.is-large),
 		.entry .entry-content .wp-block-quote:not(.is-style-large) {
@@ -145,6 +145,8 @@ function twentynineteen_custom_colors_css() {
 		.author-bio .author-description .author-link:hover,
 		.comment .comment-author .fn a:hover,
 		.comment-reply-link:hover,
+		.comment-navigation .nav-previous a:hover,
+		.comment-navigation .nav-next a:hover,
 		#cancel-comment-reply-link:hover,
 		.widget a:hover {
 			color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_hover . ' ); /* base: #005177; */

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -2,8 +2,8 @@
 
 .entry .entry-content > *,
 .entry .entry-summary > * {
-	margin: 32px $size__spacing-unit;
-	max-width: calc(100% - (2 * #{ $size__spacing-unit }));
+	margin: 32px 0;
+	max-width: 100%;
 
 	@include postContentMaxWidth();
 
@@ -44,8 +44,8 @@
 	&.alignfull {
 		position: relative;
 		left: -#{$size__spacing-unit };
-		width: 100%;
-		max-width: calc( 100vw + (2 * #{$size__spacing-unit}));
+		width: calc( 100% + (2 * #{$size__spacing-unit}));
+		max-width: calc( 100% + (2 * #{$size__spacing-unit}));
 
 		@include media(tablet) {
 			margin-top: calc(2 * #{$size__spacing-unit});
@@ -61,6 +61,9 @@
 		float: left;
 		max-width: calc(5 * (100vw / 12));
 		margin-top: 0;
+		margin-left: 0;
+		/*rtl:ignore*/
+		margin-right: $size__spacing-unit;
 
 		@include media(tablet) {
 			max-width: calc(4 * (100vw / 12));
@@ -80,7 +83,7 @@
 		margin-top: 0;
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
-		margin-right: $size__spacing-unit;
+		margin-right: 0;
 
 		@include media(tablet) {
 			max-width: calc(4 * (100vw / 12));
@@ -380,7 +383,7 @@
 
 		&.is-large,
 		&.is-style-large {
-			margin: $size__spacing-unit;
+			margin: $size__spacing-unit 0;
 			padding: 0;
 			border-left: none;
 

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -4,12 +4,12 @@
 .post-navigation {
 
 	margin: calc(3 * 1rem) 0;
-	
+
 	@include media(tablet) {
 		margin: calc(3 * 1rem) $size__site-margins;
 		max-width: calc(6 * (100vw / 12));
 	}
-	
+
 	@include media(desktop) {
 		margin: calc(3 * 1rem) 0;
 		max-width: 100%;
@@ -21,7 +21,7 @@
 		max-width: 100%;
 		display: flex;
 		flex-direction: column;
-		
+
 		@include media(tablet) {
 			margin: 0;
 		}
@@ -155,12 +155,6 @@
 	.nav-links {
 		display: flex;
 		flex-direction: row;
-		margin: 0 $size__spacing-unit;
-
-		@include media(desktop) {
-			margin: 0 $size__site-margins;
-			max-width: $size__site-tablet-content;
-		}
 	}
 
 	.nav-previous,
@@ -183,13 +177,6 @@
 			position: relative;
 			margin: 0 -0.35em;
 			top: -1px;
-		}
-
-		a {
-
-			&:hover {
-				color: $color__link;
-			}
 		}
 	}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -178,16 +178,12 @@
 
 	.comment-meta {
 		position: relative;
-
-		@include media(tablet) {
-			display: flex;
-		}
 	}
 
 	.comment-author {
 
 		@include media(tablet) {
-			flex: 0 0 auto;
+			display: inline-block;
 			vertical-align: baseline;
 		}
 
@@ -250,7 +246,7 @@
 	.comment-metadata {
 
 		@include media(tablet) {
-			flex: 1 0 auto;
+			display: inline;
 			margin-left: $size__spacing-unit;
 			position: relative;
 			vertical-align: baseline;
@@ -259,7 +255,7 @@
 
 		> a,
 		.comment-edit-link {
-			display: inline-block;
+			display: inline;
 			font-weight: 500;
 			color: $color__text-light;
 			vertical-align: baseline;

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -166,12 +166,15 @@
 	position: relative;
 
 	@include media(tablet) {
-		margin-left: calc(3.25 * #{$size__spacing-unit});
 		padding-left: calc(.5 * (#{$size__spacing-unit} + calc(100vw / 12 )));
 
 		&.depth-1,
 		.children {
 			padding-left: 0;
+		}
+
+		&.depth-1 {
+			margin-left: calc(3.25 * #{$size__spacing-unit});
 		}
 	}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -14,6 +14,16 @@
 		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
 	}
 
+	& > * {
+		margin-top: calc(2 * #{$size__spacing-unit});
+		margin-bottom: calc(2 * #{$size__spacing-unit});
+
+		@include media(tablet) {
+			margin-top: calc(3 * #{$size__spacing-unit});
+			margin-bottom: calc(3 * #{$size__spacing-unit});
+		}
+	}
+
 	/* Add extra margin when the comments section is located immediately after the
 	 * post itself (this happens on pages).
 	 */
@@ -112,7 +122,8 @@
 		margin-top: 0;
 	}
 
-	.pingback {
+	.pingback,
+	.trackback {
 
 		.comment-body {
 			color: $color__text-light;
@@ -160,8 +171,10 @@
 	position: relative;
 
 	@include media(tablet) {
+
 		padding-left: calc(.5 * (#{$size__spacing-unit} + calc(100vw / 12 )));
 
+		&.depth-1,
 		.children {
 			padding-left: 0;
 		}
@@ -265,7 +278,7 @@
 			}
 
 			&:hover {
-				color: $color__text-hover;
+				color: $color__link-hover;
 				text-decoration: none;
 			}
 		}
@@ -316,6 +329,10 @@
 
 		> *:last-child {
 			margin-bottom: 0;
+		}
+
+		blockquote {
+			margin-left: 0;
 		}
 
 		a {

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -130,6 +130,7 @@
 			font-family: $font__heading;
 			font-size: $font__size-xs;
 			font-weight: 500;
+			margin-top: $size__spacing-unit;
 			margin-bottom: $size__spacing-unit;
 
 			a:not(.comment-edit-link) {
@@ -150,12 +151,6 @@
 }
 
 .comment-reply {
-
-	@include media(desktop) {
-		left: 100%;
-		bottom: 0;
-		position: absolute;
-	}
 
 	#respond + & {
 		display: none;
@@ -182,10 +177,6 @@
 
 	.comment-body {
 		margin: calc(2 * #{$size__spacing-unit}) 0 0;
-
-		@include media(desktop) {
-			margin: calc(2 * #{$size__spacing-unit}) 0;
-		}
 	}
 
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -166,7 +166,7 @@
 	position: relative;
 
 	@include media(tablet) {
-
+		margin-left: calc(3.25 * #{$size__spacing-unit});
 		padding-left: calc(.5 * (#{$size__spacing-unit} + calc(100vw / 12 )));
 
 		&.depth-1,
@@ -186,11 +186,6 @@
 
 	.comment-author {
 
-		@include media(tablet) {
-			display: inline-block;
-			vertical-align: baseline;
-		}
-
 		.avatar {
 			float: left;
 			margin-right: $size__spacing-unit;
@@ -208,11 +203,6 @@
 		.fn {
 			position: relative;
 			display: block;
-
-			@include media(tablet) {
-				display: inline-block;
-				vertical-align: baseline;
-			}
 
 			a {
 				color: inherit;
@@ -248,14 +238,6 @@
 	}
 
 	.comment-metadata {
-
-		@include media(tablet) {
-			display: inline;
-			margin-left: $size__spacing-unit;
-			position: relative;
-			vertical-align: baseline;
-			line-height: 2.25;
-		}
 
 		> a,
 		.comment-edit-link {

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -7,21 +7,18 @@
 }
 
 .comments-area {
+	margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
+	@include postContentMaxWidth();
+
+	@include media(tablet) {
+		margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
+	}
 
 	/* Add extra margin when the comments section is located immediately after the
 	 * post itself (this happens on pages).
 	 */
 	.entry + & {
 		margin-top: calc(3 * #{$size__spacing-unit});
-	}
-
-	> * {
-		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
-		@include postContentMaxWidth();
-
-		@include media(tablet) {
-			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
-		}
 	}
 
 	.comments-title-wrap {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -177,6 +177,8 @@
 
 	.entry-content,
 	.entry-summary {
+		max-width: calc(100% - (2 * #{ $size__spacing-unit }));
+		margin: 0 $size__spacing-unit;
 
 		@include media(tablet) {
 			max-width: 80%;
@@ -218,11 +220,10 @@
 		// Overwrite iframe embeds that have inline styles.
 		> iframe[style] {
 
-			margin: 32px $size__spacing-unit !important;
-			max-width: calc(100vw - (2 * #{ $size__spacing-unit })) !important;
+			margin: 32px 0 !important;
+			max-width: 100% !important;
 
 			@include media(tablet) {
-				margin: 32px 0 !important;
 				max-width: $size__site-tablet-content !important;
 			}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3494,7 +3494,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
-  margin: 1rem;
+  margin: 1rem 0;
   padding: 0;
   border-right: none;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2565,6 +2565,7 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.71111em;
   font-weight: 500;
+  margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
@@ -2599,6 +2600,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comment {
+    margin-right: calc(3.25 * 1rem);
     padding-right: calc(.5 * (1rem + calc(100vw / 12 )));
   }
   .comment.depth-1,
@@ -2613,13 +2615,6 @@ body.page .main-navigation {
 
 .comment .comment-meta {
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-author {
-    display: inline-block;
-    vertical-align: baseline;
-  }
 }
 
 .comment .comment-author .avatar {
@@ -2641,13 +2636,6 @@ body.page .main-navigation {
 .comment .comment-author .fn {
   position: relative;
   display: block;
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-author .fn {
-    display: inline-block;
-    vertical-align: baseline;
-  }
 }
 
 .comment .comment-author .fn a {
@@ -2681,16 +2669,6 @@ body.page .main-navigation {
   display: block;
   fill: white;
   transform: scale(0.875);
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-metadata {
-    display: inline;
-    margin-right: 1rem;
-    position: relative;
-    vertical-align: baseline;
-    line-height: 2.25;
-  }
 }
 
 .comment .comment-metadata > a,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2284,6 +2284,12 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content,
+.entry .entry-summary {
+  max-width: calc(100% - (2 * 1rem));
+  margin: 0 1rem;
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content,
   .entry .entry-summary {
@@ -2322,13 +2328,12 @@ body.page .main-navigation {
 }
 
 .entry .entry-content > iframe[style] {
-  margin: 32px 1rem !important;
-  max-width: calc(100vw - (2 * 1rem)) !important;
+  margin: 32px 0 !important;
+  max-width: 100% !important;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    margin: 32px 0 !important;
     max-width: calc(8 * (100vw / 12) - 28px) !important;
   }
 }
@@ -3073,8 +3078,8 @@ body.page .main-navigation {
 /* !Block styles */
 .entry .entry-content > *,
 .entry .entry-summary > * {
-  margin: 32px 1rem;
-  max-width: calc(100% - (2 * 1rem));
+  margin: 32px 0;
+  max-width: 100%;
   /*
 	// Set top margins for headings
 	& + h1:before,
@@ -3137,8 +3142,8 @@ body.page .main-navigation {
 .entry .entry-summary > *.alignfull {
   position: relative;
   right: -1rem;
-  width: 100%;
-  max-width: calc( 100vw + (2 * 1rem));
+  width: calc( 100% + (2 * 1rem));
+  max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
@@ -3157,6 +3162,8 @@ body.page .main-navigation {
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
+  margin-right: 0;
+  margin-right: 1rem;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3180,7 +3187,7 @@ body.page .main-navigation {
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
   margin-left: 1rem;
-  margin-left: 1rem;
+  margin-left: 0;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2627,14 +2627,8 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .comment .comment-meta {
-    display: flex;
-  }
-}
-
-@media only screen and (min-width: 768px) {
   .comment .comment-author {
-    flex: 0 0 auto;
+    display: inline-block;
     vertical-align: baseline;
   }
 }
@@ -2702,7 +2696,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comment .comment-metadata {
-    flex: 1 0 auto;
+    display: inline;
     margin-right: 1rem;
     position: relative;
     vertical-align: baseline;
@@ -2712,7 +2706,7 @@ body.page .main-navigation {
 
 .comment .comment-metadata > a,
 .comment .comment-metadata .comment-edit-link {
-  display: inline-block;
+  display: inline;
   font-weight: 500;
   color: #767676;
   vertical-align: baseline;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1493,14 +1493,6 @@ body.page .main-navigation {
 .comment-navigation .nav-links {
   display: flex;
   flex-direction: row;
-  margin: 0 1rem;
-}
-
-@media only screen and (min-width: 1168px) {
-  .comment-navigation .nav-links {
-    margin: 0 calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
 }
 
 .comment-navigation .nav-previous,
@@ -1529,11 +1521,6 @@ body.page .main-navigation {
   position: relative;
   margin: 0 -0.35em;
   top: -1px;
-}
-
-.comment-navigation .nav-previous a:hover,
-.comment-navigation .nav-next a:hover {
-  color: #0073aa;
 }
 
 .comment-navigation .nav-next {
@@ -2459,6 +2446,18 @@ body.page .main-navigation {
   }
 }
 
+.comments-area > * {
+  margin-top: calc(2 * 1rem);
+  margin-bottom: calc(2 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area > * {
+    margin-top: calc(3 * 1rem);
+    margin-bottom: calc(3 * 1rem);
+  }
+}
+
 .entry + .comments-area {
   margin-top: calc(3 * 1rem);
 }
@@ -2560,7 +2559,8 @@ body.page .main-navigation {
   margin-top: 0;
 }
 
-.comment-list .pingback .comment-body {
+.comment-list .pingback .comment-body,
+.comment-list .trackback .comment-body {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.71111em;
@@ -2568,7 +2568,8 @@ body.page .main-navigation {
   margin-bottom: 1rem;
 }
 
-.comment-list .pingback .comment-body a:not(.comment-edit-link) {
+.comment-list .pingback .comment-body a:not(.comment-edit-link),
+.comment-list .trackback .comment-body a:not(.comment-edit-link) {
   font-weight: bold;
   font-size: 19.55556px;
   line-height: 1.5;
@@ -2576,7 +2577,8 @@ body.page .main-navigation {
   display: block;
 }
 
-.comment-list .pingback .comment-body .comment-edit-link {
+.comment-list .pingback .comment-body .comment-edit-link,
+.comment-list .trackback .comment-body .comment-edit-link {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 500;
@@ -2607,6 +2609,7 @@ body.page .main-navigation {
   .comment {
     padding-right: calc(.5 * (1rem + calc(100vw / 12 )));
   }
+  .comment.depth-1,
   .comment .children {
     padding-right: 0;
   }
@@ -2770,6 +2773,10 @@ body.page .main-navigation {
 
 .comment .comment-content > *:last-child {
   margin-bottom: 0;
+}
+
+.comment .comment-content blockquote {
+  margin-right: 0;
 }
 
 .comment .comment-content a {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2435,35 +2435,32 @@ body.page .main-navigation {
 }
 
 .comments-area {
+  margin: calc(2 * 1rem) 1rem;
   /* Add extra margin when the comments section is located immediately after the
 	 * post itself (this happens on pages).
 	 */
 }
 
-.entry + .comments-area {
-  margin-top: calc(3 * 1rem);
-}
-
-.comments-area > * {
-  margin: calc(2 * 1rem) 1rem;
-}
-
 @media only screen and (min-width: 768px) {
-  .comments-area > * {
+  .comments-area {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .comments-area > * {
+  .comments-area {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area > * {
+  .comments-area {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
+}
+
+.entry + .comments-area {
+  margin-top: calc(3 * 1rem);
 }
 
 @media only screen and (min-width: 768px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2584,14 +2584,6 @@ body.page .main-navigation {
   font-weight: 500;
 }
 
-@media only screen and (min-width: 1168px) {
-  .comment-reply {
-    right: 100%;
-    bottom: 0;
-    position: absolute;
-  }
-}
-
 #respond + .comment-reply {
   display: none;
 }
@@ -2617,12 +2609,6 @@ body.page .main-navigation {
 
 .comment .comment-body {
   margin: calc(2 * 1rem) 0 0;
-}
-
-@media only screen and (min-width: 1168px) {
-  .comment .comment-body {
-    margin: calc(2 * 1rem) 0;
-  }
 }
 
 .comment .comment-meta {
@@ -2722,7 +2708,7 @@ body.page .main-navigation {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #4a4a4a;
+  color: #005177;
   text-decoration: none;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2600,12 +2600,14 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comment {
-    margin-right: calc(3.25 * 1rem);
     padding-right: calc(.5 * (1rem + calc(100vw / 12 )));
   }
   .comment.depth-1,
   .comment .children {
     padding-right: 0;
+  }
+  .comment.depth-1 {
+    margin-right: calc(3.25 * 1rem);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2438,35 +2438,32 @@ body.page .main-navigation {
 }
 
 .comments-area {
+  margin: calc(2 * 1rem) 1rem;
   /* Add extra margin when the comments section is located immediately after the
 	 * post itself (this happens on pages).
 	 */
 }
 
-.entry + .comments-area {
-  margin-top: calc(3 * 1rem);
-}
-
-.comments-area > * {
-  margin: calc(2 * 1rem) 1rem;
-}
-
 @media only screen and (min-width: 768px) {
-  .comments-area > * {
+  .comments-area {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .comments-area > * {
+  .comments-area {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .comments-area > * {
+  .comments-area {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
+}
+
+.entry + .comments-area {
+  margin-top: calc(3 * 1rem);
 }
 
 @media only screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -1493,14 +1493,6 @@ body.page .main-navigation {
 .comment-navigation .nav-links {
   display: flex;
   flex-direction: row;
-  margin: 0 1rem;
-}
-
-@media only screen and (min-width: 1168px) {
-  .comment-navigation .nav-links {
-    margin: 0 calc(10% + 60px);
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
 }
 
 .comment-navigation .nav-previous,
@@ -1529,11 +1521,6 @@ body.page .main-navigation {
   position: relative;
   margin: 0 -0.35em;
   top: -1px;
-}
-
-.comment-navigation .nav-previous a:hover,
-.comment-navigation .nav-next a:hover {
-  color: #0073aa;
 }
 
 .comment-navigation .nav-next {
@@ -2462,6 +2449,18 @@ body.page .main-navigation {
   }
 }
 
+.comments-area > * {
+  margin-top: calc(2 * 1rem);
+  margin-bottom: calc(2 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area > * {
+    margin-top: calc(3 * 1rem);
+    margin-bottom: calc(3 * 1rem);
+  }
+}
+
 .entry + .comments-area {
   margin-top: calc(3 * 1rem);
 }
@@ -2563,7 +2562,8 @@ body.page .main-navigation {
   margin-top: 0;
 }
 
-.comment-list .pingback .comment-body {
+.comment-list .pingback .comment-body,
+.comment-list .trackback .comment-body {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.71111em;
@@ -2571,7 +2571,8 @@ body.page .main-navigation {
   margin-bottom: 1rem;
 }
 
-.comment-list .pingback .comment-body a:not(.comment-edit-link) {
+.comment-list .pingback .comment-body a:not(.comment-edit-link),
+.comment-list .trackback .comment-body a:not(.comment-edit-link) {
   font-weight: bold;
   font-size: 19.55556px;
   line-height: 1.5;
@@ -2579,7 +2580,8 @@ body.page .main-navigation {
   display: block;
 }
 
-.comment-list .pingback .comment-body .comment-edit-link {
+.comment-list .pingback .comment-body .comment-edit-link,
+.comment-list .trackback .comment-body .comment-edit-link {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 500;
@@ -2610,6 +2612,7 @@ body.page .main-navigation {
   .comment {
     padding-left: calc(.5 * (1rem + calc(100vw / 12 )));
   }
+  .comment.depth-1,
   .comment .children {
     padding-left: 0;
   }
@@ -2722,7 +2725,7 @@ body.page .main-navigation {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #4a4a4a;
+  color: #005177;
   text-decoration: none;
 }
 
@@ -2773,6 +2776,10 @@ body.page .main-navigation {
 
 .comment .comment-content > *:last-child {
   margin-bottom: 0;
+}
+
+.comment .comment-content blockquote {
+  margin-left: 0;
 }
 
 .comment .comment-content a {

--- a/style.css
+++ b/style.css
@@ -2568,6 +2568,7 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.71111em;
   font-weight: 500;
+  margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
@@ -2585,14 +2586,6 @@ body.page .main-navigation {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 500;
-}
-
-@media only screen and (min-width: 1168px) {
-  .comment-reply {
-    left: 100%;
-    bottom: 0;
-    position: absolute;
-  }
 }
 
 #respond + .comment-reply {
@@ -2620,12 +2613,6 @@ body.page .main-navigation {
 
 .comment .comment-body {
   margin: calc(2 * 1rem) 0 0;
-}
-
-@media only screen and (min-width: 1168px) {
-  .comment .comment-body {
-    margin: calc(2 * 1rem) 0;
-  }
 }
 
 .comment .comment-meta {

--- a/style.css
+++ b/style.css
@@ -2603,12 +2603,14 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comment {
-    margin-left: calc(3.25 * 1rem);
     padding-left: calc(.5 * (1rem + calc(100vw / 12 )));
   }
   .comment.depth-1,
   .comment .children {
     padding-left: 0;
+  }
+  .comment.depth-1 {
+    margin-left: calc(3.25 * 1rem);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2630,14 +2630,8 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .comment .comment-meta {
-    display: flex;
-  }
-}
-
-@media only screen and (min-width: 768px) {
   .comment .comment-author {
-    flex: 0 0 auto;
+    display: inline-block;
     vertical-align: baseline;
   }
 }
@@ -2705,7 +2699,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comment .comment-metadata {
-    flex: 1 0 auto;
+    display: inline;
     margin-left: 1rem;
     position: relative;
     vertical-align: baseline;
@@ -2715,7 +2709,7 @@ body.page .main-navigation {
 
 .comment .comment-metadata > a,
 .comment .comment-metadata .comment-edit-link {
-  display: inline-block;
+  display: inline;
   font-weight: 500;
   color: #767676;
   vertical-align: baseline;

--- a/style.css
+++ b/style.css
@@ -2603,6 +2603,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comment {
+    margin-left: calc(3.25 * 1rem);
     padding-left: calc(.5 * (1rem + calc(100vw / 12 )));
   }
   .comment.depth-1,
@@ -2617,13 +2618,6 @@ body.page .main-navigation {
 
 .comment .comment-meta {
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-author {
-    display: inline-block;
-    vertical-align: baseline;
-  }
 }
 
 .comment .comment-author .avatar {
@@ -2645,13 +2639,6 @@ body.page .main-navigation {
 .comment .comment-author .fn {
   position: relative;
   display: block;
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-author .fn {
-    display: inline-block;
-    vertical-align: baseline;
-  }
 }
 
 .comment .comment-author .fn a {
@@ -2685,16 +2672,6 @@ body.page .main-navigation {
   display: block;
   fill: white;
   transform: scale(0.875);
-}
-
-@media only screen and (min-width: 768px) {
-  .comment .comment-metadata {
-    display: inline;
-    margin-left: 1rem;
-    position: relative;
-    vertical-align: baseline;
-    line-height: 2.25;
-  }
 }
 
 .comment .comment-metadata > a,

--- a/style.css
+++ b/style.css
@@ -2287,6 +2287,12 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content,
+.entry .entry-summary {
+  max-width: calc(100% - (2 * 1rem));
+  margin: 0 1rem;
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content,
   .entry .entry-summary {
@@ -2325,13 +2331,12 @@ body.page .main-navigation {
 }
 
 .entry .entry-content > iframe[style] {
-  margin: 32px 1rem !important;
-  max-width: calc(100vw - (2 * 1rem)) !important;
+  margin: 32px 0 !important;
+  max-width: 100% !important;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    margin: 32px 0 !important;
     max-width: calc(8 * (100vw / 12) - 28px) !important;
   }
 }
@@ -3076,8 +3081,8 @@ body.page .main-navigation {
 /* !Block styles */
 .entry .entry-content > *,
 .entry .entry-summary > * {
-  margin: 32px 1rem;
-  max-width: calc(100% - (2 * 1rem));
+  margin: 32px 0;
+  max-width: 100%;
   /*
 	// Set top margins for headings
 	& + h1:before,
@@ -3140,8 +3145,8 @@ body.page .main-navigation {
 .entry .entry-summary > *.alignfull {
   position: relative;
   left: -1rem;
-  width: 100%;
-  max-width: calc( 100vw + (2 * 1rem));
+  width: calc( 100% + (2 * 1rem));
+  max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
@@ -3161,6 +3166,9 @@ body.page .main-navigation {
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
+  margin-left: 0;
+  /*rtl:ignore*/
+  margin-right: 1rem;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3187,7 +3195,7 @@ body.page .main-navigation {
   margin-top: 0;
   /*rtl:ignore*/
   margin-left: 1rem;
-  margin-right: 1rem;
+  margin-right: 0;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3495,7 +3503,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
-  margin: 1rem;
+  margin: 1rem 0;
   padding: 0;
   border-left: none;
 }


### PR DESCRIPTION
A counterpart to the recent margins updates in #502. Fixes the issue reported in #460. 

Should generally have no effect on the visual appearance of default theme elements. But this will make sure that when a plugin adds an element to entry-content, the element has the correct `1rem` left/right margins on smaller screens. 

This also applies the same treatment to our `comment-area` children, instead of styling them each individually using a `*` rule.

Example with Jetpack related posts: 

**Before:**
<img width="429" alt="screen shot 2018-11-09 at 1 21 56 pm" src="https://user-images.githubusercontent.com/1202812/48280801-ac90ec80-e422-11e8-9d2a-651b1fb55c97.png">

**After:**
<img width="429" alt="screen shot 2018-11-09 at 1 21 45 pm" src="https://user-images.githubusercontent.com/1202812/48280806-b0247380-e422-11e8-837f-cbc145277ce4.png">
