### PR TITLE
Update widgets to use sans-serif fonts for all list-style widgets

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -208,19 +208,32 @@
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
 			line-height: $font__line-height-heading;
+			padding-bottom: ( .75 * $size__spacing-unit );
 
-			&:not(.menu-item-has-children) {
-				padding-bottom: ( .75 * $size__spacing-unit );
+			&.menu-item-has-children,
+			&:last-child {
+				padding-bottom: 0;
 			}
 
 			a {
 				text-decoration: none;
 			}
-
-			ul {
-				padding-left: $size__spacing-unit;
-			}
 		}
+	}
+
+	//! Latest categories
+	.wp-block-categories {
+
+		ul {
+			padding-top: ( .75 * $size__spacing-unit );
+		}
+		
+		li ul {
+			list-style: none;
+			padding-left: 0;
+		}
+
+		@include nestedSubMenuPadding();
 	}
 
 	//! Latest posts grid view

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -187,4 +187,40 @@
 	}
 }
 
+/* Nested sub-menu padding: 10 levels deep */
+@mixin nestedSubMenuPadding() {
+
+	ul li > a:before {
+		font-family: $font__body;
+		font-weight: normal;
+	}
+	ul > li > a:before {
+		content: "\2013\00a0";
+	}
+	ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0";
+	}
+	ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+}
+
 @import "utilities";

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -17,11 +17,11 @@
 
 .widget_archive,
 .widget_categories,
-.widget_nav_menu,
 .widget_meta,
+.widget_nav_menu,
 .widget_pages,
-.widget_recent_entries,
 .widget_recent_comments,
+.widget_recent_entries,
 .widget_rss {
 
 	ul {

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -16,9 +16,12 @@
 }
 
 .widget_archive,
+.widget_categories,
 .widget_nav_menu,
 .widget_meta,
+.widget_pages,
 .widget_recent_entries,
+.widget_recent_comments,
 .widget_rss {
 
 	ul {
@@ -29,26 +32,58 @@
 			color: $color__text-light;
 			font-family: $font__heading;
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
-			font-weight: bold;
+			font-weight: 700;
 			line-height: $font__line-height-heading;
-
-			&:not(.menu-item-has-children) {
-				padding-bottom: ( .75 * $size__spacing-unit );
-			}
-
-			ul {
-				padding-left: $size__spacing-unit;
-			}
+			margin-top: #{0.5 * $size__spacing-unit};
+			margin-bottom: #{0.5 * $size__spacing-unit};
 		}
 
-		&.sub-menu {
-			padding-top: ( .75 * $size__spacing-unit );
+		/* Nested sub-menu padding: 10 levels deep */
+		ul li > a:before {
+			font-family: $font__body;
+			font-weight: normal;
+		}
+		ul > li > a:before {
+			content: "\2013\00a0";
+		}
+		ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0";
+		}
+		ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0";
+		}
+		ul ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+		}
+		ul ul ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+		}
+		ul ul ul ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+		}
+		ul ul ul ul ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+		}
+		ul ul ul ul ul ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+		}
+		ul ul ul ul ul ul ul ul ul li > a:before {
+			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 		}
 	}
 }
 
+.widget_tag_cloud {
+
+	.tagcloud {
+		font-family: $font__heading;
+		font-weight: 700;
+	}
+}
+
+
 .widget_search {
-	
+
 	.search-submit {
 		display: block;
 		margin-top: $size__spacing-unit;
@@ -59,11 +94,11 @@
 	text-align: center;
 	font-family: $font__heading;
 
-	table td, 
+	table td,
 	table th {
 		border: none;
 	}
-	
+
 	a {
 		text-decoration: underline;
 	}

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -38,38 +38,7 @@
 			margin-bottom: #{0.5 * $size__spacing-unit};
 		}
 
-		/* Nested sub-menu padding: 10 levels deep */
-		ul li > a:before {
-			font-family: $font__body;
-			font-weight: normal;
-		}
-		ul > li > a:before {
-			content: "\2013\00a0";
-		}
-		ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0";
-		}
-		ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0";
-		}
-		ul ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		ul ul ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		ul ul ul ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		ul ul ul ul ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		ul ul ul ul ul ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		ul ul ul ul ul ul ul ul ul li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
+		@include nestedSubMenuPadding();
 	}
 }
 

--- a/style-editor-customizer.css
+++ b/style-editor-customizer.css
@@ -9,6 +9,7 @@ NOTE: This file is automatically populated with additional styles if the user se
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Fallback for non-latin fonts */
 /* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
 /** === Non-Latin font fallbacks === */
 /* Arabic */
 html[lang="ar"] .wp-block *,

--- a/style-editor.css
+++ b/style-editor.css
@@ -7,6 +7,7 @@ Twenty Nineteen Editor Styles
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Fallback for non-latin fonts */
 /* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
 /* 
  * Chrome renders extra-wide &nbsp; characters for the Hoefler Text font. 
  * This results in a jumping cursor when typing in both the Classic and block 
@@ -528,12 +529,15 @@ ul.wp-block-archives li,
   font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
+  padding-bottom: 0.75rem;
 }
 
-ul.wp-block-archives li:not(.menu-item-has-children),
-.wp-block-categories li:not(.menu-item-has-children),
-.wp-block-latest-posts li:not(.menu-item-has-children) {
-  padding-bottom: 0.75rem;
+ul.wp-block-archives li.menu-item-has-children, ul.wp-block-archives li:last-child,
+.wp-block-categories li.menu-item-has-children,
+.wp-block-categories li:last-child,
+.wp-block-latest-posts li.menu-item-has-children,
+.wp-block-latest-posts li:last-child {
+  padding-bottom: 0;
 }
 
 ul.wp-block-archives li a,
@@ -546,6 +550,57 @@ ul.wp-block-archives li ul,
 .wp-block-categories li ul,
 .wp-block-latest-posts li ul {
   padding-left: 1rem;
+}
+
+.wp-block-categories ul {
+  padding-top: 0.75rem;
+}
+
+.wp-block-categories ul ul li > a:before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+}
+
+.wp-block-categories ul ul > li > a:before {
+  content: "\2013\00a0";
+}
+
+.wp-block-categories ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories ul ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.wp-block-categories li ul {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: -0.75rem;
 }
 
 /** === Latest Posts grid view === */

--- a/style-editor.css
+++ b/style-editor.css
@@ -8,11 +8,11 @@ Twenty Nineteen Editor Styles
 /* Fallback for non-latin fonts */
 /* Calculates maximum width for post content */
 /* Nested sub-menu padding: 10 levels deep */
-/* 
- * Chrome renders extra-wide &nbsp; characters for the Hoefler Text font. 
- * This results in a jumping cursor when typing in both the Classic and block 
- * editors. The following font-face override fixes the issue by manually inserting 
- * a custom font that includes just a Hoefler Text space replacement for that 
+/*
+ * Chrome renders extra-wide &nbsp; characters for the Hoefler Text font.
+ * This results in a jumping cursor when typing in both the Classic and block
+ * editors. The following font-face override fixes the issue by manually inserting
+ * a custom font that includes just a Hoefler Text space replacement for that
  * character instead.
  */
 @font-face {
@@ -525,6 +525,7 @@ ul.wp-block-archives ul,
 ul.wp-block-archives li,
 .wp-block-categories li,
 .wp-block-latest-posts li {
+  color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
   font-weight: bold;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -548,9 +548,11 @@ ul.wp-block-archives,
 		font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 		font-weight: bold;
 		line-height: $font__line-height-heading;
+		padding-bottom: ( .75 * $size__spacing-unit );
 
-		&:not(.menu-item-has-children) {
-			padding-bottom: ( .75 * $size__spacing-unit );
+		&.menu-item-has-children,
+		&:last-child {
+			padding-bottom: 0;
 		}
 
 		a {
@@ -561,6 +563,21 @@ ul.wp-block-archives,
 			padding-left: $size__spacing-unit;
 		}
 	}
+}
+
+.wp-block-categories {
+
+	ul {
+		padding-top: ( .75 * $size__spacing-unit );
+		@include nestedSubMenuPadding();
+	}
+	
+	li ul {
+		list-style: none;
+		padding-left: 0;
+		margin-bottom: ( -.75 * $size__spacing-unit );
+	}
+
 }
 
 /** === Latest Posts grid view === */

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -8,11 +8,11 @@ Twenty Nineteen Editor Styles
 @import "sass/variables-site/colors";
 @import "sass/mixins/mixins-master";
 
-/* 
- * Chrome renders extra-wide &nbsp; characters for the Hoefler Text font. 
- * This results in a jumping cursor when typing in both the Classic and block 
- * editors. The following font-face override fixes the issue by manually inserting 
- * a custom font that includes just a Hoefler Text space replacement for that 
+/*
+ * Chrome renders extra-wide &nbsp; characters for the Hoefler Text font.
+ * This results in a jumping cursor when typing in both the Classic and block
+ * editors. The following font-face override fixes the issue by manually inserting
+ * a custom font that includes just a Hoefler Text space replacement for that
  * character instead.
  */
 @font-face {
@@ -179,15 +179,15 @@ a {
 	}
 }
 
-.has-primary-background-color { 
-	
+.has-primary-background-color {
+
 	p,
-	h1, 
+	h1,
 	h2,
 	h3,
 	h4,
 	h5,
-	h6, 
+	h6,
 	a,
 	a:hover {
 		color: $color__background-body;
@@ -544,6 +544,7 @@ ul.wp-block-archives,
 	}
 
 	li {
+		color: $color__text-light;
 		font-family: $font__heading;
 		font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 		font-weight: bold;
@@ -571,7 +572,7 @@ ul.wp-block-archives,
 		padding-top: ( .75 * $size__spacing-unit );
 		@include nestedSubMenuPadding();
 	}
-	
+
 	li ul {
 		list-style: none;
 		padding-left: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3034,11 +3034,11 @@ body.page .main-navigation {
 
 .widget_archive ul,
 .widget_categories ul,
-.widget_nav_menu ul,
 .widget_meta ul,
+.widget_nav_menu ul,
 .widget_pages ul,
-.widget_recent_entries ul,
 .widget_recent_comments ul,
+.widget_recent_entries ul,
 .widget_rss ul {
   padding: 0;
   list-style: none;
@@ -3047,11 +3047,11 @@ body.page .main-navigation {
 
 .widget_archive ul li,
 .widget_categories ul li,
-.widget_nav_menu ul li,
 .widget_meta ul li,
+.widget_nav_menu ul li,
 .widget_pages ul li,
-.widget_recent_entries ul li,
 .widget_recent_comments ul li,
+.widget_recent_entries ul li,
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -3064,11 +3064,11 @@ body.page .main-navigation {
 
 .widget_archive ul ul li > a:before,
 .widget_categories ul ul li > a:before,
-.widget_nav_menu ul ul li > a:before,
 .widget_meta ul ul li > a:before,
+.widget_nav_menu ul ul li > a:before,
 .widget_pages ul ul li > a:before,
-.widget_recent_entries ul ul li > a:before,
 .widget_recent_comments ul ul li > a:before,
+.widget_recent_entries ul ul li > a:before,
 .widget_rss ul ul li > a:before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
@@ -3076,99 +3076,99 @@ body.page .main-navigation {
 
 .widget_archive ul ul > li > a:before,
 .widget_categories ul ul > li > a:before,
-.widget_nav_menu ul ul > li > a:before,
 .widget_meta ul ul > li > a:before,
+.widget_nav_menu ul ul > li > a:before,
 .widget_pages ul ul > li > a:before,
-.widget_recent_entries ul ul > li > a:before,
 .widget_recent_comments ul ul > li > a:before,
+.widget_recent_entries ul ul > li > a:before,
 .widget_rss ul ul > li > a:before {
   content: "\2013\00a0";
 }
 
 .widget_archive ul ul ul li > a:before,
 .widget_categories ul ul ul li > a:before,
-.widget_nav_menu ul ul ul li > a:before,
 .widget_meta ul ul ul li > a:before,
+.widget_nav_menu ul ul ul li > a:before,
 .widget_pages ul ul ul li > a:before,
-.widget_recent_entries ul ul ul li > a:before,
 .widget_recent_comments ul ul ul li > a:before,
+.widget_recent_entries ul ul ul li > a:before,
 .widget_rss ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -58,6 +58,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Fallback for non-latin fonts */
 /* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
 /* Normalize */
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
@@ -1152,26 +1153,12 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1181,13 +1168,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3042,7 +3022,6 @@ body.page .main-navigation {
 .widget_rss ul {
   padding: 0;
   list-style: none;
-  /* Nested sub-menu padding: 10 levels deep */
 }
 
 .widget_archive ul li,
@@ -3447,12 +3426,15 @@ body.page .main-navigation {
   font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
+  padding-bottom: 0.75rem;
 }
 
-.entry .entry-content .wp-block-archives li:not(.menu-item-has-children),
-.entry .entry-content .wp-block-categories li:not(.menu-item-has-children),
-.entry .entry-content .wp-block-latest-posts li:not(.menu-item-has-children) {
-  padding-bottom: 0.75rem;
+.entry .entry-content .wp-block-archives li.menu-item-has-children, .entry .entry-content .wp-block-archives li:last-child,
+.entry .entry-content .wp-block-categories li.menu-item-has-children,
+.entry .entry-content .wp-block-categories li:last-child,
+.entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
+.entry .entry-content .wp-block-latest-posts li:last-child {
+  padding-bottom: 0;
 }
 
 .entry .entry-content .wp-block-archives li a,
@@ -3461,10 +3443,54 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
-.entry .entry-content .wp-block-archives li ul,
-.entry .entry-content .wp-block-categories li ul,
-.entry .entry-content .wp-block-latest-posts li ul {
-  padding-right: 1rem;
+.entry .entry-content .wp-block-categories ul {
+  padding-top: 0.75rem;
+}
+
+.entry .entry-content .wp-block-categories li ul {
+  list-style: none;
+  padding-right: 0;
+}
+
+.entry .entry-content .wp-block-categories ul li > a:before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+}
+
+.entry .entry-content .wp-block-categories ul > li > a:before {
+  content: "\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1153,12 +1153,26 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1168,6 +1182,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3033,48 +3033,149 @@ body.page .main-navigation {
 }
 
 .widget_archive ul,
+.widget_categories ul,
 .widget_nav_menu ul,
 .widget_meta ul,
+.widget_pages ul,
 .widget_recent_entries ul,
+.widget_recent_comments ul,
 .widget_rss ul {
   padding: 0;
   list-style: none;
+  /* Nested sub-menu padding: 10 levels deep */
 }
 
 .widget_archive ul li,
+.widget_categories ul li,
 .widget_nav_menu ul li,
 .widget_meta ul li,
+.widget_pages ul li,
 .widget_recent_entries ul li,
+.widget_recent_comments ul li,
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1.2;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.widget_archive ul li:not(.menu-item-has-children),
-.widget_nav_menu ul li:not(.menu-item-has-children),
-.widget_meta ul li:not(.menu-item-has-children),
-.widget_recent_entries ul li:not(.menu-item-has-children),
-.widget_rss ul li:not(.menu-item-has-children) {
-  padding-bottom: 0.75rem;
+.widget_archive ul ul li > a:before,
+.widget_categories ul ul li > a:before,
+.widget_nav_menu ul ul li > a:before,
+.widget_meta ul ul li > a:before,
+.widget_pages ul ul li > a:before,
+.widget_recent_entries ul ul li > a:before,
+.widget_recent_comments ul ul li > a:before,
+.widget_rss ul ul li > a:before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
 }
 
-.widget_archive ul li ul,
-.widget_nav_menu ul li ul,
-.widget_meta ul li ul,
-.widget_recent_entries ul li ul,
-.widget_rss ul li ul {
-  padding-right: 1rem;
+.widget_archive ul ul > li > a:before,
+.widget_categories ul ul > li > a:before,
+.widget_nav_menu ul ul > li > a:before,
+.widget_meta ul ul > li > a:before,
+.widget_pages ul ul > li > a:before,
+.widget_recent_entries ul ul > li > a:before,
+.widget_recent_comments ul ul > li > a:before,
+.widget_rss ul ul > li > a:before {
+  content: "\2013\00a0";
 }
 
-.widget_archive ul.sub-menu,
-.widget_nav_menu ul.sub-menu,
-.widget_meta ul.sub-menu,
-.widget_recent_entries ul.sub-menu,
-.widget_rss ul.sub-menu {
-  padding-top: 0.75rem;
+.widget_archive ul ul ul li > a:before,
+.widget_categories ul ul ul li > a:before,
+.widget_nav_menu ul ul ul li > a:before,
+.widget_meta ul ul ul li > a:before,
+.widget_pages ul ul ul li > a:before,
+.widget_recent_entries ul ul ul li > a:before,
+.widget_recent_comments ul ul ul li > a:before,
+.widget_rss ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_tag_cloud .tagcloud {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-weight: 700;
 }
 
 .widget_search .search-submit {
@@ -3795,14 +3896,12 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-file .wp-block-file__button:hover {
+  background: #111;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:focus, .entry .entry-content .wp-block-file .wp-block-file__button:hover {
-  background: #111;
-}
-
 .entry .entry-content .wp-block-file .wp-block-file__button:focus {
+  background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }

--- a/style.css
+++ b/style.css
@@ -58,6 +58,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Fallback for non-latin fonts */
 /* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
 /* Normalize */
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
@@ -3045,7 +3046,6 @@ body.page .main-navigation {
 .widget_rss ul {
   padding: 0;
   list-style: none;
-  /* Nested sub-menu padding: 10 levels deep */
 }
 
 .widget_archive ul li,
@@ -3455,12 +3455,15 @@ body.page .main-navigation {
   font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
+  padding-bottom: 0.75rem;
 }
 
-.entry .entry-content .wp-block-archives li:not(.menu-item-has-children),
-.entry .entry-content .wp-block-categories li:not(.menu-item-has-children),
-.entry .entry-content .wp-block-latest-posts li:not(.menu-item-has-children) {
-  padding-bottom: 0.75rem;
+.entry .entry-content .wp-block-archives li.menu-item-has-children, .entry .entry-content .wp-block-archives li:last-child,
+.entry .entry-content .wp-block-categories li.menu-item-has-children,
+.entry .entry-content .wp-block-categories li:last-child,
+.entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
+.entry .entry-content .wp-block-latest-posts li:last-child {
+  padding-bottom: 0;
 }
 
 .entry .entry-content .wp-block-archives li a,
@@ -3469,10 +3472,54 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
-.entry .entry-content .wp-block-archives li ul,
-.entry .entry-content .wp-block-categories li ul,
-.entry .entry-content .wp-block-latest-posts li ul {
-  padding-left: 1rem;
+.entry .entry-content .wp-block-categories ul {
+  padding-top: 0.75rem;
+}
+
+.entry .entry-content .wp-block-categories li ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.entry .entry-content .wp-block-categories ul li > a:before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+}
+
+.entry .entry-content .wp-block-categories ul > li > a:before {
+  content: "\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li {

--- a/style.css
+++ b/style.css
@@ -3037,11 +3037,11 @@ body.page .main-navigation {
 
 .widget_archive ul,
 .widget_categories ul,
-.widget_nav_menu ul,
 .widget_meta ul,
+.widget_nav_menu ul,
 .widget_pages ul,
-.widget_recent_entries ul,
 .widget_recent_comments ul,
+.widget_recent_entries ul,
 .widget_rss ul {
   padding: 0;
   list-style: none;
@@ -3050,11 +3050,11 @@ body.page .main-navigation {
 
 .widget_archive ul li,
 .widget_categories ul li,
-.widget_nav_menu ul li,
 .widget_meta ul li,
+.widget_nav_menu ul li,
 .widget_pages ul li,
-.widget_recent_entries ul li,
 .widget_recent_comments ul li,
+.widget_recent_entries ul li,
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -3067,11 +3067,11 @@ body.page .main-navigation {
 
 .widget_archive ul ul li > a:before,
 .widget_categories ul ul li > a:before,
-.widget_nav_menu ul ul li > a:before,
 .widget_meta ul ul li > a:before,
+.widget_nav_menu ul ul li > a:before,
 .widget_pages ul ul li > a:before,
-.widget_recent_entries ul ul li > a:before,
 .widget_recent_comments ul ul li > a:before,
+.widget_recent_entries ul ul li > a:before,
 .widget_rss ul ul li > a:before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
@@ -3079,99 +3079,99 @@ body.page .main-navigation {
 
 .widget_archive ul ul > li > a:before,
 .widget_categories ul ul > li > a:before,
-.widget_nav_menu ul ul > li > a:before,
 .widget_meta ul ul > li > a:before,
+.widget_nav_menu ul ul > li > a:before,
 .widget_pages ul ul > li > a:before,
-.widget_recent_entries ul ul > li > a:before,
 .widget_recent_comments ul ul > li > a:before,
+.widget_recent_entries ul ul > li > a:before,
 .widget_rss ul ul > li > a:before {
   content: "\2013\00a0";
 }
 
 .widget_archive ul ul ul li > a:before,
 .widget_categories ul ul ul li > a:before,
-.widget_nav_menu ul ul ul li > a:before,
 .widget_meta ul ul ul li > a:before,
+.widget_nav_menu ul ul ul li > a:before,
 .widget_pages ul ul ul li > a:before,
-.widget_recent_entries ul ul ul li > a:before,
 .widget_recent_comments ul ul ul li > a:before,
+.widget_recent_entries ul ul ul li > a:before,
 .widget_rss ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
 .widget_archive ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_categories ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_meta ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_pages ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_recent_comments ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
 .widget_rss ul ul ul ul ul ul ul ul ul ul li > a:before {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }

--- a/style.css
+++ b/style.css
@@ -3036,48 +3036,149 @@ body.page .main-navigation {
 }
 
 .widget_archive ul,
+.widget_categories ul,
 .widget_nav_menu ul,
 .widget_meta ul,
+.widget_pages ul,
 .widget_recent_entries ul,
+.widget_recent_comments ul,
 .widget_rss ul {
   padding: 0;
   list-style: none;
+  /* Nested sub-menu padding: 10 levels deep */
 }
 
 .widget_archive ul li,
+.widget_categories ul li,
 .widget_nav_menu ul li,
 .widget_meta ul li,
+.widget_pages ul li,
 .widget_recent_entries ul li,
+.widget_recent_comments ul li,
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1.2;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.widget_archive ul li:not(.menu-item-has-children),
-.widget_nav_menu ul li:not(.menu-item-has-children),
-.widget_meta ul li:not(.menu-item-has-children),
-.widget_recent_entries ul li:not(.menu-item-has-children),
-.widget_rss ul li:not(.menu-item-has-children) {
-  padding-bottom: 0.75rem;
+.widget_archive ul ul li > a:before,
+.widget_categories ul ul li > a:before,
+.widget_nav_menu ul ul li > a:before,
+.widget_meta ul ul li > a:before,
+.widget_pages ul ul li > a:before,
+.widget_recent_entries ul ul li > a:before,
+.widget_recent_comments ul ul li > a:before,
+.widget_rss ul ul li > a:before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
 }
 
-.widget_archive ul li ul,
-.widget_nav_menu ul li ul,
-.widget_meta ul li ul,
-.widget_recent_entries ul li ul,
-.widget_rss ul li ul {
-  padding-left: 1rem;
+.widget_archive ul ul > li > a:before,
+.widget_categories ul ul > li > a:before,
+.widget_nav_menu ul ul > li > a:before,
+.widget_meta ul ul > li > a:before,
+.widget_pages ul ul > li > a:before,
+.widget_recent_entries ul ul > li > a:before,
+.widget_recent_comments ul ul > li > a:before,
+.widget_rss ul ul > li > a:before {
+  content: "\2013\00a0";
 }
 
-.widget_archive ul.sub-menu,
-.widget_nav_menu ul.sub-menu,
-.widget_meta ul.sub-menu,
-.widget_recent_entries ul.sub-menu,
-.widget_rss ul.sub-menu {
-  padding-top: 0.75rem;
+.widget_archive ul ul ul li > a:before,
+.widget_categories ul ul ul li > a:before,
+.widget_nav_menu ul ul ul li > a:before,
+.widget_meta ul ul ul li > a:before,
+.widget_pages ul ul ul li > a:before,
+.widget_recent_entries ul ul ul li > a:before,
+.widget_recent_comments ul ul ul li > a:before,
+.widget_rss ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_archive ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_categories ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_meta ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_pages ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_recent_comments ul ul ul ul ul ul ul ul ul ul li > a:before,
+.widget_rss ul ul ul ul ul ul ul ul ul ul li > a:before {
+  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+}
+
+.widget_tag_cloud .tagcloud {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-weight: 700;
 }
 
 .widget_search .search-submit {


### PR DESCRIPTION
I noticed some font inconsistencies between lists-style widgets. 

Screenshot before:
![image](https://user-images.githubusercontent.com/709581/48295354-2774fa00-e459-11e8-8c2d-e2634b261f3b.png)

This PR makes any list-style widgets use the same fonts and list styling:

Screenshot after: 
![image](https://user-images.githubusercontent.com/709581/48295391-6905a500-e459-11e8-9baf-74101114e13b.png)

I also added dashes to the nested list styles so they match the menu’s nested styles: 

![image](https://user-images.githubusercontent.com/709581/48295403-80dd2900-e459-11e8-844b-41caccd45678.png)