### PR TITLE
Add custom colors support for text selection CSS

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -26,14 +26,17 @@ function twentynineteen_custom_colors_css() {
 	 * @param int $saturation Color saturation level.
 	 */
 
-	$saturation      = absint( apply_filters( 'twentynineteen_custom_colors_saturation', 100 ) );
-	$saturation      = $saturation . '%';
+	$saturation          = absint( apply_filters( 'twentynineteen_custom_colors_saturation', 100 ) );
+	$saturation          = $saturation . '%';
 
-	$lightness       = absint( apply_filters( 'twentynineteen_custom_colors_lightness', 33 ) );
-	$lightness       = $lightness . '%';
+	$lightness           = absint( apply_filters( 'twentynineteen_custom_colors_lightness', 33 ) );
+	$lightness           = $lightness . '%';
 
-	$lightness_hover = absint( apply_filters( 'twentynineteen_custom_colors_lightness_hover', 23 ) );
-	$lightness_hover = $lightness_hover . '%';
+	$lightness_hover     = absint( apply_filters( 'twentynineteen_custom_colors_lightness_hover', 23 ) );
+	$lightness_hover     = $lightness_hover . '%';
+
+	$lightness_selection = absint( apply_filters( 'twentynineteen_custom_colors_lightness_selection', 90 ) );
+	$lightness_selection = $lightness_selection . '%';
 
 	$theme_css = '
 		/*
@@ -158,7 +161,15 @@ function twentynineteen_custom_colors_css() {
 		.main-navigation .sub-menu > li > a:focus:after,
 		.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):hover,
 		.main-navigation .sub-menu > li > a:not(.mobile-submenu-expand):focus {
-			background: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_hover . ' ); /* base: #005177; */
+			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_hover . ' ); /* base: #005177; */
+		}
+
+		/* Text selection colors */
+		::selection {
+			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_selection . ' ); /* base: #005177; */
+		}
+		::-moz-selection {
+			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_selection . ' ); /* base: #005177; */
 		}';
 
 	$editor_css = '

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -3,10 +3,11 @@ html {
 }
 
 ::-moz-selection {
-	background: $color__background_selection;
+	background-color: $color__background_selection;
 }
+
 ::selection {
-	background: $color__background_selection;
+	background-color: $color__background_selection;
 }
 
 *,
@@ -16,7 +17,7 @@ html {
 }
 
 body {
-	background: $color__background-body;
+	background-color: $color__background-body;
 }
 
 a {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -723,11 +723,11 @@ html {
 }
 
 ::-moz-selection {
-  background: #bfdcea;
+  background-color: #bfdcea;
 }
 
 ::selection {
-  background: #bfdcea;
+  background-color: #bfdcea;
 }
 
 *,
@@ -737,7 +737,7 @@ html {
 }
 
 body {
-  background: #fff;
+  background-color: #fff;
 }
 
 a {
@@ -3766,14 +3766,12 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-file .wp-block-file__button:hover {
+  background: #111;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:focus, .entry .entry-content .wp-block-file .wp-block-file__button:hover {
-  background: #111;
-}
-
 .entry .entry-content .wp-block-file .wp-block-file__button:focus {
+  background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }

--- a/style.css
+++ b/style.css
@@ -723,11 +723,11 @@ html {
 }
 
 ::-moz-selection {
-  background: #bfdcea;
+  background-color: #bfdcea;
 }
 
 ::selection {
-  background: #bfdcea;
+  background-color: #bfdcea;
 }
 
 *,
@@ -737,7 +737,7 @@ html {
 }
 
 body {
-  background: #fff;
+  background-color: #fff;
 }
 
 a {


### PR DESCRIPTION
Adds a 90% lightness color to custom-colors for use in text selection CSS (`::selection { }`).

Before: 
![image](https://user-images.githubusercontent.com/709581/48304396-065aea80-e4e7-11e8-85f5-93e1dff2d978.png)

After:
![image](https://user-images.githubusercontent.com/709581/48304414-34d8c580-e4e7-11e8-915c-c489dd43cf94.png)

![image](https://user-images.githubusercontent.com/709581/48304419-520d9400-e4e7-11e8-84ff-2a0c90a31ad9.png)
