### PR TITLE
Unset nested content selector styles for easier shortcode and plugin compatibility

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -10,17 +10,6 @@
 	@include media(tablet) {
 		margin: 32px 0;
 	}
-/*
-	// Set top margins for headings
-	& + h1:before,
-	& + h2:before,
-	& + h3,
-	& + h4,
-	& + h5,
-	& + h6 {
-		margin-top: calc(4 * #{ $size__spacing-unit});
-	}
-*/
 
 	> *:first-child {
 		margin-top: 0;
@@ -101,6 +90,29 @@
 		@include media(tablet) {
 			margin-left: 0;
 			margin-right: 0;
+		}
+	}
+}
+
+/*
+ * Unset nested content selector styles
+ * - Prevents layout styles from cascading too deeply
+ * - helps with plugin compatibility
+ */
+.entry .entry-content,
+.entry .entry-summary {
+
+	.entry-content,
+	.entry-summary,
+	.entry {
+		margin: inherit;
+		max-width: inherit;
+		padding: inherit;
+
+		@include media(tablet) {
+			margin: inherit;
+			max-width: inherit;
+			padding: inherit;
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3084,17 +3084,6 @@ body.page .main-navigation {
 .entry .entry-summary > * {
   margin: 32px 0;
   max-width: 100%;
-  /*
-	// Set top margins for headings
-	& + h1:before,
-	& + h2:before,
-	& + h3,
-	& + h4,
-	& + h5,
-	& + h6 {
-		margin-top: calc(4 * 1rem);
-	}
-*/
 }
 
 @media only screen and (min-width: 768px) {
@@ -3228,6 +3217,35 @@ body.page .main-navigation {
   .entry .entry-summary > *.aligncenter {
     margin-right: 0;
     margin-left: 0;
+  }
+}
+
+/*
+ * Unset nested content selector styles
+ * - Prevents layout styles from cascading too deeply
+ * - helps with plugin compatibility
+ */
+.entry .entry-content .entry-content,
+.entry .entry-content .entry-summary,
+.entry .entry-content .entry,
+.entry .entry-summary .entry-content,
+.entry .entry-summary .entry-summary,
+.entry .entry-summary .entry {
+  margin: inherit;
+  max-width: inherit;
+  padding: inherit;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .entry-content,
+  .entry .entry-content .entry-summary,
+  .entry .entry-content .entry,
+  .entry .entry-summary .entry-content,
+  .entry .entry-summary .entry-summary,
+  .entry .entry-summary .entry {
+    margin: inherit;
+    max-width: inherit;
+    padding: inherit;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3087,17 +3087,6 @@ body.page .main-navigation {
 .entry .entry-summary > * {
   margin: 32px 0;
   max-width: 100%;
-  /*
-	// Set top margins for headings
-	& + h1:before,
-	& + h2:before,
-	& + h3,
-	& + h4,
-	& + h5,
-	& + h6 {
-		margin-top: calc(4 * 1rem);
-	}
-*/
 }
 
 @media only screen and (min-width: 768px) {
@@ -3237,6 +3226,35 @@ body.page .main-navigation {
   .entry .entry-summary > *.aligncenter {
     margin-left: 0;
     margin-right: 0;
+  }
+}
+
+/*
+ * Unset nested content selector styles
+ * - Prevents layout styles from cascading too deeply
+ * - helps with plugin compatibility
+ */
+.entry .entry-content .entry-content,
+.entry .entry-content .entry-summary,
+.entry .entry-content .entry,
+.entry .entry-summary .entry-content,
+.entry .entry-summary .entry-summary,
+.entry .entry-summary .entry {
+  margin: inherit;
+  max-width: inherit;
+  padding: inherit;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .entry-content,
+  .entry .entry-content .entry-summary,
+  .entry .entry-content .entry,
+  .entry .entry-summary .entry-content,
+  .entry .entry-summary .entry-summary,
+  .entry .entry-summary .entry {
+    margin: inherit;
+    max-width: inherit;
+    padding: inherit;
   }
 }
 


### PR DESCRIPTION
- Prevents layout styles from cascading too deeply
- Helps with plugin, shortcode and non-Gutenberg-Block compatibility where elements may reuse the `.entry-content`, `.entry-summary`, and `.entry` classes inside of the theme’s `.entry-content` wrappers.
- Also removes some obsolete commented CSS

Here’s an example of how WooCommerce exposes the problem.

Before: 
![image](https://user-images.githubusercontent.com/709581/48305045-c9482580-e4f1-11e8-9449-344c97958208.png)

After: 
![image](https://user-images.githubusercontent.com/709581/48305074-2fcd4380-e4f2-11e8-93e8-bc6841657152.png)
