### PR TITLE
Restrict featured images to only post and page post-types

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -99,7 +99,7 @@ add_filter( 'get_the_archive_title', 'twentynineteen_get_the_archive_title' );
  * Determines if post thumbnail can be displayed.
  */
 function twentynineteen_can_show_post_thumbnail() {
-	return apply_filters( 'twentynineteen_can_show_post_thumbnail', ! post_password_required() && ! is_attachment() && has_post_thumbnail() );
+	return apply_filters( 'twentynineteen_can_show_post_thumbnail', ! post_password_required() && ( 'post' == get_post_type() || 'page' == get_post_type() ) && has_post_thumbnail() );
 }
 
 /**


### PR DESCRIPTION
This ensures that Products, Portfolios, Testimonials and any other custom-post-types do not display featured images by default. 

A theme/plugin author can always use the `twentynineteen_can_show_post_thumbnail` filter to define their own conditional restrictions on when the featured header image should be displayed. 

WooCommerce as an example, utilizes featured images in a _non-standard_ way and we don’t want the theme to assume how it (or any plugin) might want to display featured images. 