### PR TITLE
Add theme version to stylesheet

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -167,7 +167,7 @@ add_action( 'after_setup_theme', 'twentynineteen_content_width', 0 );
  * Enqueue scripts and styles.
  */
 function twentynineteen_scripts() {
-	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri() );
+	wp_enqueue_style( 'twentynineteen-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 
 	wp_style_add_data( 'twentynineteen-style', 'rtl', 'replace' );
 


### PR DESCRIPTION
This will add the theme verion to the stylesheet instead of the WordPress version and flush the changes when there is a new theme update instead of on every WordPress update.