### PR TITLE
Update Pullquote Block styles for better front/back end consistency

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -291,7 +291,8 @@
 		blockquote {
 			color: $color__text-main;
 			border: none;
-			padding-bottom: calc(2 * #{$size__spacing-unit});
+			margin-top: calc(3 * #{ $size__spacing-unit});
+			margin-bottom: calc(3.33 * #{ $size__spacing-unit});
 			margin-right: 0;
 		}
 
@@ -338,8 +339,9 @@
 		}
 
 		&.is-style-solid-color {
-
 			background-color: $color__link;
+			padding-left: 0;
+			padding-right: 0;
 
 			p {
 				font-size: $font__size-lg;
@@ -362,7 +364,10 @@
 
 			blockquote {
 				color: $color__background-body;
-				margin: 0 auto;
+				max-width: 80%;
+				margin-left: auto;
+				margin-right: auto;
+				padding-left: 0;
 			}
 
 			.has-primary-background-color {
@@ -371,17 +376,7 @@
 
 			&.alignleft,
 			&.alignright {
-				padding: $size__spacing-unit $size__spacing-unit 0;
-
-				blockquote {
-					padding: 0 0 calc( 1.5 * #{$size__spacing-unit} );
-					margin-left: 0;
-					margin-top: 0;
-				}
-
-				@include media(tablet) {
-					padding: calc( 2 * #{$size__spacing-unit} ) calc( 2 * #{$size__spacing-unit} ) $size__spacing-unit;
-				}
+				padding: 0 $size__spacing-unit;
 			}
 		}
 	}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -291,8 +291,8 @@
 		blockquote {
 			color: $color__text-main;
 			border: none;
-			margin-top: calc(3 * #{ $size__spacing-unit});
-			margin-bottom: calc(3.33 * #{ $size__spacing-unit});
+			margin-top: calc(4 * #{ $size__spacing-unit});
+			margin-bottom: calc(4.33 * #{ $size__spacing-unit});
 			margin-right: 0;
 		}
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -357,6 +357,18 @@ figcaption,
 /** === Pullquote === */
 .wp-block-pullquote {
   border: none;
+  color: #000;
+}
+
+.wp-block-pullquote blockquote {
+  margin-top: calc(3 * 1rem);
+  margin-bottom: calc(3.33 * 1rem);
+  hyphens: auto;
+  word-break: break-word;
+}
+
+.wp-block-pullquote:not(.is-style-solid-color) .wp-block-pullquote__citation {
+  color: #767676;
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
@@ -382,11 +394,6 @@ figcaption,
 
 .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
   background-color: #0073aa;
-}
-
-.wp-block-pullquote blockquote {
-  hyphens: auto;
-  word-break: break-word;
 }
 
 .wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -389,6 +389,18 @@ figcaption,
 
 .wp-block-pullquote {
 	border: none;
+	color: #000;
+
+	blockquote {
+		margin-top: calc(3 * #{ $size__spacing-unit});
+		margin-bottom: calc(3.33 * #{ $size__spacing-unit});
+		hyphens: auto;
+		word-break: break-word;
+	}
+
+	&:not(.is-style-solid-color) .wp-block-pullquote__citation {
+		color: $color__text-light;
+	}
 
 	&.is-style-solid-color {
 
@@ -412,11 +424,6 @@ figcaption,
 		&:not(.has-background-color) {
 			background-color: $color__link;
 		}
-	}
-
-	blockquote {
-		hyphens: auto;
-		word-break: break-word;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1165,12 +1165,26 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1180,6 +1194,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3393,8 +3414,8 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote {
   color: #111;
   border: none;
-  margin-top: calc(3 * 1rem);
-  margin-bottom: calc(3.33 * 1rem);
+  margin-top: calc(4 * 1rem);
+  margin-bottom: calc(4.33 * 1rem);
   margin-left: 0;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3393,7 +3393,8 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote {
   color: #111;
   border: none;
-  padding-bottom: calc(2 * 1rem);
+  margin-top: calc(3 * 1rem);
+  margin-bottom: calc(3.33 * 1rem);
   margin-left: 0;
 }
 
@@ -3441,6 +3442,8 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
   background-color: #0073aa;
+  padding-right: 0;
+  padding-left: 0;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
@@ -3466,7 +3469,10 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   color: #fff;
-  margin: 0 auto;
+  max-width: 80%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 0;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
@@ -3474,19 +3480,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-  padding: 1rem 1rem 0;
-}
-
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
-  padding: 0 0 calc( 1.5 * 1rem);
-  margin-right: 0;
-  margin-top: 0;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-    padding: calc( 2 * 1rem) calc( 2 * 1rem) 1rem;
-  }
+  padding: 0 1rem;
 }
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1165,26 +1165,12 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1194,13 +1180,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;

--- a/style.css
+++ b/style.css
@@ -3423,8 +3423,8 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote {
   color: #111;
   border: none;
-  margin-top: calc(3 * 1rem);
-  margin-bottom: calc(3.33 * 1rem);
+  margin-top: calc(4 * 1rem);
+  margin-bottom: calc(4.33 * 1rem);
   margin-right: 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -1173,26 +1173,12 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  left: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1208,13 +1194,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-left: 0;
-    position: absolute;
-    left: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;
@@ -3444,7 +3423,8 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote {
   color: #111;
   border: none;
-  padding-bottom: calc(2 * 1rem);
+  margin-top: calc(3 * 1rem);
+  margin-bottom: calc(3.33 * 1rem);
   margin-right: 0;
 }
 
@@ -3492,6 +3472,8 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
   background-color: #0073aa;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
@@ -3517,7 +3499,10 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   color: #fff;
-  margin: 0 auto;
+  max-width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 0;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
@@ -3525,19 +3510,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-  padding: 1rem 1rem 0;
-}
-
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft blockquote, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright blockquote {
-  padding: 0 0 calc( 1.5 * 1rem);
-  margin-left: 0;
-  margin-top: 0;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-    padding: calc( 2 * 1rem) calc( 2 * 1rem) 1rem;
-  }
+  padding: 0 1rem;
 }
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {

--- a/style.css
+++ b/style.css
@@ -1173,12 +1173,26 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  left: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1194,6 +1208,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-left: 0;
+    position: absolute;
+    left: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;


### PR DESCRIPTION
Adjusts margins and text color of the pullquote block to improve consistency between frontend and the editor. 

**Text Color**

Editor Style Before (All text was gray in the backend) 
<img width="455" alt="screen shot 2018-11-11 at 12 38 18 pm" src="https://user-images.githubusercontent.com/1202812/48316852-e1ce4380-e5b6-11e8-8e27-9285f990b16e.png">

Editor Style After (Quote text is no longer gray)
<img width="453" alt="screen shot 2018-11-11 at 12 38 33 pm" src="https://user-images.githubusercontent.com/1202812/48316860-f0b4f600-e5b6-11e8-99fc-fca6518d42fa.png">

**Margins**

Before: 
![margins-before](https://user-images.githubusercontent.com/1202812/48316881-4093bd00-e5b7-11e8-8dcc-6f8357483062.gif)

After: 
![margins](https://user-images.githubusercontent.com/1202812/48316866-0aeed400-e5b7-11e8-9e36-0b35f7ddf7a2.gif)
