### PR TITLE
Adjust RTL float styles.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -70,15 +70,15 @@
 		float: right;
 		max-width: calc(5 * (100vw / 12));
 		margin-top: 0;
+		margin-right: 0;
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
-		margin-right: 0;
 
 		@include media(tablet) {
 			max-width: calc(4 * (100vw / 12));
+			margin-right: 0;
 			/*rtl:ignore*/
 			margin-left: calc(2 * #{$size__spacing-unit});
-			margin-right: 0;
 		}
 	}
 	&.aligncenter {

--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -1,7 +1,13 @@
 .alignleft {
 	/*rtl:ignore*/
 	float: left;
+	/*rtl:ignore*/
 	margin-right: $size__spacing-unit;
+
+	@include media(tablet) {
+		/*rtl:ignore*/
+		margin-right: calc(2 * #{$size__spacing-unit});
+	}
 }
 
 .alignright {
@@ -9,6 +15,11 @@
 	float: right;
 	/*rtl:ignore*/
 	margin-left: $size__spacing-unit;
+
+	@include media(tablet) {
+		/*rtl:ignore*/
+		margin-left: calc(2 * #{$size__spacing-unit});
+	}
 }
 
 .aligncenter {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1608,12 +1608,24 @@ body.page .main-navigation {
 /* Alignments */
 .alignleft {
   float: left;
-  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .alignleft {
+    margin-right: calc(2 * 1rem);
+  }
 }
 
 .alignright {
   float: right;
   margin-left: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .alignright {
+    margin-left: calc(2 * 1rem);
+  }
 }
 
 .aligncenter {
@@ -3179,16 +3191,16 @@ body.page .main-navigation {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
-  margin-left: 1rem;
   margin-left: 0;
+  margin-left: 1rem;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
-    margin-left: calc(2 * 1rem);
     margin-left: 0;
+    margin-left: calc(2 * 1rem);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1609,7 +1609,15 @@ body.page .main-navigation {
 .alignleft {
   /*rtl:ignore*/
   float: left;
+  /*rtl:ignore*/
   margin-right: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .alignleft {
+    /*rtl:ignore*/
+    margin-right: calc(2 * 1rem);
+  }
 }
 
 .alignright {
@@ -1617,6 +1625,13 @@ body.page .main-navigation {
   float: right;
   /*rtl:ignore*/
   margin-left: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .alignright {
+    /*rtl:ignore*/
+    margin-left: calc(2 * 1rem);
+  }
 }
 
 .aligncenter {
@@ -3186,18 +3201,18 @@ body.page .main-navigation {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
+  margin-right: 0;
   /*rtl:ignore*/
   margin-left: 1rem;
-  margin-right: 0;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright {
     max-width: calc(4 * (100vw / 12));
+    margin-right: 0;
     /*rtl:ignore*/
     margin-left: calc(2 * 1rem);
-    margin-right: 0;
   }
 }
 


### PR DESCRIPTION
Fixes #325 (Again 🙂) by adjusting the order of margin rules for our right-aligned blocks. The RTL styles were being overridden by the `margin: 0` rule. This PR corrects that. 

Also, this PR syncs up margin spacing between blocks and non-block elements. Previously, blocks used `2rem` of padding on breakpoints above our tablet size, whereas non-blocks used just `1rem`. Now, they both will use `2rem`. 



**Before:**
<img width="750" alt="screen shot 2018-11-11 at 7 34 10 pm" src="https://user-images.githubusercontent.com/1202812/48320501-e1e73700-e5e8-11e8-9575-93f72fde8c8b.png">

**After**
<img width="758" alt="screen shot 2018-11-11 at 7 31 33 pm" src="https://user-images.githubusercontent.com/1202812/48320503-e4e22780-e5e8-11e8-9df1-afd0f2508370.png">