### PR TITLE
Need to return attributes from filter

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -123,7 +123,7 @@ function twentynineteen_image_filters_enabled() {
 function twentynineteen_post_thumbnail_sizes_attr( $attr ) {
 
 	if ( is_admin() ) {
-		return;
+		return $attr;
 	}
 
 	if ( ! is_singular() ) {


### PR DESCRIPTION
Fixes part of https://github.com/WordPress/twentynineteen/issues/541

Have to always return the attributes from the filter, otherwise you end up with no featured image in the classic editor, along with these errors (posting for future searches):

```
PHP Warning:  array_map(): Argument #2 should be an array in /wp-includes/media.php on line 920

PHP Warning:  Invalid argument supplied for foreach() in /wp-includes/media.php on line 922
```