### PR TITLE
Clean up text alignment & spacing for Cover and Pullquote blocks.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -20,9 +20,9 @@
 	}
 
 	&.alignwide {
-
 		margin-left: auto;
 		margin-right: auto;
+		clear: both;
 
 		@include media(tablet) {
 			width: 100%;
@@ -35,6 +35,7 @@
 		left: -#{$size__spacing-unit };
 		width: calc( 100% + (2 * #{$size__spacing-unit}));
 		max-width: calc( 100% + (2 * #{$size__spacing-unit}));
+		clear: both;
 
 		@include media(tablet) {
 			margin-top: calc(2 * #{$size__spacing-unit});
@@ -328,6 +329,7 @@
 
 		&.alignleft,
 		&.alignright {
+			width: 100%;
 			padding: 0;
 
 			blockquote {
@@ -479,7 +481,7 @@
 		padding: $size__spacing-unit;
 
 		@include media(tablet) {
-			padding: $size__spacing-unit 10%;
+			padding: $size__spacing-unit 0;
 		}
 
 		.wp-block-cover-image-text,
@@ -494,12 +496,10 @@
 
 			@include media(tablet) {
 				font-size: $font__size-xl;
-				padding: 0;
+				padding: 10%;
 			}
 		}
 
-		&.alignleft,
-		&.alignright,
 		&.aligncenter {
 			h2,
 			.wp-block-cover-image-text,
@@ -523,6 +523,12 @@
 			@include media(tablet) {
 				padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
 				padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+
+				.wp-block-cover-image-text,
+				.wp-block-cover-text,
+				h2 {
+					padding: 0;
+				}
 			}
 		}
 	}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -497,6 +497,7 @@
 			@include media(tablet) {
 				font-size: $font__size-xl;
 				padding: 10%;
+				max-width: 100%;
 			}
 		}
 
@@ -519,6 +520,12 @@
 		}
 
 		&.alignfull {
+
+			.wp-block-cover-image-text,
+			.wp-block-cover-text,
+			h2 {
+				@include postContentMaxWidth();
+			}
 
 			@include media(tablet) {
 				padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -343,6 +343,11 @@
 			padding-left: 0;
 			padding-right: 0;
 
+			@include media(tablet) {
+				padding-left: 10%;
+				padding-right: 10%;
+			}
+
 			p {
 				font-size: $font__size-lg;
 				line-height: 1.3;
@@ -369,14 +374,21 @@
 				margin-left: $size__spacing-unit;
 
 				@include media(tablet) {
-					max-width: 80%;
-					margin-left: auto;
-					margin-right: auto;
+					margin-left: 0;
+					margin-right: 0;
 				}
 			}
 
 			.has-primary-background-color {
 				background-color: $color__link;
+			}
+
+			&.alignfull {
+
+				@include media(tablet) {
+					padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+					padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+				}
 			}
 		}
 	}
@@ -467,7 +479,7 @@
 		padding: $size__spacing-unit;
 
 		@include media(tablet) {
-			padding: $size__spacing-unit 0;
+			padding: $size__spacing-unit 10%;
 		}
 
 		.wp-block-cover-image-text,
@@ -482,7 +494,7 @@
 
 			@include media(tablet) {
 				font-size: $font__size-xl;
-				max-width: 80%;
+				padding: 0;
 			}
 		}
 
@@ -506,9 +518,12 @@
 			width: 100%;
 		}
 
-		&.has-left-content,
-		&.has-right-content {
-			justify-content: center;
+		&.alignfull {
+
+			@include media(tablet) {
+				padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+				padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+			}
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -481,7 +481,7 @@
 		padding: $size__spacing-unit;
 
 		@include media(tablet) {
-			padding: $size__spacing-unit 0;
+			padding: $size__spacing-unit 10%;
 		}
 
 		.wp-block-cover-image-text,
@@ -496,7 +496,6 @@
 
 			@include media(tablet) {
 				font-size: $font__size-xl;
-				padding: 10%;
 				max-width: 100%;
 			}
 		}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -363,20 +363,20 @@
 			}
 
 			blockquote {
+				max-width: calc(100% - (2 * #{$size__spacing-unit}));
 				color: $color__background-body;
-				max-width: 80%;
-				margin-left: auto;
-				margin-right: auto;
 				padding-left: 0;
+				margin-left: $size__spacing-unit;
+
+				@include media(tablet) {
+					max-width: 80%;
+					margin-left: auto;
+					margin-right: auto;
+				}
 			}
 
 			.has-primary-background-color {
 				background-color: $color__link;
-			}
-
-			&.alignleft,
-			&.alignright {
-				padding: 0 $size__spacing-unit;
 			}
 		}
 	}
@@ -464,6 +464,11 @@
 	.wp-block-cover {
 		position: relative;
 		min-height: 430px;
+		padding: $size__spacing-unit;
+
+		@include media(tablet) {
+			padding: $size__spacing-unit 0;
+		}
 
 		.wp-block-cover-image-text,
 		.wp-block-cover-text,
@@ -472,21 +477,12 @@
 			font-size: $font__size-lg;
 			font-weight: bold;
 			line-height: 1.25;
-			padding: $size__spacing-unit;
+			padding: 0;
 			color: #fff;
-
-			width: calc(100vw - (2 * #{ $size__spacing-unit }));
-			max-width: calc(100vw - (2 * #{ $size__spacing-unit }));
-
-			@include postContentMaxWidth();
 
 			@include media(tablet) {
 				font-size: $font__size-xl;
-				width: $size__site-tablet-content;
-			}
-
-			@include media(desktop) {
-				width: $size__site-desktop-content;
+				max-width: 80%;
 			}
 		}
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -248,17 +248,10 @@ figcaption,
 }
 
 /** === Cover === */
-@media only screen and (min-width: 768px) {
-  .wp-block-cover {
-    padding-left: 10%;
-    padding-right: 10%;
-  }
-}
-
 .wp-block-cover h2,
 .wp-block-cover .wp-block-cover-text {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 2.25em;
+  font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.4;
 }
@@ -279,6 +272,17 @@ figcaption,
 
 .wp-block-cover.has-left-content, .wp-block-cover.has-right-content {
   justify-content: center;
+}
+
+@media only screen and (min-width: 768px) {
+  .wp-block-cover {
+    padding-left: 10%;
+    padding-right: 10%;
+  }
+  .wp-block-cover h2,
+  .wp-block-cover .wp-block-cover-text {
+    font-size: 2.25em;
+  }
 }
 
 .wp-block[data-type="core/cover"][data-align="left"] h2,

--- a/style-editor.css
+++ b/style-editor.css
@@ -270,10 +270,6 @@ figcaption,
   }
 }
 
-.wp-block-cover.has-left-content, .wp-block-cover.has-right-content {
-  justify-content: center;
-}
-
 @media only screen and (min-width: 768px) {
   .wp-block-cover {
     padding-left: 10%;
@@ -308,6 +304,13 @@ figcaption,
   .wp-block[data-type="core/cover"][data-align="full"] h2,
   .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover-text {
     max-width: calc(6 * (100vw / 12));
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover {
+    padding-left: calc(10% + 64px);
+    padding-right: calc(10% + 64px);
   }
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -254,6 +254,8 @@ figcaption,
   font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.4;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .wp-block-cover h2 strong,

--- a/style-editor.css
+++ b/style-editor.css
@@ -281,12 +281,15 @@ figcaption,
   }
 }
 
-.wp-block[data-type="core/cover"][data-align="left"] h2,
-.wp-block[data-type="core/cover"][data-align="left"] .wp-block-cover-text,
-.wp-block[data-type="core/cover"][data-align="right"] h2,
-.wp-block[data-type="core/cover"][data-align="right"] .wp-block-cover-text {
+.wp-block[data-type="core/cover"][data-align="left"] .editor-block-list__block-edit,
+.wp-block[data-type="core/cover"][data-align="right"] .editor-block-list__block-edit {
+  width: calc(4 * (100vw / 12));
+}
+
+.wp-block[data-type="core/cover"][data-align="left"] .wp-block-cover,
+.wp-block[data-type="core/cover"][data-align="right"] .wp-block-cover {
   width: 100%;
-  max-width: 305px;
+  max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
@@ -461,6 +464,7 @@ figcaption,
 
 .wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit,
 .wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit {
+  width: calc(4 * (100vw / 12));
   max-width: 50%;
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -403,13 +403,6 @@ figcaption,
 @media only screen and (min-width: 768px) {
   .wp-block-pullquote.is-style-solid-color blockquote {
     max-width: 80%;
-    width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .wp-block-pullquote.is-style-solid-color blockquote {
-    width: calc(6 * (100vw / 12));
   }
 }
 
@@ -490,6 +483,12 @@ figcaption,
 .wp-block[data-type="core/pullquote"][data-align="right"] p,
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation {
   text-align: left;
+}
+
+@media only screen and (min-width: 768px) {
+  .wp-block[data-type="core/pullquote"][data-align="full"] .wp-block-pullquote blockquote {
+    max-width: calc(80% - 128px);
+  }
 }
 
 /** === File === */

--- a/style-editor.css
+++ b/style-editor.css
@@ -248,6 +248,13 @@ figcaption,
 }
 
 /** === Cover === */
+@media only screen and (min-width: 768px) {
+  .wp-block-cover {
+    padding-left: 10%;
+    padding-right: 10%;
+  }
+}
+
 .wp-block-cover h2,
 .wp-block-cover .wp-block-cover-text {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -261,14 +268,17 @@ figcaption,
   font-weight: bolder;
 }
 
-.wp-block-cover.has-left-content h2,
-.wp-block-cover.has-left-content .wp-block-cover-text {
-  padding: 1em;
+@media only screen and (min-width: 768px) {
+  .wp-block-cover h2,
+  .wp-block-cover .wp-block-cover-text {
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0;
+  }
 }
 
-.wp-block-cover.has-right-content h2,
-.wp-block-cover.has-right-content .wp-block-cover-text {
-  padding: 1em;
+.wp-block-cover.has-left-content, .wp-block-cover.has-right-content {
+  justify-content: center;
 }
 
 .wp-block[data-type="core/cover"][data-align="left"] h2,
@@ -279,13 +289,20 @@ figcaption,
   max-width: 305px;
 }
 
+@media only screen and (min-width: 768px) {
+  .wp-block[data-type="core/cover"][data-align="wide"] h2,
+  .wp-block[data-type="core/cover"][data-align="wide"] .wp-block-cover-text,
+  .wp-block[data-type="core/cover"][data-align="full"] h2,
+  .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover-text {
+    max-width: calc(8 * (100vw / 12));
+  }
+}
+
 @media only screen and (min-width: 1168px) {
   .wp-block[data-type="core/cover"][data-align="wide"] h2,
   .wp-block[data-type="core/cover"][data-align="wide"] .wp-block-cover-text,
   .wp-block[data-type="core/cover"][data-align="full"] h2,
   .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover-text {
-    padding: 0;
-    width: calc(6 * (100vw / 12));
     max-width: calc(6 * (100vw / 12));
   }
 }
@@ -372,12 +389,13 @@ figcaption,
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
-  width: calc(100vw - (2 * 1rem));
-  max-width: 80%;
+  width: calc(100% - (2 * 1rem));
+  max-width: calc( 100% - (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
   .wp-block-pullquote.is-style-solid-color blockquote {
+    max-width: 80%;
     width: calc(8 * (100vw / 12));
   }
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -260,6 +260,8 @@ figcaption,
 		font-size: $font__size-lg;
 		font-weight: bold;
 		line-height: 1.4;
+		padding-left: $size__spacing-unit;
+		padding-right: $size__spacing-unit;
 
 		strong {
 			font-weight: bolder;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -254,15 +254,10 @@ figcaption,
 
 .wp-block-cover {
 
-	@include media(tablet) {
-		padding-left: 10%;
-		padding-right: 10%;
-	}
-
 	h2,
 	.wp-block-cover-text {
 		font-family: $font__heading;
-		font-size: $font__size-xl;
+		font-size: $font__size-lg;
 		font-weight: bold;
 		line-height: 1.4;
 
@@ -280,6 +275,16 @@ figcaption,
 	&.has-left-content,
 	&.has-right-content {
 		justify-content: center;
+	}
+
+	@include media(tablet) {
+		padding-left: 10%;
+		padding-right: 10%;
+
+		h2,
+		.wp-block-cover-text {
+			font-size: $font__size-xl;
+		}
 	}
 }
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -286,10 +286,13 @@ figcaption,
 .wp-block[data-type="core/cover"][data-align="left"],
 .wp-block[data-type="core/cover"][data-align="right"] {
 
-	h2,
-	.wp-block-cover-text {
+	.editor-block-list__block-edit {
+		width: calc(4 * (100vw / 12));
+	}
+
+	.wp-block-cover {
 		width: 100%;
-		max-width: 305px;
+		max-width: 100%;
 	}
 }
 
@@ -476,6 +479,7 @@ figcaption,
 .wp-block[data-type="core/pullquote"][data-align="right"] {
 
 	.editor-block-list__block-edit {
+		width: calc(4 * (100vw / 12));
 		max-width: 50%;
 
 		.wp-block-pullquote:not(.is-style-solid-color) {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -429,11 +429,6 @@ figcaption,
 
 			@include media(tablet) {
 				max-width: 80%;
-				width: calc(8 * (100vw / 12));
-			}
-
-			@include media(desktop) {
-				width: calc(6 * (100vw / 12));
 			}
 		}
 
@@ -499,6 +494,17 @@ figcaption,
 		text-align: left;
 	}
 }
+
+.wp-block[data-type="core/pullquote"][data-align="full"] {
+	
+	@include media(tablet) {
+		
+		.wp-block-pullquote blockquote {
+			max-width: calc(80% - 128px);
+		}
+	}
+}
+
 
 /** === File === */
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -254,31 +254,32 @@ figcaption,
 
 .wp-block-cover {
 
+	@include media(tablet) {
+		padding-left: 10%;
+		padding-right: 10%;
+	}
+
 	h2,
 	.wp-block-cover-text {
 		font-family: $font__heading;
 		font-size: $font__size-xl;
 		font-weight: bold;
 		line-height: 1.4;
+
 		strong {
 			font-weight: bolder;
 		}
-	}
 
-	&.has-left-content {
-
-		h2,
-		.wp-block-cover-text {
-			padding: 1em;
+		@include media(tablet) {
+			margin-left: auto;
+			margin-right: auto;
+			padding: 0;
 		}
 	}
 
+	&.has-left-content,
 	&.has-right-content {
-
-		h2,
-		.wp-block-cover-text {
-			padding: 1em;
-		}
+		justify-content: center;
 	}
 }
 
@@ -295,11 +296,18 @@ figcaption,
 .wp-block[data-type="core/cover"][data-align="wide"],
 .wp-block[data-type="core/cover"][data-align="full"] {
 
-	@include media(desktop) {
+	@include media(tablet) {
+
 		h2,
 		.wp-block-cover-text {
-			padding: 0;
-			width: calc(6 * (100vw / 12));
+			max-width: calc(8 * (100vw / 12));
+		}
+	}
+
+	@include media(desktop) {
+
+		h2,
+		.wp-block-cover-text {
 			max-width: calc(6 * (100vw / 12));
 		}
 	}
@@ -405,10 +413,11 @@ figcaption,
 	&.is-style-solid-color {
 
 		blockquote {
-			width: calc(100vw - (2 * #{ $size__spacing-unit}));
-			max-width: 80%;
+			width: calc(100% - (2 * #{ $size__spacing-unit}));
+			max-width: calc( 100% - (2 * #{ $size__spacing-unit}));
 
 			@include media(tablet) {
+				max-width: 80%;
 				width: calc(8 * (100vw / 12));
 			}
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -272,11 +272,6 @@ figcaption,
 		}
 	}
 
-	&.has-left-content,
-	&.has-right-content {
-		justify-content: center;
-	}
-
 	@include media(tablet) {
 		padding-left: 10%;
 		padding-right: 10%;
@@ -314,6 +309,17 @@ figcaption,
 		h2,
 		.wp-block-cover-text {
 			max-width: calc(6 * (100vw / 12));
+		}
+	}
+}
+
+.wp-block[data-type="core/cover"][data-align="full"] {
+
+	@include media(tablet) {
+
+		.wp-block-cover {
+			padding-left: calc(10% + 64px);
+			padding-right: calc(10% + 64px);
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1165,12 +1165,26 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1180,6 +1194,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3461,6 +3482,13 @@ body.page .main-navigation {
   padding-left: 0;
 }
 
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color {
+    padding-right: 10%;
+    padding-left: 10%;
+  }
+}
+
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
@@ -3491,14 +3519,20 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
-    max-width: 80%;
-    margin-right: auto;
-    margin-left: auto;
+    margin-right: 0;
+    margin-left: 0;
   }
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
   background-color: #0073aa;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
+    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + (2 * 1rem));
+  }
 }
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
@@ -3582,7 +3616,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
-    padding: 1rem 0;
+    padding: 1rem 10%;
   }
 }
 
@@ -3608,7 +3642,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    max-width: 80%;
+    padding: 0;
   }
 }
 
@@ -3642,10 +3676,12 @@ body.page .main-navigation {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-cover-image.has-left-content, .entry .entry-content .wp-block-cover-image.has-right-content,
-.entry .entry-content .wp-block-cover.has-left-content,
-.entry .entry-content .wp-block-cover.has-right-content {
-  justify-content: center;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull,
+  .entry .entry-content .wp-block-cover.alignfull {
+    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + (2 * 1rem));
+  }
 }
 
 .entry .entry-content .wp-block-gallery {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1173,12 +1173,26 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1194,6 +1208,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3136,6 +3157,7 @@ body.page .main-navigation {
 .entry .entry-summary > *.alignwide {
   margin-right: auto;
   margin-left: auto;
+  clear: both;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3152,6 +3174,7 @@ body.page .main-navigation {
   right: -1rem;
   width: calc( 100% + (2 * 1rem));
   max-width: calc( 100% + (2 * 1rem));
+  clear: both;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3466,6 +3489,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+  width: 100%;
   padding: 0;
 }
 
@@ -3616,7 +3640,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
-    padding: 1rem 10%;
+    padding: 1rem 0;
   }
 }
 
@@ -3642,23 +3666,13 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    padding: 0;
+    padding: 10%;
   }
 }
 
-.entry .entry-content .wp-block-cover-image.alignleft h2,
-.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.alignright h2,
-.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.aligncenter h2,
+.entry .entry-content .wp-block-cover-image.aligncenter h2,
 .entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.alignleft h2,
-.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.alignright h2,
-.entry .entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.alignright .wp-block-cover-text,
 .entry .entry-content .wp-block-cover.aligncenter h2,
 .entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
@@ -3681,6 +3695,14 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull {
     padding-right: calc(10% + 58px + (2 * 1rem));
     padding-left: calc(10% + 58px + (2 * 1rem));
+  }
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    padding: 0;
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1173,26 +1173,12 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1208,13 +1194,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3667,6 +3646,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     padding: 10%;
+    max-width: 100%;
   }
 }
 
@@ -3703,6 +3683,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
     padding: 0;
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3646,6 +3646,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     padding: 10%;
+    width: 100%;
     max-width: 100%;
   }
 }
@@ -3671,6 +3672,28 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
   .entry .entry-content .wp-block-cover.alignfull {
     padding-right: calc(10% + 58px + (2 * 1rem));
@@ -3683,7 +3706,6 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
     padding: 0;
-    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1165,40 +1165,12 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
@@ -1208,20 +1180,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-right: 0;
-    position: absolute;
-    right: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3541,10 +3499,6 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
   background-color: #0073aa;
-}
-
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-  padding: 0 1rem;
 }
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1173,12 +1173,26 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   right: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-right: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1194,6 +1208,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-right: 0;
+    position: absolute;
+    right: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-right: 0;
     position: absolute;
@@ -3504,11 +3525,18 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+  max-width: calc(100% - (2 * 1rem));
   color: #fff;
-  max-width: 80%;
-  margin-right: auto;
-  margin-left: auto;
   padding-right: 0;
+  margin-right: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+    max-width: 80%;
+    margin-right: auto;
+    margin-left: auto;
+  }
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
@@ -3594,6 +3622,14 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover {
   position: relative;
   min-height: 430px;
+  padding: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image,
+  .entry .entry-content .wp-block-cover {
+    padding: 1rem 0;
+  }
 }
 
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
@@ -3606,32 +3642,8 @@ body.page .main-navigation {
   font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.25;
-  padding: 1rem;
+  padding: 0;
   color: #fff;
-  width: calc(100vw - (2 * 1rem));
-  max-width: calc(100vw - (2 * 1rem));
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover-image h2,
-  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover-image h2,
-  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
 }
 
 @media only screen and (min-width: 768px) {
@@ -3642,18 +3654,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover-image h2,
-  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
-    width: calc(6 * (100vw / 12) - 28px);
+    max-width: 80%;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1173,26 +1173,12 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
-  display: block;
-  left: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: calc( 100vw - 2rem);
-}
-
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
-}
-
-.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-  margin-top: inherit;
-  position: relative;
-  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1208,13 +1194,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
-    padding-left: 0;
-    position: absolute;
-    left: 100%;
-    width: max-content;
-    top: 0;
-  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;
@@ -3512,6 +3491,13 @@ body.page .main-navigation {
   padding-right: 0;
 }
 
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color {
+    padding-left: 10%;
+    padding-right: 10%;
+  }
+}
+
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
@@ -3542,14 +3528,20 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
-    max-width: 80%;
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
   background-color: #0073aa;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
+    padding-left: calc(10% + 58px + (2 * 1rem));
+    padding-right: calc(10% + 58px + (2 * 1rem));
+  }
 }
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
@@ -3633,7 +3625,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
-    padding: 1rem 0;
+    padding: 1rem 10%;
   }
 }
 
@@ -3659,7 +3651,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    max-width: 80%;
+    padding: 0;
   }
 }
 
@@ -3693,10 +3685,12 @@ body.page .main-navigation {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-cover-image.has-left-content, .entry .entry-content .wp-block-cover-image.has-right-content,
-.entry .entry-content .wp-block-cover.has-left-content,
-.entry .entry-content .wp-block-cover.has-right-content {
-  justify-content: center;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull,
+  .entry .entry-content .wp-block-cover.alignfull {
+    padding-left: calc(10% + 58px + (2 * 1rem));
+    padding-right: calc(10% + 58px + (2 * 1rem));
+  }
 }
 
 .entry .entry-content .wp-block-gallery {

--- a/style.css
+++ b/style.css
@@ -3513,19 +3513,22 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+  max-width: calc(100% - (2 * 1rem));
   color: #fff;
-  max-width: 80%;
-  margin-left: auto;
-  margin-right: auto;
   padding-left: 0;
+  margin-left: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+    max-width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color .has-primary-background-color {
   background-color: #0073aa;
-}
-
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright {
-  padding: 0 1rem;
 }
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
@@ -3603,6 +3606,14 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover {
   position: relative;
   min-height: 430px;
+  padding: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image,
+  .entry .entry-content .wp-block-cover {
+    padding: 1rem 0;
+  }
 }
 
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
@@ -3615,32 +3626,8 @@ body.page .main-navigation {
   font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.25;
-  padding: 1rem;
+  padding: 0;
   color: #fff;
-  width: calc(100vw - (2 * 1rem));
-  max-width: calc(100vw - (2 * 1rem));
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover-image h2,
-  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover-image h2,
-  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
 }
 
 @media only screen and (min-width: 768px) {
@@ -3651,18 +3638,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover-image h2,
-  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
-    width: calc(6 * (100vw / 12) - 28px);
+    max-width: 80%;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3139,6 +3139,7 @@ body.page .main-navigation {
 .entry .entry-summary > *.alignwide {
   margin-left: auto;
   margin-right: auto;
+  clear: both;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3155,6 +3156,7 @@ body.page .main-navigation {
   left: -1rem;
   width: calc( 100% + (2 * 1rem));
   max-width: calc( 100% + (2 * 1rem));
+  clear: both;
 }
 
 @media only screen and (min-width: 768px) {
@@ -3475,6 +3477,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+  width: 100%;
   padding: 0;
 }
 
@@ -3625,7 +3628,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
-    padding: 1rem 10%;
+    padding: 1rem 0;
   }
 }
 
@@ -3651,23 +3654,13 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    padding: 0;
+    padding: 10%;
   }
 }
 
-.entry .entry-content .wp-block-cover-image.alignleft h2,
-.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.alignleft .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.alignright h2,
-.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.alignright .wp-block-cover-text, .entry .entry-content .wp-block-cover-image.aligncenter h2,
+.entry .entry-content .wp-block-cover-image.aligncenter h2,
 .entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.alignleft h2,
-.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.alignleft .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.alignright h2,
-.entry .entry-content .wp-block-cover.alignright .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.alignright .wp-block-cover-text,
 .entry .entry-content .wp-block-cover.aligncenter h2,
 .entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
@@ -3690,6 +3683,14 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull {
     padding-left: calc(10% + 58px + (2 * 1rem));
     padding-right: calc(10% + 58px + (2 * 1rem));
+  }
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    padding: 0;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3655,6 +3655,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
     padding: 10%;
+    max-width: 100%;
   }
 }
 
@@ -3676,6 +3677,28 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {
   width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
 }
 
 @media only screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -3628,7 +3628,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
-    padding: 1rem 0;
+    padding: 1rem 10%;
   }
 }
 
@@ -3654,7 +3654,6 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
     font-size: 2.25em;
-    padding: 10%;
     max-width: 100%;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1173,12 +1173,26 @@ body.page .main-navigation {
   width: calc( 100vw - 2rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu {
+  display: block;
+  left: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: calc( 100vw - 2rem);
+}
+
 .main-navigation .main-menu .menu-item-has-children:focus-within > .sub-menu {
   display: block;
   left: 0;
   margin-top: 0;
   opacity: 1;
   width: calc( 100vw - 2rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+  margin-top: inherit;
+  position: relative;
+  padding-left: 1rem;
 }
 
 .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
@@ -1194,6 +1208,13 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
+    padding-left: 0;
+    position: absolute;
+    left: 100%;
+    width: max-content;
+    top: 0;
+  }
   .main-navigation .main-menu .menu-item-has-children[focus-within] > .sub-menu .sub-menu {
     padding-left: 0;
     position: absolute;


### PR DESCRIPTION
This PR fixes a wide variety of issues with the Cover and Pullquote blocks:

- It fixes non-existent editor margins for Cover blocks. 
- Makes sure that the text alignment for both blocks is in sync at all sizes/alignments.  
- For full-width Cover & Pullquote blocks, it aligns the text with the text column. 
- Adds a min-width for left/right-aligned Cover & Pullquote blocks.
- Adds  `clear: both` to all `alignfull` and `alignwide` blocks on the front end, so that they don't overlap with floated elements. 

When testing, please also double-check that mobile styles still work correctly. 


## Before 

_Front End_
![front-end-before](https://user-images.githubusercontent.com/1202812/48353431-64a9d980-e65d-11e8-92a8-0848e5b56ac8.png)

_Editor_
![editor-before](https://user-images.githubusercontent.com/1202812/48353622-deda5e00-e65d-11e8-8750-71e2111c3c31.png)

## After

_Front End_
![twentynineteen test__p 2124](https://user-images.githubusercontent.com/1202812/48354328-6d031400-e65f-11e8-99a0-9ff63d0564b7.png)

_Editor_
![editor](https://user-images.githubusercontent.com/1202812/48353677-016c7700-e65e-11e8-8946-ebbf7d41193b.png)

