### PR TITLE
Prevent Gutenberg's meta boxes area from overlapping the content

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -27,12 +27,16 @@ body .wp-block[data-align="full"] {
 
 @media only screen and (min-width: 600px) {
   body {
-    overflow-x: hidden;
+    padding-top: 0;
   }
   body :not(.editor-inner-blocks) > .editor-block-list__layout,
   body .editor-post-title {
     padding-left: 0;
     padding-right: 0;
+  }
+  body .editor-writing-flow {
+    padding-top: 50px;
+    overflow: hidden;
   }
   body .wp-block[data-align="full"] {
     position: relative;
@@ -46,7 +50,8 @@ body .wp-block[data-align="full"] {
     padding-left: 46px;
     padding-right: 46px;
   }
-  body .editor-writing-flow {
+  body .editor-block-list__layout,
+  body .editor-post-title {
     max-width: 80%;
     margin: 0 10%;
   }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -31,12 +31,17 @@ body {
 	}
 
 	@include media(mobile) {
-		overflow-x: hidden;
+		padding-top: 0;
 
 		:not(.editor-inner-blocks) > .editor-block-list__layout, // Target only the top level layout element, or nested blocks will also be affected.
 		.editor-post-title {
 			padding-left: 0;
 			padding-right: 0;
+		}
+
+		.editor-writing-flow {
+			padding-top: 50px;
+			overflow: hidden;
 		}
 
 		.wp-block[data-align="full"] {
@@ -53,7 +58,8 @@ body {
 			padding-right: 46px;
 		}
 
-		.editor-writing-flow {
+		.editor-block-list__layout,
+		.editor-post-title {
 			max-width: 80%;
 			margin: 0 10%;
 		}


### PR DESCRIPTION
Fixes #564.

This PR moves our editor margin and overflow rules from the `.editor-styles-wrapper` to its `.editor-writing-flow` child element instead. This should have no effect on the visual appearance/function of our editor styles, except that it allows Gutenberg's meta boxes (for instance, the Yoast SEO box) to flow beneath the content, instead of overlapping it.

Note:
- When moving the overflow property to `.editor-writing-flow`, I had to change `overflow-x` to `overflow`. Otherwise, a second vertical scrollbar appeared.
- The cleaner way to do this would be to eliminate using that `overflow` rule at all. The overflow mostly happens between `600px`-`768px` viewports, but sometimes at larger sizes too. I did some brief digging before moving these styles over, but I was unable to pin down a clear reason for the overflow. 
- When making this change, I had to remove the default 50px of top padding from the `.editor-styles-wrapper`, and move it to the `.editor-writing-flow` instead. This ensures that the permalink doesn't get clipped off the top of the post title area.

## Screenshots

**Before** (Metabox appears overlapping the content)

![screen shot 2018-11-12 at 12 14 25 pm](https://user-images.githubusercontent.com/1202812/48363693-88c4e500-e674-11e8-8eb4-126e21cad2a3.png)

**After** (Metabox appears below the content)

![screen shot 2018-11-12 at 12 14 01 pm](https://user-images.githubusercontent.com/1202812/48363708-8d899900-e674-11e8-88c6-551c33bee1b9.png)

![screen shot 2018-11-12 at 12 16 11 pm](https://user-images.githubusercontent.com/1202812/48363795-c3c71880-e674-11e8-83a0-1fd089e1ee97.png)
