### PR TITLE
Tidy up our print styles

### DIFF
--- a/print.css
+++ b/print.css
@@ -99,7 +99,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .entry .entry-title:before,
   .entry-meta, .entry-footer,
   .author-description:before,
-  .post-navigation {
+  .post-navigation,
+  .widget-area,
+  .comment-form-flex {
     display: none;
   }
 }

--- a/print.css
+++ b/print.css
@@ -19,6 +19,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   @page {
     margin: 2cm;
   }
+  .entry {
+    margin-top: 1em;
+  }
   .entry .entry-header, .site-footer .site-info {
     margin: 0;
   }

--- a/print.css
+++ b/print.css
@@ -139,6 +139,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     object-fit: none;
     min-width: 0;
     min-height: 0;
+    max-width: 100%;
     margin-top: 1rem;
   }
   /* Remove image filters from featured image */

--- a/print.css
+++ b/print.css
@@ -97,11 +97,52 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .social-navigation,
   .site-branding-container:before,
   .entry .entry-title:before,
-  .entry-meta, .entry-footer,
+  .entry-footer,
   .author-description:before,
   .post-navigation,
   .widget-area,
   .comment-form-flex {
     display: none;
+  }
+  /* Site Header (With Featured Image) */
+  .site-header.featured-image {
+    min-height: 0;
+  }
+  .site-header.featured-image .main-navigation a,
+  .site-header.featured-image .main-navigation a + svg,
+  .site-header.featured-image .social-navigation a,
+  .site-header.featured-image .site-title a,
+  .site-header.featured-image .site-featured-image a,
+  .site-header.featured-image .site-branding .site-title,
+  .site-header.featured-image .site-branding .site-description,
+  .site-header.featured-image .main-navigation a:after,
+  .site-header.featured-image .main-navigation .main-menu > li.menu-item-has-children:after,
+  .site-header.featured-image .main-navigation li,
+  .site-header.featured-image .social-navigation li,
+  .site-header.featured-image .entry-meta,
+  .site-header.featured-image .entry-title {
+    color: #000;
+    text-shadow: none;
+  }
+  .site-header.featured-image .site-featured-image .entry-header,
+  .site-header.featured-image .site-branding-container {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .site-header.featured-image .site-featured-image .post-thumbnail img {
+    position: relative;
+    height: initial;
+    width: initial;
+    object-fit: none;
+    min-width: 0;
+    min-height: 0;
+    margin-top: 1rem;
+  }
+  /* Remove image filters from featured image */
+  .image-filters-enabled *:after {
+    display: none !important;
+  }
+  .image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
+    filter: none;
   }
 }

--- a/print.scss
+++ b/print.scss
@@ -166,6 +166,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
       object-fit: none;
       min-width: 0;
       min-height: 0;
+      max-width: 100%;
       margin-top: 1rem;
     }
   }

--- a/print.scss
+++ b/print.scss
@@ -23,6 +23,10 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     margin: 2cm;
   }
 
+  .entry {
+    margin-top: 1em;
+  }
+
   .entry .entry-header, .site-footer .site-info {
     margin: 0;
   }

--- a/print.scss
+++ b/print.scss
@@ -120,11 +120,61 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .social-navigation,
   .site-branding-container:before, 
   .entry .entry-title:before, 
-  .entry-meta, .entry-footer, 
+  .entry-footer, 
   .author-description:before, 
   .post-navigation,
   .widget-area,
   .comment-form-flex {
     display: none;
+  }
+
+  /* Site Header (With Featured Image) */
+  .site-header.featured-image {
+    min-height: 0;
+    
+    .main-navigation a, 
+    .main-navigation a + svg, 
+    .social-navigation a, 
+    .site-title a, 
+    .site-featured-image a,
+    .site-branding .site-title, 
+    .site-branding .site-description, 
+    .main-navigation a:after, 
+    .main-navigation .main-menu > li.menu-item-has-children:after, 
+    .main-navigation li, 
+    .social-navigation li, 
+    .entry-meta, 
+    .entry-title {
+      color: #000;
+      text-shadow: none;
+    }
+
+    .site-featured-image .entry-header,
+    .site-branding-container {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    .site-featured-image .post-thumbnail img {
+      position: relative;
+      height: initial;
+      width: initial;
+      object-fit: none;
+      min-width: 0;
+      min-height: 0;
+      margin-top: 1rem;
+    }
+  }
+  
+  /* Remove image filters from featured image */
+  .image-filters-enabled {
+
+    *:after {
+      display: none !important;
+    }
+
+    .site-header.featured-image .site-featured-image .post-thumbnail img {
+      filter: none;
+    }
   }
 }

--- a/print.scss
+++ b/print.scss
@@ -122,7 +122,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .entry .entry-title:before, 
   .entry-meta, .entry-footer, 
   .author-description:before, 
-  .post-navigation {
+  .post-navigation,
+  .widget-area,
+  .comment-form-flex {
     display: none;
   }
 }


### PR DESCRIPTION
Resolves #553

Improves our print styles by:

- Removing widgets
- Removing the comment form
- Slimming margins that were too spacious
- Stripping styles and filters from our featured images

**Before**

<img width="671" alt="screen shot 2018-11-12 at 2 02 34 pm" src="https://user-images.githubusercontent.com/1202812/48369265-152ad400-e684-11e8-9b7a-824611079665.png">
<img width="671" alt="screen shot 2018-11-12 at 2 02 49 pm" src="https://user-images.githubusercontent.com/1202812/48369266-152ad400-e684-11e8-8c88-aa80c246b9fe.png">
<img width="671" alt="screen shot 2018-11-12 at 2 03 04 pm" src="https://user-images.githubusercontent.com/1202812/48369267-152ad400-e684-11e8-882f-489d3548c014.png">
<img width="671" alt="screen shot 2018-11-12 at 2 03 21 pm" src="https://user-images.githubusercontent.com/1202812/48369268-152ad400-e684-11e8-8936-8bcc007f35b0.png">

**After**

<img width="671" alt="screen shot 2018-11-12 at 2 00 53 pm" src="https://user-images.githubusercontent.com/1202812/48369278-1c51e200-e684-11e8-9a1c-eba3676f78a9.png">
<img width="672" alt="screen shot 2018-11-12 at 2 01 13 pm" src="https://user-images.githubusercontent.com/1202812/48369279-1c51e200-e684-11e8-959b-89cc74d4273d.png">
<img width="671" alt="screen shot 2018-11-12 at 2 00 01 pm" src="https://user-images.githubusercontent.com/1202812/48369284-1eb43c00-e684-11e8-860a-03ae52cf89eb.png">