### PR TITLE
Fix priority+ menu when the customizer refreshes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -174,8 +174,11 @@ function twentynineteen_scripts() {
 	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
 
 	if ( has_nav_menu( 'menu-1' ) ) {
-		wp_enqueue_script( 'twentynineteen-priority-menu', get_theme_file_uri( '/js/priority-menu.js' ), array(), '1.0', true );
 		wp_enqueue_script( 'twentynineteen-touch-navigation', get_theme_file_uri( '/js/touch-keyboard-navigation.js' ), array(), '1.0', true );
+		if ( ! is_customize_preview() ) {
+			// Remove priorty+ menu script from customizer
+			wp_enqueue_script( 'twentynineteen-priority-menu', get_theme_file_uri( '/js/priority-menu.js' ), array(), '1.0', true );
+		}
 	}
 
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -209,7 +209,7 @@ function twentynineteen_add_ellipses_to_nav( $nav_menu, $args ) {
 		$nav_menu .= '<ul class="main-menu" tabindex="0">';
 		$nav_menu .= '<li class="menu-item menu-item-has-children">';
 		$nav_menu .= '<a href="#" class="screen-reader-text" aria-label="More" aria-haspopup="true" aria-expanded="false">' . esc_html( 'More', 'twentynineteen' ) . '</a>';
-		$nav_menu .= '<span class="submenu-expand main-menu-more-toggle" tabindex="-1">';
+		$nav_menu .= '<span class="submenu-expand main-menu-more-toggle is-hidden" tabindex="-1">';
 		$nav_menu .= twentynineteen_get_icon_svg( 'arrow_drop_down_ellipsis' );
 		$nav_menu .= '</span>';
 		$nav_menu .= '<ul class="sub-menu hidden-links is-hidden">';

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -85,6 +85,10 @@
 						}
 					}
 
+					&.is-hidden {
+						display: none;
+					}
+
 					svg {
 						position: relative;
 						top: 0.2rem;
@@ -96,10 +100,6 @@
 			&:last-child.menu-item-has-children .submenu-expand {
 				margin-right: 0;
 			}
-		}
-
-		.is-hidden {
-			display: none;
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1096,6 +1096,10 @@ body.page .main-navigation {
   vertical-align: text-bottom;
 }
 
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-hidden {
+  display: none;
+}
+
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
@@ -1104,10 +1108,6 @@ body.page .main-navigation {
 .main-navigation .main-menu > li:last-child > a,
 .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
   margin-left: 0;
-}
-
-.main-navigation .main-menu .is-hidden {
-  display: none;
 }
 
 .main-navigation .sub-menu {

--- a/style.css
+++ b/style.css
@@ -1096,6 +1096,10 @@ body.page .main-navigation {
   vertical-align: text-bottom;
 }
 
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-hidden {
+  display: none;
+}
+
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
@@ -1104,10 +1108,6 @@ body.page .main-navigation {
 .main-navigation .main-menu > li:last-child > a,
 .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
   margin-right: 0;
-}
-
-.main-navigation .main-menu .is-hidden {
-  display: none;
 }
 
 .main-navigation .sub-menu {


### PR DESCRIPTION
Addresses #558 

This is an in-progress temporary fix that simply removes the priority+ behavior from the main menu in the customizer. The priority+ script is written in vanilla Javascript while the customizer itself relies on jQuery. Usually this would be fine, but [vanilla JS cannot listen for events created by jQuery](https://stackoverflow.com/questions/40915156/listen-for-jquery-event-with-vanilla-js), so when the menu gets refreshed there’s no way to re-run the script.

Instead forcing a jQuery dependency on the frontend, I think the next best solution is to add a new customizer-only jQuery version of the priority+ script and only run it in the customizer.