### PR TITLE
Remove outdated aligncenter styles for the audio block

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -147,11 +147,6 @@
 				max-width: (0.33 * $desktop_width);
 			}
 		}
-
-		&.aligncenter {
-			margin: 32px calc(2 * (100vw / 12));
-			max-width: calc(6 * (100vw / 12));
-		}
 	}
 
 	//! Video

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3726,11 +3726,6 @@ body.page .main-navigation {
   }
 }
 
-.entry .entry-content .wp-block-audio.aligncenter {
-  margin: 32px calc(2 * (100vw / 12));
-  max-width: calc(6 * (100vw / 12));
-}
-
 .entry .entry-content .wp-block-video video {
   width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -3738,11 +3738,6 @@ body.page .main-navigation {
   }
 }
 
-.entry .entry-content .wp-block-audio.aligncenter {
-  margin: 32px calc(2 * (100vw / 12));
-  max-width: calc(6 * (100vw / 12));
-}
-
 .entry .entry-content .wp-block-video video {
   width: 100%;
 }


### PR DESCRIPTION
Fixes #413

As a result of our improved margins in #502, the styles here  aren't necessary (and actually end up  breaking things when they're left in).

**Before:**
<img width="1065" alt="screen shot 2018-11-12 at 8 17 59 pm" src="https://user-images.githubusercontent.com/1202812/48384374-18d84e00-e6b8-11e8-8d79-63e202d905f5.png">

**After:**
<img width="1065" alt="screen shot 2018-11-12 at 8 17 33 pm" src="https://user-images.githubusercontent.com/1202812/48384379-1bd33e80-e6b8-11e8-8c45-608dccbabd55.png">
