### PR TITLE
Fix appender specificity issue.

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -234,7 +234,7 @@ figcaption,
 }
 
 /** === Default Appender === */
-.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+.editor-default-block-appender .editor-default-block-appender__content {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-size: 22px;
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -231,7 +231,7 @@ figcaption,
 
 /** === Default Appender === */
 
-.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+.editor-default-block-appender .editor-default-block-appender__content {
 	font-family: $font__body;
 	font-size: $font__size_base;
 }


### PR DESCRIPTION
The appender recently changed from an input field to a textarea in Gutenberg. This PR fixes the corresponding editor style to match.

Before:

<img width="811" alt="screenshot 2018-11-13 at 12 08 39" src="https://user-images.githubusercontent.com/1204802/48409759-0ce29f80-e73d-11e8-8c76-9fc368b6a220.png">

After:

<img width="779" alt="screenshot 2018-11-13 at 12 08 59" src="https://user-images.githubusercontent.com/1204802/48409762-0eac6300-e73d-11e8-904d-3d34a6c4afc4.png">
