### PR TITLE
Fix so sticky toolbar works again.

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -29,11 +29,6 @@ body .wp-block[data-align="full"] {
   body {
     padding-top: 0;
   }
-  body :not(.editor-inner-blocks) > .editor-block-list__layout,
-  body .editor-post-title {
-    padding-left: 0;
-    padding-right: 0;
-  }
   body .editor-writing-flow {
     padding-top: 50px;
   }
@@ -44,11 +39,6 @@ body .wp-block[data-align="full"] {
 }
 
 @media only screen and (min-width: 768px) {
-  body :not(.editor-inner-blocks) > .editor-block-list__layout,
-  body .editor-post-title {
-    padding-left: 46px;
-    padding-right: 46px;
-  }
   body .editor-block-list__layout,
   body .editor-post-title {
     max-width: 80%;
@@ -67,7 +57,7 @@ body .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
     width: calc( 125% + 116px);
-    max-width: calc( 125% + 116px);
+    max-width: calc( 125% + 115px);
   }
   body .wp-block[data-align="right"] {
     max-width: 125%;

--- a/style-editor.css
+++ b/style-editor.css
@@ -27,8 +27,8 @@ body .wp-block[data-align="full"] {
 
 @media only screen and (min-width: 600px) {
   body .wp-block[data-align="full"] {
-    position: relative;
-    left: 45px;
+    width: calc( 100% + 90px);
+    max-width: calc( 100% + 90px);
   }
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -26,12 +26,6 @@ body .wp-block[data-align="full"] {
 }
 
 @media only screen and (min-width: 600px) {
-  body {
-    padding-top: 0;
-  }
-  body .editor-writing-flow {
-    padding-top: 50px;
-  }
   body .wp-block[data-align="full"] {
     position: relative;
     left: 45px;
@@ -39,8 +33,7 @@ body .wp-block[data-align="full"] {
 }
 
 @media only screen and (min-width: 768px) {
-  body .editor-block-list__layout,
-  body .editor-post-title {
+  body .editor-writing-flow {
     max-width: 80%;
     margin: 0 10%;
   }

--- a/style-editor.css
+++ b/style-editor.css
@@ -36,7 +36,6 @@ body .wp-block[data-align="full"] {
   }
   body .editor-writing-flow {
     padding-top: 50px;
-    overflow: hidden;
   }
   body .wp-block[data-align="full"] {
     position: relative;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -33,12 +33,6 @@ body {
 	@include media(mobile) {
 		padding-top: 0;
 
-		:not(.editor-inner-blocks) > .editor-block-list__layout, // Target only the top level layout element, or nested blocks will also be affected.
-		.editor-post-title {
-			padding-left: 0;
-			padding-right: 0;
-		}
-
 		.editor-writing-flow {
 			padding-top: 50px;
 		}
@@ -50,12 +44,6 @@ body {
 	}
 
 	@include media(tablet) {
-
-		:not(.editor-inner-blocks) > .editor-block-list__layout, // Target only the top level layout element, or nested blocks will also be affected.
-		.editor-post-title {
-			padding-left: 46px;
-			padding-right: 46px;
-		}
 
 		.editor-block-list__layout,
 		.editor-post-title {
@@ -78,7 +66,7 @@ body {
 			position: relative;
 			left: calc( -12.5% - 14px );
 			width: calc( 125% + 116px );
-			max-width: calc( 125% + 116px );
+			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages. 
 		}
 
 		.wp-block[data-align="right"] {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -41,7 +41,6 @@ body {
 
 		.editor-writing-flow {
 			padding-top: 50px;
-			overflow: hidden;
 		}
 
 		.wp-block[data-align="full"] {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -33,8 +33,8 @@ body {
 	@include media(mobile) {
 
 		.wp-block[data-align="full"] {
-			position: relative;
-			left: 45px;
+			width: calc( 100% + 90px );
+			max-width: calc( 100% + 90px );
 		}
 	}
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -31,11 +31,6 @@ body {
 	}
 
 	@include media(mobile) {
-		padding-top: 0;
-
-		.editor-writing-flow {
-			padding-top: 50px;
-		}
 
 		.wp-block[data-align="full"] {
 			position: relative;
@@ -45,8 +40,7 @@ body {
 
 	@include media(tablet) {
 
-		.editor-block-list__layout,
-		.editor-post-title {
+		.editor-writing-flow {
 			max-width: 80%;
 			margin: 0 10%;
 		}


### PR DESCRIPTION
When you are not using the "unified toolbar" option, toolbars scroll with you down the page if content inside it is long.

A recent addition broke that, so they were fixed to the top left of the block. This PR removes the rule that broke it. To explain what's going on, the overflow rule makes the `position: sticky;` not behave as intended. 

<img width="797" alt="screenshot 2018-11-13 at 12 14 37" src="https://user-images.githubusercontent.com/1204802/48410161-1a4c5980-e73e-11e8-98be-e6ce96cb4109.png">

However before this gets approved and merged, why was that overflow rule added? Usually it's a self-clearing thing, but wanted to make sure why so we don't cause other regressions. 