### PR TITLE
Fix search input style on iOS Safari

### DIFF
--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -20,17 +20,16 @@ textarea {
 	box-sizing: border-box;
 	outline: none;
 	padding: #{.36 * $size__spacing-unit} #{.66 * $size__spacing-unit};
+	-webkit-appearance: none;
+	outline-offset: 0;
+	border-radius: 0;
 
 	&:focus {
 		border-color: $color__link;
 		outline: thin solid rgba( $color__link, 0.15 );
 		outline-offset: -4px;
 	}
-}
 
-input[type="search"] {
-	-webkit-appearance: none;
-	outline-offset: 0;
 	&::-webkit-search-decoration {
 		display: none;
 	}

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -29,7 +29,9 @@ textarea {
 		outline: thin solid rgba( $color__link, 0.15 );
 		outline-offset: -4px;
 	}
+}
 
+input[type="search"] {
 	&::-webkit-search-decoration {
 		display: none;
 	}

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -28,6 +28,14 @@ textarea {
 	}
 }
 
+input[type="search"] {
+	-webkit-appearance: none;
+	outline-offset: 0;
+	&::-webkit-search-decoration {
+		display: none;
+	}
+}
+
 select {
 
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -967,22 +967,7 @@ textarea:focus {
   outline-offset: -4px;
 }
 
-input[type="text"]::-webkit-search-decoration,
-input[type="email"]::-webkit-search-decoration,
-input[type="url"]::-webkit-search-decoration,
-input[type="password"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-decoration,
-input[type="number"]::-webkit-search-decoration,
-input[type="tel"]::-webkit-search-decoration,
-input[type="range"]::-webkit-search-decoration,
-input[type="date"]::-webkit-search-decoration,
-input[type="month"]::-webkit-search-decoration,
-input[type="week"]::-webkit-search-decoration,
-input[type="time"]::-webkit-search-decoration,
-input[type="datetime"]::-webkit-search-decoration,
-input[type="datetime-local"]::-webkit-search-decoration,
-input[type="color"]::-webkit-search-decoration,
-textarea::-webkit-search-decoration {
+input[type="search"]::-webkit-search-decoration {
   display: none;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -941,6 +941,9 @@ textarea {
   box-sizing: border-box;
   outline: none;
   padding: 0.36rem 0.66rem;
+  -webkit-appearance: none;
+  outline-offset: 0;
+  border-radius: 0;
 }
 
 input[type="text"]:focus,
@@ -964,12 +967,22 @@ textarea:focus {
   outline-offset: -4px;
 }
 
-input[type="search"] {
-  -webkit-appearance: none;
-  outline-offset: 0;
-}
-
-input[type="search"]::-webkit-search-decoration {
+input[type="text"]::-webkit-search-decoration,
+input[type="email"]::-webkit-search-decoration,
+input[type="url"]::-webkit-search-decoration,
+input[type="password"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-decoration,
+input[type="number"]::-webkit-search-decoration,
+input[type="tel"]::-webkit-search-decoration,
+input[type="range"]::-webkit-search-decoration,
+input[type="date"]::-webkit-search-decoration,
+input[type="month"]::-webkit-search-decoration,
+input[type="week"]::-webkit-search-decoration,
+input[type="time"]::-webkit-search-decoration,
+input[type="datetime"]::-webkit-search-decoration,
+input[type="datetime-local"]::-webkit-search-decoration,
+input[type="color"]::-webkit-search-decoration,
+textarea::-webkit-search-decoration {
   display: none;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -964,6 +964,15 @@ textarea:focus {
   outline-offset: -4px;
 }
 
+input[type="search"] {
+  -webkit-appearance: none;
+  outline-offset: 0;
+}
+
+input[type="search"]::-webkit-search-decoration {
+  display: none;
+}
+
 textarea {
   box-sizing: border-box;
   display: block;

--- a/style.css
+++ b/style.css
@@ -967,22 +967,7 @@ textarea:focus {
   outline-offset: -4px;
 }
 
-input[type="text"]::-webkit-search-decoration,
-input[type="email"]::-webkit-search-decoration,
-input[type="url"]::-webkit-search-decoration,
-input[type="password"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-decoration,
-input[type="number"]::-webkit-search-decoration,
-input[type="tel"]::-webkit-search-decoration,
-input[type="range"]::-webkit-search-decoration,
-input[type="date"]::-webkit-search-decoration,
-input[type="month"]::-webkit-search-decoration,
-input[type="week"]::-webkit-search-decoration,
-input[type="time"]::-webkit-search-decoration,
-input[type="datetime"]::-webkit-search-decoration,
-input[type="datetime-local"]::-webkit-search-decoration,
-input[type="color"]::-webkit-search-decoration,
-textarea::-webkit-search-decoration {
+input[type="search"]::-webkit-search-decoration {
   display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -941,6 +941,9 @@ textarea {
   box-sizing: border-box;
   outline: none;
   padding: 0.36rem 0.66rem;
+  -webkit-appearance: none;
+  outline-offset: 0;
+  border-radius: 0;
 }
 
 input[type="text"]:focus,
@@ -964,12 +967,22 @@ textarea:focus {
   outline-offset: -4px;
 }
 
-input[type="search"] {
-  -webkit-appearance: none;
-  outline-offset: 0;
-}
-
-input[type="search"]::-webkit-search-decoration {
+input[type="text"]::-webkit-search-decoration,
+input[type="email"]::-webkit-search-decoration,
+input[type="url"]::-webkit-search-decoration,
+input[type="password"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-decoration,
+input[type="number"]::-webkit-search-decoration,
+input[type="tel"]::-webkit-search-decoration,
+input[type="range"]::-webkit-search-decoration,
+input[type="date"]::-webkit-search-decoration,
+input[type="month"]::-webkit-search-decoration,
+input[type="week"]::-webkit-search-decoration,
+input[type="time"]::-webkit-search-decoration,
+input[type="datetime"]::-webkit-search-decoration,
+input[type="datetime-local"]::-webkit-search-decoration,
+input[type="color"]::-webkit-search-decoration,
+textarea::-webkit-search-decoration {
   display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -964,6 +964,15 @@ textarea:focus {
   outline-offset: -4px;
 }
 
+input[type="search"] {
+  -webkit-appearance: none;
+  outline-offset: 0;
+}
+
+input[type="search"]::-webkit-search-decoration {
+  display: none;
+}
+
 textarea {
   box-sizing: border-box;
   display: block;


### PR DESCRIPTION
Style and look-and-feel of search input is defferent with other input elements on iOS Safari. This PR fixes it.

## Before

<img width="233" alt="twentynineteen-search-input-style1" src="https://user-images.githubusercontent.com/319783/48412809-20b3f300-e789-11e8-8f9d-ce2d0542f5cb.png">

## After

<img width="233" alt="twentynineteen-search-input-style2" src="https://user-images.githubusercontent.com/319783/48412825-27db0100-e789-11e8-9762-d35b985d7283.png">
