### PR TITLE
Improve file block button position

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -186,7 +186,8 @@ function twentynineteen_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color) {
+		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
 			color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' ); /* base: #0073a8; */
 		}
 
@@ -209,7 +210,8 @@ function twentynineteen_custom_colors_css() {
 
 		/* Hover colors */
 		.editor-block-list__layout .editor-block-list__block a:hover,
-		.editor-block-list__layout .editor-block-list__block a:active {
+		.editor-block-list__layout .editor-block-list__block a:active,
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
 			color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_hover . ' ); /* base: #005177; */
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -652,10 +652,7 @@
 			padding: ($size__spacing-unit * .75) $size__spacing-unit;
 			color: #fff;
 			margin-left: 0;
-
-			@include media(tablet) {
-				display: inline-block;
-			}
+			margin-top: calc(0.75 * #{$size__spacing-unit});
 
 			@include media(desktop) {
 				font-size: $font__size-base;
@@ -671,15 +668,6 @@
 				background: $color__background-button-hover;
 				outline: thin dotted;
 				outline-offset: -4px;
-			}
-		}
-
-		* + .wp-block-file__button {
-			margin-top: calc(0.75 * #{$size__spacing-unit});
-			
-			@include media(tablet) {
-				margin-top: 0;
-				margin-left: calc(0.75 * #{$size__spacing-unit});
 			}
 		}
 	}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -639,6 +639,7 @@
 		font-family: $font__heading;
 
 		.wp-block-file__button {
+			display: table;
 			@include button-transition;
 			border: none;
 			border-radius: 5px;
@@ -650,6 +651,11 @@
 			font-weight: bold;
 			padding: ($size__spacing-unit * .75) $size__spacing-unit;
 			color: #fff;
+			margin-left: 0;
+
+			@include media(tablet) {
+				display: inline-block;
+			}
 
 			@include media(desktop) {
 				font-size: $font__size-base;
@@ -669,7 +675,12 @@
 		}
 
 		* + .wp-block-file__button {
-			margin-left: ($size__spacing-unit * .75);
+			margin-top: calc(0.75 * #{$size__spacing-unit});
+			
+			@include media(tablet) {
+				margin-top: 0;
+				margin-left: calc(0.75 * #{$size__spacing-unit});
+			}
 		}
 	}
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -508,12 +508,28 @@ figcaption,
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+.wp-block-file .wp-block-file__textlink {
+  text-decoration: underline;
+  color: #0073aa;
+}
+
+.wp-block-file .wp-block-file__textlink:hover {
+  color: #005177;
+  text-decoration: none;
+}
+
 .wp-block-file .wp-block-file__button {
+  display: table;
   line-height: 1.8;
   font-size: 0.88889em;
   font-weight: bold;
   background-color: #0073aa;
   border-radius: 5px;
+}
+
+.wp-block-file .wp-block-file__button-richtext-wrapper {
+  margin-top: calc(0.75 * 1rem);
+  margin-left: 0;
 }
 
 /** === Verse === */

--- a/style-editor.css
+++ b/style-editor.css
@@ -528,6 +528,7 @@ figcaption,
 }
 
 .wp-block-file .wp-block-file__button-richtext-wrapper {
+  display: block;
   margin-top: calc(0.75 * 1rem);
   margin-left: 0;
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -523,13 +523,30 @@ figcaption,
 .wp-block-file {
 	font-family: $font__heading;
 
+	.wp-block-file__textlink {
+		text-decoration: underline;
+		color: $color__link;
+
+		&:hover {
+			color: $color__link-hover;
+			text-decoration: none;
+		}
+	}
+
 	.wp-block-file__button {
+		display: table;
 		line-height: 1.8;
 		font-size: $font__size-sm;
 		font-weight: bold;
 		background-color: $color__link;
 		border-radius: 5px;
 	}
+
+	.wp-block-file__button-richtext-wrapper {
+		margin-top: calc(0.75 * #{$size__spacing-unit});
+		margin-left: 0;
+	}
+
 }
 
 /** === Verse === */

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -543,6 +543,7 @@ figcaption,
 	}
 
 	.wp-block-file__button-richtext-wrapper {
+		display: block;
 		margin-top: calc(0.75 * #{$size__spacing-unit});
 		margin-left: 0;
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4303,12 +4303,7 @@ body.page .main-navigation {
   padding: 0.75rem 1rem;
   color: #fff;
   margin-right: 0;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-file .wp-block-file__button {
-    display: inline-block;
-  }
+  margin-top: calc(0.75 * 1rem);
 }
 
 @media only screen and (min-width: 1168px) {
@@ -4327,12 +4322,6 @@ body.page .main-navigation {
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-file * + .wp-block-file__button {
-    margin-top: calc(0.75 * 1rem);
-  }
 }
 
 .entry .entry-content .wp-block-code {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4290,6 +4290,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-file .wp-block-file__button {
+  display: table;
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
@@ -4301,6 +4302,13 @@ body.page .main-navigation {
   font-weight: bold;
   padding: 0.75rem 1rem;
   color: #fff;
+  margin-right: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-file .wp-block-file__button {
+    display: inline-block;
+  }
 }
 
 @media only screen and (min-width: 1168px) {
@@ -4321,8 +4329,10 @@ body.page .main-navigation {
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-file * + .wp-block-file__button {
-  margin-right: 0.75rem;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-file * + .wp-block-file__button {
+    margin-top: calc(0.75 * 1rem);
+  }
 }
 
 .entry .entry-content .wp-block-code {

--- a/style.css
+++ b/style.css
@@ -4302,6 +4302,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-file .wp-block-file__button {
+  display: table;
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
@@ -4313,6 +4314,13 @@ body.page .main-navigation {
   font-weight: bold;
   padding: 0.75rem 1rem;
   color: #fff;
+  margin-left: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-file .wp-block-file__button {
+    display: inline-block;
+  }
 }
 
 @media only screen and (min-width: 1168px) {
@@ -4334,7 +4342,14 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-file * + .wp-block-file__button {
-  margin-left: 0.75rem;
+  margin-top: calc(0.75 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-file * + .wp-block-file__button {
+    margin-top: 0;
+    margin-left: calc(0.75 * 1rem);
+  }
 }
 
 .entry .entry-content .wp-block-code {

--- a/style.css
+++ b/style.css
@@ -4315,12 +4315,7 @@ body.page .main-navigation {
   padding: 0.75rem 1rem;
   color: #fff;
   margin-left: 0;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-file .wp-block-file__button {
-    display: inline-block;
-  }
+  margin-top: calc(0.75 * 1rem);
 }
 
 @media only screen and (min-width: 1168px) {
@@ -4339,17 +4334,6 @@ body.page .main-navigation {
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
-}
-
-.entry .entry-content .wp-block-file * + .wp-block-file__button {
-  margin-top: calc(0.75 * 1rem);
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-file * + .wp-block-file__button {
-    margin-top: 0;
-    margin-left: calc(0.75 * 1rem);
-  }
 }
 
 .entry .entry-content .wp-block-code {


### PR DESCRIPTION
This PR helps prevent broken-looking button positioning that occurred when the file description took up multiple lines (this happened frequently on small screens). Instead, this PR pushes the button onto its own line at all times. This change occurs in both the front end and editor.

This PR also syncs up the text styles for the button description. Previously the front end treated this as a link, while the editor displayed it as black text.

## Before

_Front End:_

![screen shot 2018-11-13 at 9 28 26 am](https://user-images.githubusercontent.com/1202812/48419899-15c87680-e727-11e8-8b9e-d7ceeded8f9a.png)

_Editor:_

![screen shot 2018-11-13 at 9 28 18 am](https://user-images.githubusercontent.com/1202812/48419905-18c36700-e727-11e8-8b9a-9eb42ae22bf2.png)

## After

_Front End:_

![screen shot 2018-11-13 at 9 26 28 am](https://user-images.githubusercontent.com/1202812/48419925-25e05600-e727-11e8-98e9-5a647d928cd5.png)

_Editor:_

![screen shot 2018-11-13 at 9 23 32 am](https://user-images.githubusercontent.com/1202812/48419960-414b6100-e727-11e8-88d3-faeea02b3648.png)
