### PR TITLE
Hide empty links within menu items

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -181,6 +181,10 @@
 				}
 			}
 
+			> a:empty {
+				display: none;
+			}
+
 			&.mobile-parent-nav-menu-item {
 
 				display: none;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1184,6 +1184,10 @@ body.page .main-navigation {
   background: #005177;
 }
 
+.main-navigation .sub-menu > li > a:empty {
+  height: 0;
+}
+
 .main-navigation .sub-menu > li.mobile-parent-nav-menu-item {
   display: none;
   font-size: 0.88889em;

--- a/style.css
+++ b/style.css
@@ -1184,6 +1184,10 @@ body.page .main-navigation {
   background: #005177;
 }
 
+.main-navigation .sub-menu > li > a:empty {
+  display: none;
+}
+
 .main-navigation .sub-menu > li.mobile-parent-nav-menu-item {
   display: none;
   font-size: 0.88889em;


### PR DESCRIPTION
Fixes #587 

When a submenu item link is empty, we should not display it. Currently, empty links are shown in the menu, and can be hovered (but not clicked on). 

To test:

- Create a "Custom Link" top-level menu item [with an empty URL field](https://cloudup.com/cKEWKJOED5A).
- Add a submenu item.
- Compare to the comps below. This should result in [an empty `<a>` tag inside one of your list items](https://cloudup.com/cRBuA1Sd4ld), but it should be hidden. 

**Before:**

![screen shot 2018-11-13 at 7 52 53 pm](https://user-images.githubusercontent.com/1202812/48452772-923a7400-e77e-11e8-9ff6-77dfe64be0e3.png)

![menu-older](https://user-images.githubusercontent.com/1202812/48452798-ae3e1580-e77e-11e8-9432-894262ba55ae.gif)

**After:**

![screen shot 2018-11-13 at 7 52 42 pm](https://user-images.githubusercontent.com/1202812/48452804-b72ee700-e77e-11e8-936c-1e105c9cbf3c.png)

![menu-old](https://user-images.githubusercontent.com/1202812/48452806-b9914100-e77e-11e8-8629-500239741030.gif)