### PR TITLE
Add front end padding to column blocks.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -681,6 +681,11 @@
 	//! Columns
 	.wp-block-columns {
 
+		&.alignfull {
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
+		}
+
 		@include media(tablet) {
 			.wp-block-column > * {
 
@@ -706,11 +711,6 @@
 				padding-left: calc(2 * #{$size__spacing-unit});
 				padding-right: calc(2 * #{$size__spacing-unit});
 			}
-		}
-
-		&.alignfull, {
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -700,6 +700,17 @@
 					margin-right: 0;
 				}
 			}
+
+			&.alignfull,
+			&.alignfull .wp-block-column {
+				padding-left: calc(2 * #{$size__spacing-unit});
+				padding-right: calc(2 * #{$size__spacing-unit});
+			}
+		}
+
+		&.alignfull, {
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4361,12 +4361,16 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
     margin-left: 0;
   }
+  .entry .entry-content .wp-block-columns.alignfull,
+  .entry .entry-content .wp-block-columns.alignfull .wp-block-column {
+    padding-right: calc(2 * 1rem);
+    padding-left: calc(2 * 1rem);
+  }
 }
 
-.entry .entry-content .wp-block-columns.alignfull,
-.entry .entry-content .wp-block-columns.alignfull .wp-block-column {
-  padding-right: calc( 2* 1rem);
-  padding-left: calc( 2* 1rem);
+.entry .entry-content .wp-block-columns.alignfull {
+  padding-right: 1rem;
+  padding-left: 1rem;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4363,6 +4363,12 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content .wp-block-columns.alignfull,
+.entry .entry-content .wp-block-columns.alignfull .wp-block-column {
+  padding-right: calc( 2* 1rem);
+  padding-left: calc( 2* 1rem);
+}
+
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4348,6 +4348,11 @@ body.page .main-navigation {
   word-break: break-word;
 }
 
+.entry .entry-content .wp-block-columns.alignfull {
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;
@@ -4366,11 +4371,6 @@ body.page .main-navigation {
     padding-right: calc(2 * 1rem);
     padding-left: calc(2 * 1rem);
   }
-}
-
-.entry .entry-content .wp-block-columns.alignfull {
-  padding-right: 1rem;
-  padding-left: 1rem;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {

--- a/style.css
+++ b/style.css
@@ -4360,6 +4360,11 @@ body.page .main-navigation {
   word-break: break-word;
 }
 
+.entry .entry-content .wp-block-columns.alignfull {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;
@@ -4378,11 +4383,6 @@ body.page .main-navigation {
     padding-left: calc(2 * 1rem);
     padding-right: calc(2 * 1rem);
   }
-}
-
-.entry .entry-content .wp-block-columns.alignfull {
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {

--- a/style.css
+++ b/style.css
@@ -4373,6 +4373,16 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
     margin-right: 0;
   }
+  .entry .entry-content .wp-block-columns.alignfull,
+  .entry .entry-content .wp-block-columns.alignfull .wp-block-column {
+    padding-left: calc(2 * 1rem);
+    padding-right: calc(2 * 1rem);
+  }
+}
+
+.entry .entry-content .wp-block-columns.alignfull {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {


### PR DESCRIPTION
Fixes #517.

This PR seeks to add some padding to our `alignfull` columns so that they match up more closely with the editor.

**Appearance in editor:**

_Note: this is based on the columns appearance seen in the #575 branch. That happens to correct a bug that inserts too-wide margins on the columns block. As a result, it might be helpful to wait until that PR is merged to text/merge this one._

![screen shot 2018-11-14 at 11 02 10 am](https://user-images.githubusercontent.com/1202812/48495358-ca34cc00-e7fd-11e8-9a1a-fe29f417f0b0.png)

**Current appearance in front end:**

![screen shot 2018-11-14 at 11 08 08 am](https://user-images.githubusercontent.com/1202812/48495393-dcaf0580-e7fd-11e8-9daf-0756f1f0ce8b.png)

**Updated appearance in front end:** 

_Note: This does not line up exactly. But that's mostly because the editor seems to add inconsistent margins on the left and right side of the columns block when it's full-screen. I've filed a Gutenberg bug for that (https://github.com/WordPress/gutenberg/issues/11869), but in the meantime we don't want to replicate that error._

![screen shot 2018-11-14 at 11 02 23 am](https://user-images.githubusercontent.com/1202812/48495419-e9cbf480-e7fd-11e8-9e6f-a48977a9ad5f.png)

---

This also adds padding to smaller screens: 

**Before:** 
![screen shot 2018-11-14 at 11 30 43 am](https://user-images.githubusercontent.com/1202812/48496796-ce161d80-e800-11e8-988b-c19fc60d1858.png)

**After**
![screen shot 2018-11-14 at 11 31 06 am](https://user-images.githubusercontent.com/1202812/48496803-d1110e00-e800-11e8-9b2e-f89475bfa120.png)