### PR TITLE
Minor: Update header font weight in editor.

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -98,6 +98,7 @@ h4,
 h5,
 h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-weight: 700;
 }
 
 h1 {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -95,6 +95,7 @@ h4,
 h5,
 h6 {
 	font-family: $font__heading;
+	font-weight: 700;
 }
 
 h1 {


### PR DESCRIPTION
Fixes #592

Both are bold, but should use 700 weight instead of 600 weight.

**Before:**
![screen shot 2018-11-14 at 12 07 56 pm](https://user-images.githubusercontent.com/1202812/48499215-ef2d3d00-e805-11e8-95a0-57819d251ebf.png)

**After:**
![screen shot 2018-11-14 at 12 07 38 pm](https://user-images.githubusercontent.com/1202812/48499221-f18f9700-e805-11e8-91ba-b36c82c156f8.png)
