### PR TITLE
Restore README.md line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![Build Status](https://travis-ci.org/WordPress/twentynineteen.svg?branch=master)](https://travis-ci.org/WordPress/twentynineteen)
 
-**Contributors:** the WordPress team
-**Requires at least:** WordPress 4.9.6
-**Tested up to:** WordPress 4.9.8
-**Version:** 1.0
-**License:** GPLv2 or later
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+**Contributors:** the WordPress team  
+**Requires at least:** WordPress 4.9.6  
+**Tested up to:** WordPress 4.9.8  
+**Version:** 1.0  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 **Tags:** one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
 
 ## Description


### PR DESCRIPTION
These were removed in #507, but are actually valid markdown syntax for line breaks. 

This can be verified by visiting the README in this banch and verifying that the first section has appropriate line breaks:

https://github.com/WordPress/twentynineteen/blob/fix/readme-line-breaks/README.md