### PR TITLE
Try: Removing overflow: hidden from Twitter block

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -617,7 +617,7 @@
 
 	//! Twitter Embed
 	.wp-block-embed-twitter {
-		overflow: hidden;
+		word-break: break-word;
 	}
 
 	//! Table

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4299,7 +4299,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-embed-twitter {
-  overflow: hidden;
+  word-break: break-word;
 }
 
 .entry .entry-content .wp-block-table th,

--- a/style.css
+++ b/style.css
@@ -4311,7 +4311,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-embed-twitter {
-  overflow: hidden;
+  word-break: break-word;
 }
 
 .entry .entry-content .wp-block-table th,


### PR DESCRIPTION
I'm not sure exactly why this rule is in place, but I think it's causing #500. I can't reproduce the same error noted in that ticket, but I do see clipped text if I'm on a small screen and the embed doesn't load (I tested this by loading my local test site while my computer's offline): 

![screen shot 2018-11-14 at 2 21 11 pm](https://user-images.githubusercontent.com/1202812/48507597-5bb23700-e81a-11e8-9fc2-e66e721d10a0.png)

Removing the `overflow: hidden;` rule and replacing it with `word-wrap: break-word;` fixes that: 

![screen shot 2018-11-14 at 2 20 33 pm](https://user-images.githubusercontent.com/1202812/48507601-5ead2780-e81a-11e8-97e6-cd42840f99ad.png)

... and also seems to have no negative effects on other states of the embed: 

_Partially loaded_

![screen shot 2018-11-14 at 2 23 08 pm](https://user-images.githubusercontent.com/1202812/48507646-7d132300-e81a-11e8-846a-cff88432f51a.png)

_Default_

![screen shot 2018-11-14 at 2 25 13 pm](https://user-images.githubusercontent.com/1202812/48507656-8603f480-e81a-11e8-8b5d-098bd78fbdc2.png)
