### PR TITLE
Adds button styles to legacy wp `.button` class elements

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -82,7 +82,7 @@ function twentynineteen_custom_colors_css() {
 		 * - Widget links
 		 */
 		a,
-		a:visited,
+		a:not(.button):visited,
 		.main-navigation .main-menu > li,
 		.main-navigation ul.main-menu > li > a,
 		.post-navigation .post-title,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -238,7 +238,7 @@
 		ul {
 			padding-top: ( .75 * $size__spacing-unit );
 		}
-		
+
 		li ul {
 			list-style: none;
 			padding-left: 0;

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -9,25 +9,28 @@ input[type="submit"] {
 	border: none;
 	border-radius: 5px;
 	box-sizing: border-box;
-	color: white;
+	color: $color__background-body;
 	font-family: $font__heading;
 	font-size: $font__size-sm;
-	font-weight: 600;
+	font-weight: 700;
 	line-height: $font__line-height-heading;
 	outline: none;
 	padding: ( $size__spacing-unit * .76 ) $size__spacing-unit;
+	text-decoration: none;
 	vertical-align: bottom;
 
 	&:hover {
+		background: $color__background-button-hover;
 		cursor: pointer;
 	}
 
-	&:hover,
-	&:focus {
-		background: $color__background-button-hover;
+	&:visited {
+		color: $color__background-body;
+		text-decoration: none;
 	}
 
 	&:focus {
+		background: $color__background-button-hover;
 		outline: thin dotted;
 		outline-offset: -4px;
 	}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -212,8 +212,14 @@
 		a {
 			text-decoration: underline;
 
+			&.button,
 			&:hover {
 				text-decoration: none;
+			}
+
+			&.button:hover {
+				background: $color__background-button-hover;
+				cursor: pointer;
 			}
 		}
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -46,7 +46,7 @@ body {
 			position: relative;
 			left: calc( -12.5% - 14px );
 			width: calc( 125% + 116px );
-			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages. 
+			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages.
 		}
 
 		.wp-block[data-align="right"] {
@@ -482,9 +482,9 @@ figcaption,
 }
 
 .wp-block[data-type="core/pullquote"][data-align="full"] {
-	
+
 	@include media(tablet) {
-		
+
 		.wp-block-pullquote blockquote {
 			max-width: calc(80% - 128px);
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -893,13 +893,14 @@ input[type="submit"] {
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
-  color: white;
+  color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1.2;
   outline: none;
   padding: 0.76rem 1rem;
+  text-decoration: none;
   vertical-align: bottom;
 }
 
@@ -908,19 +909,17 @@ button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
+  background: #111;
   cursor: pointer;
 }
 
-.button:hover, .button:focus,
-button:hover,
-button:focus,
-input[type="button"]:hover,
-input[type="button"]:focus,
-input[type="reset"]:hover,
-input[type="reset"]:focus,
-input[type="submit"]:hover,
-input[type="submit"]:focus {
-  background: #111;
+.button:visited,
+button:visited,
+input[type="button"]:visited,
+input[type="reset"]:visited,
+input[type="submit"]:visited {
+  color: #fff;
+  text-decoration: none;
 }
 
 .button:focus,
@@ -928,6 +927,7 @@ button:focus,
 input[type="button"]:focus,
 input[type="reset"]:focus,
 input[type="submit"]:focus {
+  background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
@@ -2717,8 +2717,13 @@ body.page .main-navigation {
   text-decoration: underline;
 }
 
-.entry .entry-content a:hover {
+.entry .entry-content a.button, .entry .entry-content a:hover {
   text-decoration: none;
+}
+
+.entry .entry-content a.button:hover {
+  background: #111;
+  cursor: pointer;
 }
 
 .entry .entry-content > iframe[style] {

--- a/style.css
+++ b/style.css
@@ -893,13 +893,14 @@ input[type="submit"] {
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
-  color: white;
+  color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1.2;
   outline: none;
   padding: 0.76rem 1rem;
+  text-decoration: none;
   vertical-align: bottom;
 }
 
@@ -908,19 +909,17 @@ button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
+  background: #111;
   cursor: pointer;
 }
 
-.button:hover, .button:focus,
-button:hover,
-button:focus,
-input[type="button"]:hover,
-input[type="button"]:focus,
-input[type="reset"]:hover,
-input[type="reset"]:focus,
-input[type="submit"]:hover,
-input[type="submit"]:focus {
-  background: #111;
+.button:visited,
+button:visited,
+input[type="button"]:visited,
+input[type="reset"]:visited,
+input[type="submit"]:visited {
+  color: #fff;
+  text-decoration: none;
 }
 
 .button:focus,
@@ -928,6 +927,7 @@ button:focus,
 input[type="button"]:focus,
 input[type="reset"]:focus,
 input[type="submit"]:focus {
+  background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
@@ -2723,8 +2723,13 @@ body.page .main-navigation {
   text-decoration: underline;
 }
 
-.entry .entry-content a:hover {
+.entry .entry-content a.button, .entry .entry-content a:hover {
   text-decoration: none;
+}
+
+.entry .entry-content a.button:hover {
+  background: #111;
+  cursor: pointer;
 }
 
 .entry .entry-content > iframe[style] {


### PR DESCRIPTION
Adds a fix for #567 

Many WP themes include a `a.button` class to allow users to make normal links look like buttons. This PR fixes an issue where `a.button:visited` button links would run into a color conflict. 

Before:
![image](https://user-images.githubusercontent.com/709581/48517004-fc145580-e832-11e8-9cab-8afb414e1cde.png)

After: 
![image](https://user-images.githubusercontent.com/709581/48516966-e69f2b80-e832-11e8-89c9-00c57354feb8.png)

This PR fixes the color conflict but it does not include styles for the editor since the `a.button` markup is the same as normal text-link markup in the editor. It does not use the same `editable` element wrappers that are used in the Button Block, and so there’s a simple way to make the `a.button` styles match the Button Block styles while still being editable text. The end result is this: 

![fix-visited-button-links-2](https://user-images.githubusercontent.com/709581/48517647-f9b2fb00-e834-11e8-93f1-ff00dd578263.gif)

@kjellr or @jasmussen how do you think we should best deal with this? 