### PR TITLE
Reduce saturation and increase lightness in text-selection color for better contrast/legibility

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -38,7 +38,7 @@ function twentynineteen_custom_colors_css() {
 	$lightness_hover      = absint( apply_filters( 'twentynineteen_custom_colors_lightness_hover', 23 ) );
 	$lightness_hover      = $lightness_hover . '%';
 
-	$lightness_selection  = absint( apply_filters( 'twentynineteen_custom_colors_lightness_selection', 90 ) );
+	$lightness_selection  = absint( apply_filters( 'twentynineteen_custom_colors_lightness_selection', 95 ) );
 	$lightness_selection  = $lightness_selection . '%';
 
 	$theme_css = '

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -26,17 +26,20 @@ function twentynineteen_custom_colors_css() {
 	 * @param int $saturation Color saturation level.
 	 */
 
-	$saturation          = absint( apply_filters( 'twentynineteen_custom_colors_saturation', 100 ) );
-	$saturation          = $saturation . '%';
+	$saturation           = absint( apply_filters( 'twentynineteen_custom_colors_saturation', 100 ) );
+	$saturation           = $saturation . '%';
 
-	$lightness           = absint( apply_filters( 'twentynineteen_custom_colors_lightness', 33 ) );
-	$lightness           = $lightness . '%';
+	$saturation_selection = absint( apply_filters( 'twentynineteen_custom_colors_saturation_selection', 50 ) );
+	$saturation_selection = $saturation_selection . '%';
 
-	$lightness_hover     = absint( apply_filters( 'twentynineteen_custom_colors_lightness_hover', 23 ) );
-	$lightness_hover     = $lightness_hover . '%';
+	$lightness            = absint( apply_filters( 'twentynineteen_custom_colors_lightness', 33 ) );
+	$lightness            = $lightness . '%';
 
-	$lightness_selection = absint( apply_filters( 'twentynineteen_custom_colors_lightness_selection', 90 ) );
-	$lightness_selection = $lightness_selection . '%';
+	$lightness_hover      = absint( apply_filters( 'twentynineteen_custom_colors_lightness_hover', 23 ) );
+	$lightness_hover      = $lightness_hover . '%';
+
+	$lightness_selection  = absint( apply_filters( 'twentynineteen_custom_colors_lightness_selection', 90 ) );
+	$lightness_selection  = $lightness_selection . '%';
 
 	$theme_css = '
 		/*
@@ -168,10 +171,10 @@ function twentynineteen_custom_colors_css() {
 
 		/* Text selection colors */
 		::selection {
-			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_selection . ' ); /* base: #005177; */
+			background-color: hsl( ' . $primary_color . ', ' . $saturation_selection . ', ' . $lightness_selection . ' ); /* base: #005177; */
 		}
 		::-moz-selection {
-			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness_selection . ' ); /* base: #005177; */
+			background-color: hsl( ' . $primary_color . ', ' . $saturation_selection . ', ' . $lightness_selection . ' ); /* base: #005177; */
 		}';
 
 	$editor_css = '


### PR DESCRIPTION
This is a small changes that improves legibility for selected text when using custom colors.

Before: 
![selection-color-before](https://user-images.githubusercontent.com/709581/48571450-e0618b80-e8d4-11e8-99fa-f606cb9a098d.gif)

After:
![selection-color-after](https://user-images.githubusercontent.com/709581/48571584-333b4300-e8d5-11e8-8513-976c6381be37.gif)
