### PR TITLE
Prevent the nav-menu ellipses icon from appearing when javascript is disabled

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -212,7 +212,7 @@ function twentynineteen_add_ellipses_to_nav( $nav_menu, $args ) {
 		$nav_menu .= '<span class="submenu-expand main-menu-more-toggle is-empty" tabindex="-1">';
 		$nav_menu .= twentynineteen_get_icon_svg( 'arrow_drop_down_ellipsis' );
 		$nav_menu .= '</span>';
-		$nav_menu .= '<ul class="sub-menu hidden-links is-hidden">';
+		$nav_menu .= '<ul class="sub-menu hidden-links">';
 		$nav_menu .= '<li id="menu-item--1" class="mobile-parent-nav-menu-item menu-item--1">';
 		$nav_menu .= '<span class="menu-item-link-return">';
 		$nav_menu .= twentynineteen_get_icon_svg( 'chevron_left' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -205,11 +205,11 @@ function twentynineteen_add_ellipses_to_nav( $nav_menu, $args ) {
 
 	if ( 'menu-1' === $args->theme_location ) :
 
-		$nav_menu .= '<div class="main-menu-more"	>';
+		$nav_menu .= '<div class="main-menu-more">';
 		$nav_menu .= '<ul class="main-menu" tabindex="0">';
 		$nav_menu .= '<li class="menu-item menu-item-has-children">';
 		$nav_menu .= '<a href="#" class="screen-reader-text" aria-label="More" aria-haspopup="true" aria-expanded="false">' . esc_html__( 'More', 'twentynineteen' ) . '</a>';
-		$nav_menu .= '<span class="submenu-expand main-menu-more-toggle" tabindex="-1">';
+		$nav_menu .= '<span class="submenu-expand main-menu-more-toggle is-empty" tabindex="-1">';
 		$nav_menu .= twentynineteen_get_icon_svg( 'arrow_drop_down_ellipsis' );
 		$nav_menu .= '</span>';
 		$nav_menu .= '<ul class="sub-menu hidden-links is-hidden">';

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -73,6 +73,28 @@
 	}
 
 	/**
+	 * Shows an element by adding a hidden className.
+	 *
+	 * @param {Element} element
+	 */
+	function showButton(element) {
+		// classList.remove is not supported in IE11
+		element.className = element.className.replace('is-empty', '');
+	}
+
+	/**
+	 * Hides an element by removing the hidden className.
+	 *
+	 * @param {Element} element
+	 */
+	function hideButton(element) {
+		// classList.add is not supported in IE11
+		if (!element.classList.contains('is-empty')) {
+			element.className += ' is-empty';
+		}
+	}
+
+	/**
 	 * Returns the currently available space in the menu container.
 	 *
 	 * @returns {number} Available space
@@ -113,7 +135,9 @@
 			// Move last item to the hidden list
 			prependElement( hiddenList, ! visibleList.lastChild || null === visibleList.lastChild ? visibleList.previousElementSibling : visibleList.lastChild );
 			// Show the toggle button
-			showElement( toggleButton );
+			showButton( toggleButton );
+
+			console.log(toggleButton);
 
 		} else {
 
@@ -126,7 +150,7 @@
 
 			// Hide the dropdown btn if hidden list is empty
 			if (breaks.length < 2) {
-				hideElement( toggleButton );
+				hideButton( toggleButton );
 				hideElement( hiddenList );
 			}
 		}

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -55,28 +55,6 @@
 	 *
 	 * @param {Element} element
 	 */
-	function showElement(element) {
-		// classList.remove is not supported in IE11
-		element.className = element.className.replace('is-hidden', '');
-	}
-
-	/**
-	 * Hides an element by removing the hidden className.
-	 *
-	 * @param {Element} element
-	 */
-	function hideElement(element) {
-		// classList.add is not supported in IE11
-		if (!element.classList.contains('is-hidden')) {
-			element.className += ' is-hidden';
-		}
-	}
-
-	/**
-	 * Shows an element by adding a hidden className.
-	 *
-	 * @param {Element} element
-	 */
 	function showButton(element) {
 		// classList.remove is not supported in IE11
 		element.className = element.className.replace('is-empty', '');
@@ -100,7 +78,7 @@
 	 * @returns {number} Available space
 	 */
 	function getAvailableSpace( button, container ) {
-		return button.classList.contains('is-hidden') ? container.offsetWidth : container.offsetWidth - button.offsetWidth - 50;
+		return container.offsetWidth - button.offsetWidth - 50;
 	}
 
 	/**
@@ -137,8 +115,6 @@
 			// Show the toggle button
 			showButton( toggleButton );
 
-			console.log(toggleButton);
-
 		} else {
 
 			// There is space for another item in the nav
@@ -151,7 +127,6 @@
 			// Hide the dropdown btn if hidden list is empty
 			if (breaks.length < 2) {
 				hideButton( toggleButton );
-				hideElement( hiddenList );
 			}
 		}
 

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -87,8 +87,8 @@
 					}
 
 					.wp-customizer-unloading &,
-					&.is-hidden {
-						display: none;
+					&.is-empty {
+						opacity: 0;
 					}
 
 					svg {

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -88,7 +88,7 @@
 
 					.wp-customizer-unloading &,
 					&.is-empty {
-						opacity: 0;
+						display: none;
 					}
 
 					svg {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1116,8 +1116,8 @@ body.page .main-navigation {
   vertical-align: text-bottom;
 }
 
-.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-hidden {
-  display: none;
+.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
+  opacity: 0;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1117,7 +1117,7 @@ body.page .main-navigation {
 }
 
 .wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
-  opacity: 0;
+  display: none;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {

--- a/style.css
+++ b/style.css
@@ -1116,8 +1116,8 @@ body.page .main-navigation {
   vertical-align: text-bottom;
 }
 
-.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-hidden {
-  display: none;
+.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
+  opacity: 0;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {

--- a/style.css
+++ b/style.css
@@ -1117,7 +1117,7 @@ body.page .main-navigation {
 }
 
 .wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
-  opacity: 0;
+  display: none;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {


### PR DESCRIPTION
Fixes: #604 

Adds an `.is-empty` class which operates independently of `.is-hidden` which is only necessary for the list of hidden links. This also makes sure the nav-menu ellipses icon is hidden whenever it is empty including on first page load and on customizer refreshes.

![image](https://user-images.githubusercontent.com/709581/48575242-6aaeed00-e8df-11e8-9a41-f606d6862c7d.png)
