### PR TITLE
Submenu: Fix shift-tab navigation and animation

### DIFF
--- a/js/touch-keyboard-navigation.js
+++ b/js/touch-keyboard-navigation.js
@@ -285,20 +285,20 @@
 			if ( event.target.matches('.main-navigation > div > ul > li a') ) {
 
 				// Remove Focused elements in sibling div
-				var currentDiv        = getCurrentParent( event.target, 'div' );
+				var currentDiv        = getCurrentParent( event.target, 'div', '.main-navigation' );
 				var currentDivSibling = currentDiv.previousElementSibling === null ? currentDiv.nextElementSibling : currentDiv.previousElementSibling;
 				var focusedElement    = currentDivSibling.querySelector( '.is-focused' );
 				var focusedClass      = 'is-focused';
-				var prevLi            = getCurrentParent( event.target, '.main-navigation > div > ul > li' ).previousElementSibling;
-				var nextLi            = getCurrentParent( event.target, '.main-navigation > div > ul > li' ).nextElementSibling;
+				var prevLi            = getCurrentParent( event.target, '.main-navigation > div > ul > li', '.main-navigation' ).previousElementSibling;
+				var nextLi            = getCurrentParent( event.target, '.main-navigation > div > ul > li', '.main-navigation' ).nextElementSibling;
 
 				if ( null !== focusedElement && null !== hasClass( focusedElement, focusedClass ) ) {
 					deleteClass( focusedElement, focusedClass );
 				}
 
 				// Add .is-focused class to top-level li
-				if ( getCurrentParent( event.target, '.main-navigation > div > ul > li' ) ) {
-					addClass( getCurrentParent( event.target, '.main-navigation > div > ul > li' ), focusedClass );
+				if ( getCurrentParent( event.target, '.main-navigation > div > ul > li', '.main-navigation' ) ) {
+					addClass( getCurrentParent( event.target, '.main-navigation > div > ul > li', '.main-navigation' ), focusedClass );
 				}
 
 				// Check for previous li

--- a/js/touch-keyboard-navigation.js
+++ b/js/touch-keyboard-navigation.js
@@ -282,23 +282,23 @@
 
 		document.addEventListener('focus', function(event) {
 
-			if ( event.target.matches('.main-navigation > div > ul > li > a') ) {
+			if ( event.target.matches('.main-navigation > div > ul > li a') ) {
 
-				// Remove Focuse elements in sibling div
+				// Remove Focused elements in sibling div
 				var currentDiv        = getCurrentParent( event.target, 'div' );
 				var currentDivSibling = currentDiv.previousElementSibling === null ? currentDiv.nextElementSibling : currentDiv.previousElementSibling;
 				var focusedElement    = currentDivSibling.querySelector( '.is-focused' );
 				var focusedClass      = 'is-focused';
-				var prevLi            = event.target.parentNode.previousElementSibling;
-				var nextLi            = event.target.parentNode.nextElementSibling;
+				var prevLi            = getCurrentParent( event.target, '.main-navigation > div > ul > li' ).previousElementSibling;
+				var nextLi            = getCurrentParent( event.target, '.main-navigation > div > ul > li' ).nextElementSibling;
 
 				if ( null !== focusedElement && null !== hasClass( focusedElement, focusedClass ) ) {
 					deleteClass( focusedElement, focusedClass );
 				}
 
-				// Add .is-focused class to top-level ul
-				if ( event.target.parentNode.querySelector( '.main-navigation ul ul') ) {
-					addClass( event.target.parentNode, focusedClass );
+				// Add .is-focused class to top-level li
+				if ( getCurrentParent( event.target, '.main-navigation > div > ul > li' ) ) {
+					addClass( getCurrentParent( event.target, '.main-navigation > div > ul > li' ), focusedClass );
 				}
 
 				// Check for previous li
@@ -311,6 +311,7 @@
 					deleteClass( nextLi, focusedClass );
 				}
 			}
+
 		}, true);
 
 		document.addEventListener('click', function(event) {

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -400,11 +400,16 @@
 	}
 
 	/**
+	 * Fade-in animation for top-level submenus
+	 */
+	.main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
+		animation: fade_in 0.1s forwards;
+	}
+
+	/**
 	 * Full-screen touch device styles
 	 */
 	.main-menu .menu-item-has-children.off-canvas .sub-menu {
-
-		animation: fade_in 0.1s forwards;
 
 		.submenu-expand .svg-icon {
 			transform: rotate(270deg);

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -112,7 +112,6 @@
 		list-style: none;
 		padding-left: 0;
 
-		display: none;
 		position: absolute;
 		opacity: 0;
 		left: -999px;

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -114,7 +114,7 @@
 
 		position: absolute;
 		opacity: 0;
-		left: -999px;
+		left: -9999px;
 		z-index: 99999;
 
 		@include media(tablet) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1138,7 +1138,6 @@ body.page .main-navigation {
   color: #fff;
   list-style: none;
   padding-right: 0;
-  display: none;
   position: absolute;
   opacity: 0;
   right: -999px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1140,7 +1140,7 @@ body.page .main-navigation {
   padding-right: 0;
   position: absolute;
   opacity: 0;
-  right: -999px;
+  right: -9999px;
   z-index: 99999;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1034,6 +1034,9 @@ a:focus {
 	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
   /**
+	 * Fade-in animation for top-level submenus
+	 */
+  /**
 	 * Full-screen touch device styles
 	 */
 }
@@ -1567,7 +1570,7 @@ body.page .main-navigation {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
-.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu {
+.main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
   animation: fade_in 0.1s forwards;
 }
 

--- a/style.css
+++ b/style.css
@@ -1138,7 +1138,6 @@ body.page .main-navigation {
   color: #fff;
   list-style: none;
   padding-left: 0;
-  display: none;
   position: absolute;
   opacity: 0;
   left: -999px;

--- a/style.css
+++ b/style.css
@@ -1140,7 +1140,7 @@ body.page .main-navigation {
   padding-left: 0;
   position: absolute;
   opacity: 0;
-  left: -999px;
+  left: -9999px;
   z-index: 99999;
 }
 

--- a/style.css
+++ b/style.css
@@ -1034,6 +1034,9 @@ a:focus {
 	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
   /**
+	 * Fade-in animation for top-level submenus
+	 */
+  /**
 	 * Full-screen touch device styles
 	 */
 }
@@ -1567,7 +1570,7 @@ body.page .main-navigation {
   content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 }
 
-.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu {
+.main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
   animation: fade_in 0.1s forwards;
 }
 


### PR DESCRIPTION
Fixes #266.

When reverse-tabbing through the menu currently, you end up skipping over the submenu items: 

![current](https://user-images.githubusercontent.com/1202812/48576130-b6629600-e8e1-11e8-9a50-53b33663e64f.gif)

As @westonruter [noted](
https://github.com/WordPress/twentynineteen/issues/266#issuecomment-433560794), this is because we're using `display: none` on the submenu items when they're not in use. I don't think this is actually necessary, since we're also using `opacity: 0` and  `position: -9999px`. 

Removing this rule makes reverse-tabbing behave as expected: 

![improved](https://user-images.githubusercontent.com/1202812/48576366-58827e00-e8e2-11e8-9648-ffd0dbaed960.gif)

There's one bug that still needs to be sorted out though — you'll notice that when you shift focus from a submenu to the child of its predecessor, the original submenu remains active. That's because we currently only remove the `is-focused` class from top-level menu items if their previous/next top-level item is selected:

https://github.com/WordPress/twentynineteen/blob/a2e298368f96524ed0e6452cfe4020175c75b11f/js/touch-keyboard-navigation.js#L304-L312

@allancole, can we adjust that to also remove the `is-focused` class if the child of a  previous/next item is selected as well? 

---

This PR also moves the fade-in animation back to where it should be, so it triggers on hover.  👍 