### PR TITLE
Remove our Classic Block gallery shortcode editor styles

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -707,7 +707,6 @@ ul.wp-block-archives li ul,
 
 .wp-block-freeform {
   /* Add style for galleries in classic-editor block */
-  /* Add style for galleries in classic-editor block */
 }
 
 .wp-block-freeform blockquote {
@@ -720,51 +719,4 @@ ul.wp-block-archives li ul,
   font-style: normal;
   line-height: 1.6;
   color: #767676;
-}
-
-.wp-block-freeform .gallery {
-  display: flex;
-}
-
-.wp-block-freeform .gallery .gallery-item {
-  padding: 0.5rem;
-  text-align: center;
-  vertical-align: top;
-  width: 100%;
-}
-
-.wp-block-freeform .gallery .gallery-item .gallery-caption {
-  margin: 0;
-}
-
-.wp-block-freeform .gallery.gallery-columns-2 .gallery-item {
-  max-width: calc( ( 12 / 2 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-3 .gallery-item {
-  max-width: calc( ( 12 / 3 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-4 .gallery-item {
-  max-width: calc( ( 12 / 4 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-5 .gallery-item {
-  max-width: calc( ( 12 / 5 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-6 .gallery-item {
-  max-width: calc( ( 12 / 6 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-7 .gallery-item {
-  max-width: calc( ( 12 / 7 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-8 .gallery-item {
-  max-width: calc( ( 12 / 8 ) * (100% / 12));
-}
-
-.wp-block-freeform .gallery.gallery-columns-9 .gallery-item {
-  max-width: calc( ( 12 / 9 ) * (100% / 12));
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -694,28 +694,4 @@ ul.wp-block-archives,
 			color: $color__text-light;
 		}
 	}
-
-	/* Add style for galleries in classic-editor block */
-	.gallery {
-
-		display: flex;
-
-		.gallery-item {
-			padding: ( $size__spacing-unit * .5 );
-			text-align: center;
-			vertical-align: top;
-			width: 100%;
-
-			.gallery-caption {
-				margin: 0;
-			}
-		}
-
-		// Loops to enumerate the classes for gallery columns.
-		@for $i from 2 through 9 {
-			&.gallery-columns-#{$i} .gallery-item {
-				max-width: calc( ( 12 / #{$i} ) * (100% / 12) );
-			}
-		}
-	}
 }


### PR DESCRIPTION
As per my notes in https://github.com/WordPress/twentynineteen/issues/531#issuecomment-439187796

These styles are broken right now, but they should be provided by Gutenberg — not the theme — in the first place.

**Before:**
<img width="1280" alt="screen shot 2018-11-15 at 4 02 51 pm" src="https://user-images.githubusercontent.com/1202812/48581664-6e973b00-e8f0-11e8-9ad6-fb1951c003df.png">

**After:**
<img width="1280" alt="screen shot 2018-11-15 at 4 03 11 pm" src="https://user-images.githubusercontent.com/1202812/48581673-70f99500-e8f0-11e8-85b3-2be06b97fac9.png">
_(^ This is how the `[gallery]` shortcode appears by default in the Classic Editor block)_