### PR TITLE
Try: Better position wide and fullwide toolbars.

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -57,20 +57,10 @@ body .wp-block[data-align="full"] {
   }
 }
 
-/** === Editor Changes === */
+/** === Editor Block Toolbar Position === */
 .editor-block-list__block[data-align="wide"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar,
 .editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
   max-width: none;
-}
-
-.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
-  max-width: calc( 100% - (2 * 46px));
-}
-
-@media only screen and (min-width: 768px) {
-  .editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
-    max-width: calc( 80% - (2 * 46px) - 6px);
-  }
 }
 
 /** === Content Width === */

--- a/style-editor.css
+++ b/style-editor.css
@@ -57,6 +57,22 @@ body .wp-block[data-align="full"] {
   }
 }
 
+/** === Editor Changes === */
+.editor-block-list__block[data-align="wide"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar,
+.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
+  max-width: none;
+}
+
+.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
+  max-width: calc( 100% - (2 * 46px));
+}
+
+@media only screen and (min-width: 768px) {
+  .editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
+    max-width: calc( 80% - (2 * 46px) - 6px);
+  }
+}
+
 /** === Content Width === */
 .wp-block {
   width: calc(100vw - (2 * 1rem));

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -55,6 +55,21 @@ body {
 	}
 }
 
+/** === Editor Changes === */
+
+// Since 2019 left-aligns wide and fullwide blocks, left align the toolbar too.
+.editor-block-list__block[data-align="wide"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar,
+.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
+		max-width: none;
+}
+
+.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
+	max-width: calc( 100% - (2 * 46px));
+	@include media(tablet) {
+		max-width: calc( 80% - (2 * 46px) - 6px);
+	}
+}
+
 /** === Content Width === */
 
 .wp-block {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -55,19 +55,12 @@ body {
 	}
 }
 
-/** === Editor Changes === */
+/** === Editor Block Toolbar Position === */
 
 // Since 2019 left-aligns wide and fullwide blocks, left align the toolbar too.
 .editor-block-list__block[data-align="wide"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar,
 .editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
 		max-width: none;
-}
-
-.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
-	max-width: calc( 100% - (2 * 46px));
-	@include media(tablet) {
-		max-width: calc( 80% - (2 * 46px) - 6px);
-	}
 }
 
 /** === Content Width === */


### PR DESCRIPTION
Toolbars are a bit off when wide and fullwide. This is because the vanilla editor style assumes a centered column, with equal padding left and right when a block goes wide and fullwide.

But TwentyNineteen is smarter than that, and has a fancy left-aligned layout, except for fullwide which is truly fullwide.

This PR tries to make the experience good, but it needs your thoughts.

Before:

![screenshot 2018-11-16 at 12 38 43](https://user-images.githubusercontent.com/1204802/48619412-b1165180-e99c-11e8-8160-aaee972db377.png)

![screenshot 2018-11-16 at 12 38 51](https://user-images.githubusercontent.com/1204802/48619415-b2477e80-e99c-11e8-97d0-fd06f6855c6c.png)

After:

![toolbars](https://user-images.githubusercontent.com/1204802/48619422-ba072300-e99c-11e8-8045-5e6502c7e322.gif)

_However_. The following line of code, https://github.com/WordPress/twentynineteen/compare/try/toolbar-fix?expand=1#diff-83a29128607f3783eb58ed25d6760ad6R66, has some hacky CSS that I'd kike for us to not include in this editor style, specifically because the calc math is both obtuse, and likely to break with any future changes to the editor layout. 

If I remove lines 66  to 74 in editor-style.scss, we get this:

![preferred](https://user-images.githubusercontent.com/1204802/48619473-e884fe00-e99c-11e8-89cd-33ea17dc2a88.png)

Honestly I think we should do that. However I still think it's worth having this discussion, because POSSIBLY this is a change we should make in Gutenberg itself and not here. 

To frame it differently, the question is: when the block toolbar is docked to the block, on a wide or fullwide block, should the toolbar remain centered to match non-wide blocks? Or should it always dock to the top left corner of the block, regardless of the width and position?

Your thoughts are much appreciated. Given we're past the UI freeze, I think it might be good to include at least https://github.com/WordPress/twentynineteen/compare/try/toolbar-fix?expand=1#diff-83a29128607f3783eb58ed25d6760ad6R63, as that's a very simple and clean fix that makes the experience a lot better in TwentyNineteen. But good to discuss this regardless. 