### PR TITLE
Fix for menu items in the off-canvas menu from overflowing the viewport

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -406,7 +406,7 @@
 	}
 
 	/**
-	 * Full-screen touch device styles
+	 * Off-canvas touch device styles
 	 */
 	.main-menu .menu-item-has-children.off-canvas .sub-menu {
 
@@ -426,6 +426,11 @@
 		li > a:hover,
 		li > a:focus {
 			background-color: transparent;
+		}
+
+		> li > a,
+		> li > .menu-item-link-return {
+			white-space: inherit;
 		}
 
 		&.expanded-true {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1037,7 +1037,7 @@ a:focus {
 	 * Fade-in animation for top-level submenus
 	 */
   /**
-	 * Full-screen touch device styles
+	 * Off-canvas touch device styles
 	 */
 }
 
@@ -1589,6 +1589,11 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:hover,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:focus {
   background-color: transparent;
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > a,
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > .menu-item-link-return {
+  white-space: inherit;
 }
 
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {

--- a/style.css
+++ b/style.css
@@ -1037,7 +1037,7 @@ a:focus {
 	 * Fade-in animation for top-level submenus
 	 */
   /**
-	 * Full-screen touch device styles
+	 * Off-canvas touch device styles
 	 */
 }
 
@@ -1589,6 +1589,11 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:hover,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:focus {
   background-color: transparent;
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > a,
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > .menu-item-link-return {
+  white-space: inherit;
 }
 
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {


### PR DESCRIPTION
Fixes a small issue where longer menu items would break out of the viewport.

Before: 
![image](https://user-images.githubusercontent.com/709581/48631470-963be100-e98c-11e8-9bc7-73b9e9b92d76.png)

After: 
![image](https://user-images.githubusercontent.com/709581/48631515-b4094600-e98c-11e8-87e8-1327ef79eb6c.png)
