### PR TITLE
Increase mobile logo size and fix site-title link color

### DIFF
--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -26,7 +26,7 @@
 	.main-navigation a,
 	.main-navigation a + svg,
 	.social-navigation a,
-	.site-title a,
+	&#masthead .site-title a,
 	.site-featured-image a {
 		color: $color__background-body;
 		transition: opacity $link_transition ease-in-out;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -58,8 +58,8 @@
 		box-sizing: content-box;
 		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
 		display: block;
-		width: 32px;
-		height: 32px;
+		width: 64px;
+		height: 64px;
 		overflow: hidden;
 		transition: box-shadow $background_transition ease-in-out;
 
@@ -72,11 +72,6 @@
 		&:focus {
 			box-shadow: 0 0 0 2px rgba(0, 0, 0, 1);
 		}
-
-		@include media(tablet) {
-			width: 64px;
-			height: 64px;
-		}
 	}
 }
 
@@ -85,11 +80,18 @@
 .site-title {
 	margin: auto;
 	display: inline;
-	
 
-	a:link,
-	a:visited {
+	a {
 		color: $color__text-main;
+
+		&:link,
+		&:visited {
+			color: $color__text-main;
+		}
+
+		&:hover {
+			color: $color__text-hover;
+		}
 	}
 
 	.featured-image & {
@@ -103,14 +105,6 @@
 	/* When there is no description set, make sure navigation appears below title. */
 	+ .main-navigation {
 		display: block;
-	}
-
-	a {
-		color: inherit;
-
-		&:hover {
-			color: $color__text-hover;
-		}
 	}
 
 	@include media(tablet) {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -81,7 +81,7 @@
 	margin: auto;
 	display: inline;
 
-	a {
+	#masthead & a {
 		color: $color__text-main;
 
 		&:link,

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -72,6 +72,11 @@
 		&:focus {
 			box-shadow: 0 0 0 2px rgba(0, 0, 0, 1);
 		}
+
+		@include media(tablet) {
+			width: 50px;
+			height: 50px;
+		}
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2121,15 +2121,15 @@ body.page .main-navigation {
   /* When there is no description set, make sure navigation appears below title. */
 }
 
-.site-title a {
+#masthead .site-title a {
   color: #111;
 }
 
-.site-title a:link, .site-title a:visited {
+#masthead .site-title a:link, #masthead .site-title a:visited {
   color: #111;
 }
 
-.site-title a:hover {
+#masthead .site-title a:hover {
   color: #4a4a4a;
 }
 
@@ -2205,7 +2205,7 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .main-navigation a + svg,
 .site-header.featured-image .social-navigation a,
-.site-header.featured-image .site-title a,
+#masthead .site-header.featured-image .site-title a,
 .site-header.featured-image .site-featured-image a {
   color: #fff;
   transition: opacity 110ms ease-in-out;
@@ -2222,10 +2222,10 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation a:active,
 .site-header.featured-image .social-navigation a:hover + svg,
 .site-header.featured-image .social-navigation a:active + svg,
-.site-header.featured-image .site-title a:hover,
-.site-header.featured-image .site-title a:active,
-.site-header.featured-image .site-title a:hover + svg,
-.site-header.featured-image .site-title a:active + svg,
+#masthead .site-header.featured-image .site-title a:hover,
+#masthead .site-header.featured-image .site-title a:active,
+#masthead .site-header.featured-image .site-title a:hover + svg,
+#masthead .site-header.featured-image .site-title a:active + svg,
 .site-header.featured-image .site-featured-image a:hover,
 .site-header.featured-image .site-featured-image a:active,
 .site-header.featured-image .site-featured-image a:hover + svg,
@@ -2240,8 +2240,8 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
 .site-header.featured-image .social-navigation a:focus + svg,
-.site-header.featured-image .site-title a:focus,
-.site-header.featured-image .site-title a:focus + svg,
+#masthead .site-header.featured-image .site-title a:focus,
+#masthead .site-header.featured-image .site-title a:focus + svg,
 .site-header.featured-image .site-featured-image a:focus,
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2115,6 +2115,13 @@ body.page .main-navigation {
   box-shadow: 0 0 0 2px black;
 }
 
+@media only screen and (min-width: 768px) {
+  .site-logo .custom-logo-link {
+    width: 50px;
+    height: 50px;
+  }
+}
+
 .site-title {
   margin: auto;
   display: inline;
@@ -2205,7 +2212,7 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .main-navigation a + svg,
 .site-header.featured-image .social-navigation a,
-#masthead .site-header.featured-image .site-title a,
+.site-header.featured-image#masthead .site-title a,
 .site-header.featured-image .site-featured-image a {
   color: #fff;
   transition: opacity 110ms ease-in-out;
@@ -2222,10 +2229,10 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation a:active,
 .site-header.featured-image .social-navigation a:hover + svg,
 .site-header.featured-image .social-navigation a:active + svg,
-#masthead .site-header.featured-image .site-title a:hover,
-#masthead .site-header.featured-image .site-title a:active,
-#masthead .site-header.featured-image .site-title a:hover + svg,
-#masthead .site-header.featured-image .site-title a:active + svg,
+.site-header.featured-image#masthead .site-title a:hover,
+.site-header.featured-image#masthead .site-title a:active,
+.site-header.featured-image#masthead .site-title a:hover + svg,
+.site-header.featured-image#masthead .site-title a:active + svg,
 .site-header.featured-image .site-featured-image a:hover,
 .site-header.featured-image .site-featured-image a:active,
 .site-header.featured-image .site-featured-image a:hover + svg,
@@ -2240,8 +2247,8 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
 .site-header.featured-image .social-navigation a:focus + svg,
-#masthead .site-header.featured-image .site-title a:focus,
-#masthead .site-header.featured-image .site-title a:focus + svg,
+.site-header.featured-image#masthead .site-title a:focus,
+.site-header.featured-image#masthead .site-title a:focus + svg,
 .site-header.featured-image .site-featured-image a:focus,
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2101,8 +2101,8 @@ body.page .main-navigation {
   box-sizing: content-box;
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 64px;
+  height: 64px;
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
@@ -2115,22 +2115,22 @@ body.page .main-navigation {
   box-shadow: 0 0 0 2px black;
 }
 
-@media only screen and (min-width: 768px) {
-  .site-logo .custom-logo-link {
-    width: 64px;
-    height: 64px;
-  }
-}
-
 .site-title {
   margin: auto;
   display: inline;
   /* When there is no description set, make sure navigation appears below title. */
 }
 
-.site-title a:link,
-.site-title a:visited {
+.site-title a {
   color: #111;
+}
+
+.site-title a:link, .site-title a:visited {
+  color: #111;
+}
+
+.site-title a:hover {
+  color: #4a4a4a;
 }
 
 .featured-image .site-title {
@@ -2145,14 +2145,6 @@ body.page .main-navigation {
 
 .site-title + .main-navigation {
   display: block;
-}
-
-.site-title a {
-  color: inherit;
-}
-
-.site-title a:hover {
-  color: #4a4a4a;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -2121,6 +2121,13 @@ body.page .main-navigation {
   box-shadow: 0 0 0 2px black;
 }
 
+@media only screen and (min-width: 768px) {
+  .site-logo .custom-logo-link {
+    width: 50px;
+    height: 50px;
+  }
+}
+
 .site-title {
   margin: auto;
   display: inline;

--- a/style.css
+++ b/style.css
@@ -2107,8 +2107,8 @@ body.page .main-navigation {
   box-sizing: content-box;
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 64px;
+  height: 64px;
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
@@ -2121,22 +2121,22 @@ body.page .main-navigation {
   box-shadow: 0 0 0 2px black;
 }
 
-@media only screen and (min-width: 768px) {
-  .site-logo .custom-logo-link {
-    width: 64px;
-    height: 64px;
-  }
-}
-
 .site-title {
   margin: auto;
   display: inline;
   /* When there is no description set, make sure navigation appears below title. */
 }
 
-.site-title a:link,
-.site-title a:visited {
+.site-title a {
   color: #111;
+}
+
+.site-title a:link, .site-title a:visited {
+  color: #111;
+}
+
+.site-title a:hover {
+  color: #4a4a4a;
 }
 
 .featured-image .site-title {
@@ -2151,14 +2151,6 @@ body.page .main-navigation {
 
 .site-title + .main-navigation {
   display: block;
-}
-
-.site-title a {
-  color: inherit;
-}
-
-.site-title a:hover {
-  color: #4a4a4a;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -2127,15 +2127,15 @@ body.page .main-navigation {
   /* When there is no description set, make sure navigation appears below title. */
 }
 
-.site-title a {
+#masthead .site-title a {
   color: #111;
 }
 
-.site-title a:link, .site-title a:visited {
+#masthead .site-title a:link, #masthead .site-title a:visited {
   color: #111;
 }
 
-.site-title a:hover {
+#masthead .site-title a:hover {
   color: #4a4a4a;
 }
 
@@ -2211,7 +2211,7 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .main-navigation a + svg,
 .site-header.featured-image .social-navigation a,
-.site-header.featured-image .site-title a,
+.site-header.featured-image#masthead .site-title a,
 .site-header.featured-image .site-featured-image a {
   color: #fff;
   transition: opacity 110ms ease-in-out;
@@ -2228,10 +2228,10 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation a:active,
 .site-header.featured-image .social-navigation a:hover + svg,
 .site-header.featured-image .social-navigation a:active + svg,
-.site-header.featured-image .site-title a:hover,
-.site-header.featured-image .site-title a:active,
-.site-header.featured-image .site-title a:hover + svg,
-.site-header.featured-image .site-title a:active + svg,
+.site-header.featured-image#masthead .site-title a:hover,
+.site-header.featured-image#masthead .site-title a:active,
+.site-header.featured-image#masthead .site-title a:hover + svg,
+.site-header.featured-image#masthead .site-title a:active + svg,
 .site-header.featured-image .site-featured-image a:hover,
 .site-header.featured-image .site-featured-image a:active,
 .site-header.featured-image .site-featured-image a:hover + svg,
@@ -2246,8 +2246,8 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
 .site-header.featured-image .social-navigation a:focus + svg,
-.site-header.featured-image .site-title a:focus,
-.site-header.featured-image .site-title a:focus + svg,
+.site-header.featured-image#masthead .site-title a:focus,
+.site-header.featured-image#masthead .site-title a:focus + svg,
 .site-header.featured-image .site-featured-image a:focus,
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;


### PR DESCRIPTION
Increasing the size of the logo on mobile screens, to make it more closely match the general size of avatars in “native” mobile apps. I also noticed that the .site-title link color changes to the custom color when it should remain black. This PR fixes that as well.

Before:
![image](https://user-images.githubusercontent.com/709581/48634783-701a3f00-e994-11e8-8cbe-c16f2db1b45b.png)

After:
![image](https://user-images.githubusercontent.com/709581/48634706-30ebee00-e994-11e8-8ee5-f2c1df8ca100.png)
