### PR TITLE
Revert .button class link color to fix cascading issue

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -85,7 +85,6 @@ function twentynineteen_custom_colors_css() {
 		 * - Widget links
 		 */
 		a,
-		a:not(.button):visited,
 		.main-navigation .main-menu > li,
 		.main-navigation ul.main-menu > li > a,
 		.post-navigation .post-title,

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -26,7 +26,7 @@
 	.main-navigation a,
 	.main-navigation a + svg,
 	.social-navigation a,
-	&#masthead .site-title a,
+	.site-title a,
 	.site-featured-image a {
 		color: $color__background-body;
 		transition: opacity $link_transition ease-in-out;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -85,8 +85,9 @@
 .site-title {
 	margin: auto;
 	display: inline;
+	color: $color__text-main;
 
-	#masthead & a {
+	a {
 		color: $color__text-main;
 
 		&:link,

--- a/style.css
+++ b/style.css
@@ -2131,18 +2131,19 @@ body.page .main-navigation {
 .site-title {
   margin: auto;
   display: inline;
+  color: #111;
   /* When there is no description set, make sure navigation appears below title. */
 }
 
-#masthead .site-title a {
+.site-title a {
   color: #111;
 }
 
-#masthead .site-title a:link, #masthead .site-title a:visited {
+.site-title a:link, .site-title a:visited {
   color: #111;
 }
 
-#masthead .site-title a:hover {
+.site-title a:hover {
   color: #4a4a4a;
 }
 
@@ -2218,7 +2219,7 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .main-navigation a + svg,
 .site-header.featured-image .social-navigation a,
-.site-header.featured-image#masthead .site-title a,
+.site-header.featured-image .site-title a,
 .site-header.featured-image .site-featured-image a {
   color: #fff;
   transition: opacity 110ms ease-in-out;
@@ -2235,10 +2236,10 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation a:active,
 .site-header.featured-image .social-navigation a:hover + svg,
 .site-header.featured-image .social-navigation a:active + svg,
-.site-header.featured-image#masthead .site-title a:hover,
-.site-header.featured-image#masthead .site-title a:active,
-.site-header.featured-image#masthead .site-title a:hover + svg,
-.site-header.featured-image#masthead .site-title a:active + svg,
+.site-header.featured-image .site-title a:hover,
+.site-header.featured-image .site-title a:active,
+.site-header.featured-image .site-title a:hover + svg,
+.site-header.featured-image .site-title a:active + svg,
 .site-header.featured-image .site-featured-image a:hover,
 .site-header.featured-image .site-featured-image a:active,
 .site-header.featured-image .site-featured-image a:hover + svg,
@@ -2253,8 +2254,8 @@ body.page .main-navigation {
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
 .site-header.featured-image .social-navigation a:focus + svg,
-.site-header.featured-image#masthead .site-title a:focus,
-.site-header.featured-image#masthead .site-title a:focus + svg,
+.site-header.featured-image .site-title a:focus,
+.site-header.featured-image .site-title a:focus + svg,
 .site-header.featured-image .site-featured-image a:focus,
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;


### PR DESCRIPTION
Discovered an color cascading issue that came about while fixing a bug in #600. This change keeps that fix intact while restoring the intended colors to site-title, post-title and entry-date links.

Before:
![image](https://user-images.githubusercontent.com/709581/48638905-f0926d00-e99f-11e8-8377-94fd07c29cc1.png)
----------
![image](https://user-images.githubusercontent.com/709581/48638943-0ef86880-e9a0-11e8-8ea5-79662befa8cc.png)
----------
![image](https://user-images.githubusercontent.com/709581/48639051-64347a00-e9a0-11e8-907e-ea00787dbf5c.png)
----------

After:
![image](https://user-images.githubusercontent.com/709581/48639121-a3fb6180-e9a0-11e8-9908-0e633d3325ed.png)
----------
![image](https://user-images.githubusercontent.com/709581/48639085-84643900-e9a0-11e8-9a8b-4b7a095f720c.png)
----------
![image](https://user-images.githubusercontent.com/709581/48639107-96de7280-e9a0-11e8-851a-058cbdeaed80.png)
