### PR TITLE
Adjust max-width for alignaleft blocks, Clean up line breaks + center alignment for cover blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -501,6 +501,10 @@
 			line-height: 1.25;
 			padding: 0;
 			color: #fff;
+			-ms-hyphens: auto;
+			-moz-hyphens: auto;
+			-webkit-hyphens: auto;
+			hyphens: auto;
 
 			@include media(tablet) {
 				font-size: $font__size-xl;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -508,19 +508,6 @@
 			}
 		}
 
-		&.aligncenter {
-			h2,
-			.wp-block-cover-image-text,
-			.wp-block-cover-text {
-				width: 100%;
-				z-index: 1;
-				left: 50%;
-				position: absolute;
-				transform: translate(-50%, -50%);
-				top: 50%;
-			}
-		}
-
 		&.alignleft,
 		&.alignright {
 			width: 100%;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -60,10 +60,6 @@
 			/*rtl:ignore*/
 			margin-right: calc(2 * #{$size__spacing-unit});
 		}
-
-		@include media(desktop) {
-			max-width: calc(3 * (100vw / 12));
-		}
 	}
 
 	&.alignright {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -511,6 +511,10 @@
 		&.alignleft,
 		&.alignright {
 			width: 100%;
+
+			@include media(tablet) {
+				padding: $size__spacing-unit;
+			}
 		}
 
 		&.alignfull {

--- a/style-editor.css
+++ b/style-editor.css
@@ -289,6 +289,13 @@ figcaption,
 }
 
 @media only screen and (min-width: 768px) {
+  .wp-block[data-type="core/cover"][data-align="left"] .wp-block-cover,
+  .wp-block[data-type="core/cover"][data-align="right"] .wp-block-cover {
+    padding: 1rem;
+  }
+}
+
+@media only screen and (min-width: 768px) {
   .wp-block[data-type="core/cover"][data-align="wide"] h2,
   .wp-block[data-type="core/cover"][data-align="wide"] .wp-block-cover-text,
   .wp-block[data-type="core/cover"][data-align="full"] h2,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -276,6 +276,13 @@ figcaption,
 		width: 100%;
 		max-width: 100%;
 	}
+	
+	@include media(tablet) {
+		
+		.wp-block-cover {
+			padding: $size__spacing-unit;
+		}
+	}
 }
 
 .wp-block[data-type="core/cover"][data-align="wide"],

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4166,6 +4166,14 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+  .entry .entry-content .wp-block-cover.alignleft,
+  .entry .entry-content .wp-block-cover.alignright {
+    padding: 1rem;
+  }
+}
+
+@media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover-image.alignfull h2,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4159,20 +4159,6 @@ body.page .main-navigation {
   }
 }
 
-.entry .entry-content .wp-block-cover-image.aligncenter h2,
-.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.aligncenter h2,
-.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
-  width: 100%;
-  z-index: 1;
-  right: 50%;
-  position: absolute;
-  transform: translate(50%, -50%);
-  top: 50%;
-}
-
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4145,6 +4145,10 @@ body.page .main-navigation {
   line-height: 1.25;
   padding: 0;
   color: #fff;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3652,13 +3652,6 @@ body.page .main-navigation {
   }
 }
 
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content > *.alignleft,
-  .entry .entry-summary > *.alignleft {
-    max-width: calc(3 * (100vw / 12));
-  }
-}
-
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *.alignright {
   float: right;

--- a/style.css
+++ b/style.css
@@ -4178,6 +4178,14 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+  .entry .entry-content .wp-block-cover.alignleft,
+  .entry .entry-content .wp-block-cover.alignright {
+    padding: 1rem;
+  }
+}
+
+@media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover-image.alignfull h2,

--- a/style.css
+++ b/style.css
@@ -4157,6 +4157,10 @@ body.page .main-navigation {
   line-height: 1.25;
   padding: 0;
   color: #fff;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -4171,20 +4171,6 @@ body.page .main-navigation {
   }
 }
 
-.entry .entry-content .wp-block-cover-image.aligncenter h2,
-.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover-image.aligncenter .wp-block-cover-text,
-.entry .entry-content .wp-block-cover.aligncenter h2,
-.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover.aligncenter .wp-block-cover-text {
-  width: 100%;
-  z-index: 1;
-  left: 50%;
-  position: absolute;
-  transform: translate(-50%, -50%);
-  top: 50%;
-}
-
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {

--- a/style.css
+++ b/style.css
@@ -3661,13 +3661,6 @@ body.page .main-navigation {
   }
 }
 
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content > *.alignleft,
-  .entry .entry-summary > *.alignleft {
-    max-width: calc(3 * (100vw / 12));
-  }
-}
-
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *.alignright {
   /*rtl:ignore*/


### PR DESCRIPTION
Fixes #612 

This PR does a few things: 

- Adjusts the max-width of all left-aligned blocks to match the max-width of all right-aligned blocks.
- Decreases the margins for left/right cover image blocks to avoid line breaks when we don't need them. 
- Adds a `hyphens: auto` rule to add hyphens to line breaks (when the browser supports it)
- Removes our `aligncenter` styles for the cover image block. These were trying to fix a bug in Gutenberg, which has since been fixed upstream: 
https://github.com/WordPress/gutenberg/pull/11990

**Before:** 
![screen shot 2018-11-16 at 1 09 39 pm](https://user-images.githubusercontent.com/1202812/48639278-18ce9b80-e9a1-11e8-9e22-5b7792f130f6.png)

**After:**
![screen shot 2018-11-16 at 1 09 02 pm](https://user-images.githubusercontent.com/1202812/48639287-1bc98c00-e9a1-11e8-8091-941aaaf1de51.png)