### PR TITLE
Fix minor print styles issues

### DIFF
--- a/print.css
+++ b/print.css
@@ -109,6 +109,11 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .comment .comment-metadata .edit-link {
     display: none;
   }
+  .entry .entry-content .wp-block-button .wp-block-button__link,
+  .entry .entry-content .button {
+    color: #000;
+    background: none;
+  }
   /* Site Header (With Featured Image) */
   .site-header.featured-image {
     min-height: 0;

--- a/print.css
+++ b/print.css
@@ -123,7 +123,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title {
+  .site-header.featured-image .entry-title,
+  .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }
@@ -145,6 +146,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   /* Remove image filters from featured image */
   .image-filters-enabled *:after {
     display: none !important;
+  }
+  .image-filters-enabled .site-header.featured-image .site-featured-image:before {
+    display: none;
   }
   .image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
     filter: none;

--- a/print.css
+++ b/print.css
@@ -104,7 +104,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .author-description:before,
   .post-navigation,
   .widget-area,
-  .comment-form-flex {
+  .comment-form-flex,
+  .comment-reply,
+  .comment .comment-metadata .edit-link {
     display: none;
   }
   /* Site Header (With Featured Image) */

--- a/print.css
+++ b/print.css
@@ -75,7 +75,6 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   /* Links */
   a:link, a:visited, a {
     background: transparent;
-    color: #520;
     font-weight: bold;
     text-decoration: underline;
     text-align: left;
@@ -97,6 +96,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   }
   /* Visibility */
   .main-navigation,
+  .site-title + .main-navigation,
   .social-navigation,
   .site-branding-container:before,
   .entry .entry-title:before,

--- a/print.scss
+++ b/print.scss
@@ -93,7 +93,6 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
   a:link, a:visited, a {
     background: transparent;
-    color: #520;
     font-weight: bold;
     text-decoration: underline;
     text-align: left;

--- a/print.scss
+++ b/print.scss
@@ -134,6 +134,12 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     display: none;
   }
 
+  .entry .entry-content .wp-block-button .wp-block-button__link,
+  .entry .entry-content .button {
+    color: #000;
+    background: none;
+  }
+
   /* Site Header (With Featured Image) */
   .site-header.featured-image {
     min-height: 0;

--- a/print.scss
+++ b/print.scss
@@ -128,7 +128,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .author-description:before, 
   .post-navigation,
   .widget-area,
-  .comment-form-flex {
+  .comment-form-flex,
+  .comment-reply,
+  .comment .comment-metadata .edit-link {
     display: none;
   }
 

--- a/print.scss
+++ b/print.scss
@@ -120,6 +120,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
   /* Visibility */
   .main-navigation,
+  .site-title + .main-navigation,
   .social-navigation,
   .site-branding-container:before, 
   .entry .entry-title:before, 

--- a/print.scss
+++ b/print.scss
@@ -148,7 +148,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     .main-navigation li, 
     .social-navigation li, 
     .entry-meta, 
-    .entry-title {
+    .entry-title,
+    &#masthead .site-title a {
       color: #000;
       text-shadow: none;
     }
@@ -176,6 +177,10 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
     *:after {
       display: none !important;
+    }
+
+    .site-header.featured-image .site-featured-image:before {
+      display: none;
     }
 
     .site-header.featured-image .site-featured-image .post-thumbnail img {

--- a/print.scss
+++ b/print.scss
@@ -99,7 +99,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   }
 
   a {
-    page-break-inside: avoid
+    page-break-inside: avoid;
   }
 
   a[href^=http]:after {


### PR DESCRIPTION
Takes care of everything in https://github.com/WordPress/twentynineteen/issues/609 except for the links issue (which still confuses me).

- Removes a brown color that some links were using
- Hides the main navigation, comment reply, and comment edit links
- Removes a subtle background color for color-filtered headers that wasn't supposed to be there anymore

Before:
![screen shot 2018-11-16 at 2 40 15 pm](https://user-images.githubusercontent.com/1202812/48643384-926c8680-e9ad-11e8-8267-698db5b55987.png)
![screen shot 2018-11-16 at 2 41 02 pm](https://user-images.githubusercontent.com/1202812/48643434-b6c86300-e9ad-11e8-8dd1-0ab535cb5669.png)


After:
![screen shot 2018-11-16 at 2 32 29 pm](https://user-images.githubusercontent.com/1202812/48643331-6f41d700-e9ad-11e8-9b7d-f8bc2d8d6388.png)
![screen shot 2018-11-16 at 2 41 24 pm](https://user-images.githubusercontent.com/1202812/48643435-b8922680-e9ad-11e8-9b07-b4bad6c1e9ce.png)

