### PR TITLE
Fix non-latin language fonts effecting the editor UI

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -89,88 +89,88 @@
 
 /* Fallback for non-latin fonts */
 
-@mixin non-latin-fonts( $wrapper_classname: '.site' ) {
-	
+@mixin non-latin-fonts( $wrapper_selector: '.site *' ) {
+
 	/* Arabic */
-	html[lang="ar"] #{$wrapper_classname} *,
-	html[lang="ary"] #{$wrapper_classname} *,
-	html[lang="azb"] #{$wrapper_classname} *,
-	html[lang="ckb"] #{$wrapper_classname} *,
-	html[lang="fa-IR"] #{$wrapper_classname} *,
-	html[lang="haz"] #{$wrapper_classname} *,
-	html[lang="ps"] #{$wrapper_classname} * {
+	html[lang="ar"] #{$wrapper_selector},
+	html[lang="ary"] #{$wrapper_selector},
+	html[lang="azb"] #{$wrapper_selector},
+	html[lang="ckb"] #{$wrapper_selector},
+	html[lang="fa-IR"] #{$wrapper_selector},
+	html[lang="haz"] #{$wrapper_selector},
+	html[lang="ps"] #{$wrapper_selector} {
 	  font-family: Tahoma, Arial, sans-serif !important;
 	}
 
 	/* Cyrillic */
-	html[lang="be"] #{$wrapper_classname} *,
-	html[lang="bg-BG"] #{$wrapper_classname} *,
-	html[lang="kk"] #{$wrapper_classname} *,
-	html[lang="mk-MK"] #{$wrapper_classname} *,
-	html[lang="mn"] #{$wrapper_classname} *,
-	html[lang="ru-RU"] #{$wrapper_classname} *,
-	html[lang="sah"] #{$wrapper_classname} *,
-	html[lang="sr-RS"] #{$wrapper_classname} *,
-	html[lang="tt-RU"] #{$wrapper_classname} *,
-	html[lang="uk"] #{$wrapper_classname} * {
+	html[lang="be"] #{$wrapper_selector},
+	html[lang="bg-BG"] #{$wrapper_selector},
+	html[lang="kk"] #{$wrapper_selector},
+	html[lang="mk-MK"] #{$wrapper_selector},
+	html[lang="mn"] #{$wrapper_selector},
+	html[lang="ru-RU"] #{$wrapper_selector},
+	html[lang="sah"] #{$wrapper_selector},
+	html[lang="sr-RS"] #{$wrapper_selector},
+	html[lang="tt-RU"] #{$wrapper_selector},
+	html[lang="uk"] #{$wrapper_selector} {
 	  font-family: 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important;
 	}
 
 	/* Chinese (Hong Kong) */
-	html[lang="zh-HK"] #{$wrapper_classname} * {
+	html[lang="zh-HK"] #{$wrapper_selector} {
 		font-family: -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 	}
 
 	/* Chinese (Taiwan) */
-	html[lang="zh-TW"] #{$wrapper_classname} * {
+	html[lang="zh-TW"] #{$wrapper_selector} {
 		font-family: -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 	}
 
 	/* Chinese (China) */
-	html[lang="zh-CN"] #{$wrapper_classname} * {
+	html[lang="zh-CN"] #{$wrapper_selector} {
 		font-family: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 	}
 
 	/* Devanagari */
-	html[lang="bn-BD"] #{$wrapper_classname} *,
-	html[lang="hi-IN"] #{$wrapper_classname} *,
-	html[lang="mr"] #{$wrapper_classname} *,
-	html[lang="ne-NP"] #{$wrapper_classname} * {
+	html[lang="bn-BD"] #{$wrapper_selector},
+	html[lang="hi-IN"] #{$wrapper_selector},
+	html[lang="mr"] #{$wrapper_selector},
+	html[lang="ne-NP"] #{$wrapper_selector} {
 	  font-family: Arial, sans-serif !important;
 	}
 
 	/* Greek */
-	html[lang="el"] #{$wrapper_classname} * {
+	html[lang="el"] #{$wrapper_selector} {
 	  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
 	}
 
 	/* Gujarati */
-	html[lang="gu"] #{$wrapper_classname} * {
+	html[lang="gu"] #{$wrapper_selector} {
 	  font-family: Arial, sans-serif !important;
 	}
 
 	/* Hebrew */
-	html[lang="he-IL"] #{$wrapper_classname} * {
+	html[lang="he-IL"] #{$wrapper_selector} {
 	  font-family: 'Arial Hebrew', Arial, sans-serif !important;
 	}
 
 	/* Japanese */
-	html[lang="ja"] #{$wrapper_classname} * {
+	html[lang="ja"] #{$wrapper_selector} {
 	  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important;
 	}
 
 	/* Korean */
-	html[lang="ko-KR"] #{$wrapper_classname} * {
+	html[lang="ko-KR"] #{$wrapper_selector} {
 	  font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important;
 	}
 
 	/* Thai */
-	html[lang="th"] #{$wrapper_classname} * {
+	html[lang="th"] #{$wrapper_selector} {
 	  font-family: 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important;
 	}
 
 	/* Vietnamese */
-	html[lang="vi"] #{$wrapper_classname} * {
+	html[lang="vi"] #{$wrapper_selector} {
 	  font-family: 'Libre Franklin', sans-serif !important;
 	}
 }

--- a/style-editor-customizer.css
+++ b/style-editor-customizer.css
@@ -12,84 +12,84 @@ NOTE: This file is automatically populated with additional styles if the user se
 /* Nested sub-menu padding: 10 levels deep */
 /** === Non-Latin font fallbacks === */
 /* Arabic */
-html[lang="ar"] .wp-block *,
-html[lang="ary"] .wp-block *,
-html[lang="azb"] .wp-block *,
-html[lang="ckb"] .wp-block *,
-html[lang="fa-IR"] .wp-block *,
-html[lang="haz"] .wp-block *,
-html[lang="ps"] .wp-block * {
+html[lang="ar"] .wp-block .editor-rich-text__tinymce,
+html[lang="ary"] .wp-block .editor-rich-text__tinymce,
+html[lang="azb"] .wp-block .editor-rich-text__tinymce,
+html[lang="ckb"] .wp-block .editor-rich-text__tinymce,
+html[lang="fa-IR"] .wp-block .editor-rich-text__tinymce,
+html[lang="haz"] .wp-block .editor-rich-text__tinymce,
+html[lang="ps"] .wp-block .editor-rich-text__tinymce {
   font-family: Tahoma, Arial, sans-serif !important;
 }
 
 /* Cyrillic */
-html[lang="be"] .wp-block *,
-html[lang="bg-BG"] .wp-block *,
-html[lang="kk"] .wp-block *,
-html[lang="mk-MK"] .wp-block *,
-html[lang="mn"] .wp-block *,
-html[lang="ru-RU"] .wp-block *,
-html[lang="sah"] .wp-block *,
-html[lang="sr-RS"] .wp-block *,
-html[lang="tt-RU"] .wp-block *,
-html[lang="uk"] .wp-block * {
+html[lang="be"] .wp-block .editor-rich-text__tinymce,
+html[lang="bg-BG"] .wp-block .editor-rich-text__tinymce,
+html[lang="kk"] .wp-block .editor-rich-text__tinymce,
+html[lang="mk-MK"] .wp-block .editor-rich-text__tinymce,
+html[lang="mn"] .wp-block .editor-rich-text__tinymce,
+html[lang="ru-RU"] .wp-block .editor-rich-text__tinymce,
+html[lang="sah"] .wp-block .editor-rich-text__tinymce,
+html[lang="sr-RS"] .wp-block .editor-rich-text__tinymce,
+html[lang="tt-RU"] .wp-block .editor-rich-text__tinymce,
+html[lang="uk"] .wp-block .editor-rich-text__tinymce {
   font-family: 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important;
 }
 
 /* Chinese (Hong Kong) */
-html[lang="zh-HK"] .wp-block * {
+html[lang="zh-HK"] .wp-block .editor-rich-text__tinymce {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 }
 
 /* Chinese (Taiwan) */
-html[lang="zh-TW"] .wp-block * {
+html[lang="zh-TW"] .wp-block .editor-rich-text__tinymce {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 }
 
 /* Chinese (China) */
-html[lang="zh-CN"] .wp-block * {
+html[lang="zh-CN"] .wp-block .editor-rich-text__tinymce {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 }
 
 /* Devanagari */
-html[lang="bn-BD"] .wp-block *,
-html[lang="hi-IN"] .wp-block *,
-html[lang="mr"] .wp-block *,
-html[lang="ne-NP"] .wp-block * {
+html[lang="bn-BD"] .wp-block .editor-rich-text__tinymce,
+html[lang="hi-IN"] .wp-block .editor-rich-text__tinymce,
+html[lang="mr"] .wp-block .editor-rich-text__tinymce,
+html[lang="ne-NP"] .wp-block .editor-rich-text__tinymce {
   font-family: Arial, sans-serif !important;
 }
 
 /* Greek */
-html[lang="el"] .wp-block * {
+html[lang="el"] .wp-block .editor-rich-text__tinymce {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
 }
 
 /* Gujarati */
-html[lang="gu"] .wp-block * {
+html[lang="gu"] .wp-block .editor-rich-text__tinymce {
   font-family: Arial, sans-serif !important;
 }
 
 /* Hebrew */
-html[lang="he-IL"] .wp-block * {
+html[lang="he-IL"] .wp-block .editor-rich-text__tinymce {
   font-family: 'Arial Hebrew', Arial, sans-serif !important;
 }
 
 /* Japanese */
-html[lang="ja"] .wp-block * {
+html[lang="ja"] .wp-block .editor-rich-text__tinymce {
   font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important;
 }
 
 /* Korean */
-html[lang="ko-KR"] .wp-block * {
+html[lang="ko-KR"] .wp-block .editor-rich-text__tinymce {
   font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important;
 }
 
 /* Thai */
-html[lang="th"] .wp-block * {
+html[lang="th"] .wp-block .editor-rich-text__tinymce {
   font-family: 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important;
 }
 
 /* Vietnamese */
-html[lang="vi"] .wp-block * {
+html[lang="vi"] .wp-block .editor-rich-text__tinymce {
   font-family: 'Libre Franklin', sans-serif !important;
 }

--- a/style-editor-customizer.css
+++ b/style-editor-customizer.css
@@ -12,84 +12,84 @@ NOTE: This file is automatically populated with additional styles if the user se
 /* Nested sub-menu padding: 10 levels deep */
 /** === Non-Latin font fallbacks === */
 /* Arabic */
-html[lang="ar"] .wp-block .editor-rich-text__tinymce,
-html[lang="ary"] .wp-block .editor-rich-text__tinymce,
-html[lang="azb"] .wp-block .editor-rich-text__tinymce,
-html[lang="ckb"] .wp-block .editor-rich-text__tinymce,
-html[lang="fa-IR"] .wp-block .editor-rich-text__tinymce,
-html[lang="haz"] .wp-block .editor-rich-text__tinymce,
-html[lang="ps"] .wp-block .editor-rich-text__tinymce {
+html[lang="ar"] .wp-block .mce-content-body,
+html[lang="ary"] .wp-block .mce-content-body,
+html[lang="azb"] .wp-block .mce-content-body,
+html[lang="ckb"] .wp-block .mce-content-body,
+html[lang="fa-IR"] .wp-block .mce-content-body,
+html[lang="haz"] .wp-block .mce-content-body,
+html[lang="ps"] .wp-block .mce-content-body {
   font-family: Tahoma, Arial, sans-serif !important;
 }
 
 /* Cyrillic */
-html[lang="be"] .wp-block .editor-rich-text__tinymce,
-html[lang="bg-BG"] .wp-block .editor-rich-text__tinymce,
-html[lang="kk"] .wp-block .editor-rich-text__tinymce,
-html[lang="mk-MK"] .wp-block .editor-rich-text__tinymce,
-html[lang="mn"] .wp-block .editor-rich-text__tinymce,
-html[lang="ru-RU"] .wp-block .editor-rich-text__tinymce,
-html[lang="sah"] .wp-block .editor-rich-text__tinymce,
-html[lang="sr-RS"] .wp-block .editor-rich-text__tinymce,
-html[lang="tt-RU"] .wp-block .editor-rich-text__tinymce,
-html[lang="uk"] .wp-block .editor-rich-text__tinymce {
+html[lang="be"] .wp-block .mce-content-body,
+html[lang="bg-BG"] .wp-block .mce-content-body,
+html[lang="kk"] .wp-block .mce-content-body,
+html[lang="mk-MK"] .wp-block .mce-content-body,
+html[lang="mn"] .wp-block .mce-content-body,
+html[lang="ru-RU"] .wp-block .mce-content-body,
+html[lang="sah"] .wp-block .mce-content-body,
+html[lang="sr-RS"] .wp-block .mce-content-body,
+html[lang="tt-RU"] .wp-block .mce-content-body,
+html[lang="uk"] .wp-block .mce-content-body {
   font-family: 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important;
 }
 
 /* Chinese (Hong Kong) */
-html[lang="zh-HK"] .wp-block .editor-rich-text__tinymce {
+html[lang="zh-HK"] .wp-block .mce-content-body {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 }
 
 /* Chinese (Taiwan) */
-html[lang="zh-TW"] .wp-block .editor-rich-text__tinymce {
+html[lang="zh-TW"] .wp-block .mce-content-body {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 }
 
 /* Chinese (China) */
-html[lang="zh-CN"] .wp-block .editor-rich-text__tinymce {
+html[lang="zh-CN"] .wp-block .mce-content-body {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
 }
 
 /* Devanagari */
-html[lang="bn-BD"] .wp-block .editor-rich-text__tinymce,
-html[lang="hi-IN"] .wp-block .editor-rich-text__tinymce,
-html[lang="mr"] .wp-block .editor-rich-text__tinymce,
-html[lang="ne-NP"] .wp-block .editor-rich-text__tinymce {
+html[lang="bn-BD"] .wp-block .mce-content-body,
+html[lang="hi-IN"] .wp-block .mce-content-body,
+html[lang="mr"] .wp-block .mce-content-body,
+html[lang="ne-NP"] .wp-block .mce-content-body {
   font-family: Arial, sans-serif !important;
 }
 
 /* Greek */
-html[lang="el"] .wp-block .editor-rich-text__tinymce {
+html[lang="el"] .wp-block .mce-content-body {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
 }
 
 /* Gujarati */
-html[lang="gu"] .wp-block .editor-rich-text__tinymce {
+html[lang="gu"] .wp-block .mce-content-body {
   font-family: Arial, sans-serif !important;
 }
 
 /* Hebrew */
-html[lang="he-IL"] .wp-block .editor-rich-text__tinymce {
+html[lang="he-IL"] .wp-block .mce-content-body {
   font-family: 'Arial Hebrew', Arial, sans-serif !important;
 }
 
 /* Japanese */
-html[lang="ja"] .wp-block .editor-rich-text__tinymce {
+html[lang="ja"] .wp-block .mce-content-body {
   font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important;
 }
 
 /* Korean */
-html[lang="ko-KR"] .wp-block .editor-rich-text__tinymce {
+html[lang="ko-KR"] .wp-block .mce-content-body {
   font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important;
 }
 
 /* Thai */
-html[lang="th"] .wp-block .editor-rich-text__tinymce {
+html[lang="th"] .wp-block .mce-content-body {
   font-family: 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important;
 }
 
 /* Vietnamese */
-html[lang="vi"] .wp-block .editor-rich-text__tinymce {
+html[lang="vi"] .wp-block .mce-content-body {
   font-family: 'Libre Franklin', sans-serif !important;
 }

--- a/style-editor-customizer.scss
+++ b/style-editor-customizer.scss
@@ -10,4 +10,4 @@ NOTE: This file is automatically populated with additional styles if the user se
 
 /** === Non-Latin font fallbacks === */
 
-@include non-latin-fonts( '.wp-block .editor-rich-text__tinymce' );
+@include non-latin-fonts( '.wp-block .mce-content-body' );

--- a/style-editor-customizer.scss
+++ b/style-editor-customizer.scss
@@ -10,4 +10,4 @@ NOTE: This file is automatically populated with additional styles if the user se
 
 /** === Non-Latin font fallbacks === */
 
-@include non-latin-fonts( '.wp-block' );
+@include non-latin-fonts( '.wp-block .editor-rich-text__tinymce' );


### PR DESCRIPTION
Revises #383 and attempts to fix #602 so that the non-latin language fonts effect the Gutenberg editor less aggressively. 

Before (notice the broken icons):
![image](https://user-images.githubusercontent.com/709581/48644473-abc30200-e9b0-11e8-81e7-fbe05406ba06.png)

After: 
![image](https://user-images.githubusercontent.com/709581/48644629-3441a280-e9b1-11e8-8355-870a22e296fd.png)

This change also limits the new fonts to editable text areas, as opposed to changing the fonts on the entire block wrapper which can broke parts of the editor UI. In both screenshots, you’ll notice where the Japanese font stack is being added. In the After screenshot, its added to the `.mce-content-body` class so that these language-specific fonts don’t interfere with the Gutenberg UI. 

More info here: https://github.com/WordPress/twentynineteen/issues/602#issuecomment-439407971

@mako09 could you review this and make sure it works for you? 