### PR TITLE
Add post navigation links hovers to color-patterns.php

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -147,6 +147,7 @@ function twentynineteen_custom_colors_css() {
 		a:hover, a:active,
 		.main-navigation .main-menu > li > a:hover,
 		.main-navigation .main-menu > li > a:hover + svg,
+		.post-navigation .nav-links a:hover,
 		.post-navigation .nav-links a:hover .post-title,
 		.author-bio .author-description .author-link:hover,
 		.comment .comment-author .fn a:hover,


### PR DESCRIPTION
Fixes  #622 

That underline only shows up on focus + hover. The hover style is what needed to be specified in this case. 

Before:
<img width="363" alt="screen shot 2018-11-16 at 8 16 55 pm" src="https://user-images.githubusercontent.com/1202812/48654708-33266a80-e9dd-11e8-8297-3d29961d100d.png">

After:
<img width="391" alt="screen shot 2018-11-16 at 8 16 40 pm" src="https://user-images.githubusercontent.com/1202812/48654711-36b9f180-e9dd-11e8-91a6-f3dbd8e9c8c4.png">
