### PR TITLE
Swap the size of the site logo for mobile + desktop screens.

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -58,8 +58,8 @@
 		box-sizing: content-box;
 		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
 		display: block;
-		width: 64px;
-		height: 64px;
+		width: 50px;
+		height: 50px;
 		overflow: hidden;
 		transition: box-shadow $background_transition ease-in-out;
 
@@ -74,8 +74,8 @@
 		}
 
 		@include media(tablet) {
-			width: 50px;
-			height: 50px;
+			width: 64px;
+			height: 64px;
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2089,8 +2089,8 @@ body.page .main-navigation {
   box-sizing: content-box;
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
   display: block;
-  width: 64px;
-  height: 64px;
+  width: 50px;
+  height: 50px;
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
@@ -2105,8 +2105,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-logo .custom-logo-link {
-    width: 50px;
-    height: 50px;
+    width: 64px;
+    height: 64px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2095,8 +2095,8 @@ body.page .main-navigation {
   box-sizing: content-box;
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
   display: block;
-  width: 64px;
-  height: 64px;
+  width: 50px;
+  height: 50px;
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
@@ -2111,8 +2111,8 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-logo .custom-logo-link {
-    width: 50px;
-    height: 50px;
+    width: 64px;
+    height: 64px;
   }
 }
 


### PR DESCRIPTION
The logo should be larger on desktop, smaller on mobile. I think this was just a small mistake added via #617.

Before:
<img width="849" alt="screen shot 2018-11-16 at 9 00 27 pm" src="https://user-images.githubusercontent.com/1202812/48655294-19882180-e9e3-11e8-8b69-874c38515a08.png">

After:
<img width="784" alt="screen shot 2018-11-16 at 9 00 01 pm" src="https://user-images.githubusercontent.com/1202812/48655298-1db43f00-e9e3-11e8-96a9-7dbd35eb74ab.png">

