### PR TITLE
Minor: Make search field full-width on small screens

### DIFF
--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -53,6 +53,14 @@
 
 .widget_search {
 
+	.search-field {
+		width: 100%;
+
+		@include media(mobile) {
+			width: auto;
+		}
+	}
+
 	.search-submit {
 		display: block;
 		margin-top: $size__spacing-unit;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3536,6 +3536,16 @@ body.page .main-navigation {
   font-weight: 700;
 }
 
+.widget_search .search-field {
+  width: 100%;
+}
+
+@media only screen and (min-width: 600px) {
+  .widget_search .search-field {
+    width: auto;
+  }
+}
+
 .widget_search .search-submit {
   display: block;
   margin-top: 1rem;

--- a/style.css
+++ b/style.css
@@ -3542,6 +3542,16 @@ body.page .main-navigation {
   font-weight: 700;
 }
 
+.widget_search .search-field {
+  width: 100%;
+}
+
+@media only screen and (min-width: 600px) {
+  .widget_search .search-field {
+    width: auto;
+  }
+}
+
 .widget_search .search-submit {
   display: block;
   margin-top: 1rem;


### PR DESCRIPTION
Before: 
<img width="385" alt="screen shot 2018-11-16 at 9 38 13 pm" src="https://user-images.githubusercontent.com/1202812/48655684-36732380-e9e8-11e8-85d1-89056808e9d6.png">

After:
<img width="377" alt="screen shot 2018-11-16 at 9 38 27 pm" src="https://user-images.githubusercontent.com/1202812/48655686-38d57d80-e9e8-11e8-9853-922021f835d9.png">
