### PR TITLE
Fix reloading issue when an invalid menu-item appears in the menu

### DIFF
--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -152,8 +152,10 @@
 
 		if ( hasSelectiveRefresh ) {
 			// Force a full refresh on partial content renders to re-run updateNavigationMenu()
-			wp.customize.selectiveRefresh.bind('partial-content-rendered', function () {
-				wp.customize.preview.send('refresh');
+			wp.customize.selectiveRefresh.bind('partial-content-rendered', function ( placement ) {
+				if ( placement ) {
+					updateNavigationMenu( placement.container[0].parentNode );
+				}
 			});
         }
 	});

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -151,7 +151,7 @@
 		);
 
 		if ( hasSelectiveRefresh ) {
-			// Force a full refresh on partial content renders to re-run updateNavigationMenu()
+			// Re-run our priority+ function on partial content renders
 			wp.customize.selectiveRefresh.bind('partial-content-rendered', function ( placement ) {
 				if ( placement ) {
 					updateNavigationMenu( placement.container[0].parentNode );


### PR DESCRIPTION
Fixes: #616 

Instead of forcing a full refresh on the customizer whenever an active menu is updated, this fix re-runs the priorty+ function on partial refreshes which fixes the reloading issue and speeds up the menu configuration experience as a whole.

Before: 
![image](https://user-images.githubusercontent.com/1202812/48655081-ddec5800-e9e0-11e8-8c43-2e9c9a151c6a.gif)

After:
![invalid-menu-item-bug](https://user-images.githubusercontent.com/709581/48665903-278e7e80-ea85-11e8-818c-29740e04f3d3.gif)

To test: 

1. Create a page
2. Add it to the menu
3. Delete the page
4. Open the customizer and the menu should load only once

