### PR TITLE
Sync up gallery shortcode math with Gutenberg

### DIFF
--- a/sass/media/_galleries.scss
+++ b/sass/media/_galleries.scss
@@ -7,8 +7,8 @@
 
 .gallery-item {
 	display: inline-block;
-	margin-right: $size__spacing-unit;
-	margin-bottom: $size__spacing-unit;
+	margin-right: 16px;
+	margin-bottom: 16px;
 	text-align: center;
 	vertical-align: top;
 	width: 100%;
@@ -16,7 +16,7 @@
 	// Loops to enumerate the classes for gallery columns.
 	@for $i from 2 through 9 {
 		.gallery-columns-#{$i} & {
-			max-width: calc( ( 12 / #{$i} ) * (100% / 12) - ( #{$size__spacing-unit} * #{($i - 1) / $i} ) );
+			max-width: calc((100% - 16px * #{ $i - 1 }) / #{ $i });
 
 			&:nth-of-type(#{$i}n+#{$i}) {
 				margin-right: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4519,15 +4519,15 @@ svg {
 
 .gallery-item {
   display: inline-block;
-  margin-left: 1rem;
-  margin-bottom: 1rem;
+  margin-left: 16px;
+  margin-bottom: 16px;
   text-align: center;
   vertical-align: top;
   width: 100%;
 }
 
 .gallery-columns-2 .gallery-item {
-  max-width: calc( ( 12 / 2 ) * (100% / 12) - ( 1rem * 0.5 ));
+  max-width: calc((100% - 16px * 1) / 2);
 }
 
 .gallery-columns-2 .gallery-item:nth-of-type(2n+2) {
@@ -4535,7 +4535,7 @@ svg {
 }
 
 .gallery-columns-3 .gallery-item {
-  max-width: calc( ( 12 / 3 ) * (100% / 12) - ( 1rem * 0.66667 ));
+  max-width: calc((100% - 16px * 2) / 3);
 }
 
 .gallery-columns-3 .gallery-item:nth-of-type(3n+3) {
@@ -4543,7 +4543,7 @@ svg {
 }
 
 .gallery-columns-4 .gallery-item {
-  max-width: calc( ( 12 / 4 ) * (100% / 12) - ( 1rem * 0.75 ));
+  max-width: calc((100% - 16px * 3) / 4);
 }
 
 .gallery-columns-4 .gallery-item:nth-of-type(4n+4) {
@@ -4551,7 +4551,7 @@ svg {
 }
 
 .gallery-columns-5 .gallery-item {
-  max-width: calc( ( 12 / 5 ) * (100% / 12) - ( 1rem * 0.8 ));
+  max-width: calc((100% - 16px * 4) / 5);
 }
 
 .gallery-columns-5 .gallery-item:nth-of-type(5n+5) {
@@ -4559,7 +4559,7 @@ svg {
 }
 
 .gallery-columns-6 .gallery-item {
-  max-width: calc( ( 12 / 6 ) * (100% / 12) - ( 1rem * 0.83333 ));
+  max-width: calc((100% - 16px * 5) / 6);
 }
 
 .gallery-columns-6 .gallery-item:nth-of-type(6n+6) {
@@ -4567,7 +4567,7 @@ svg {
 }
 
 .gallery-columns-7 .gallery-item {
-  max-width: calc( ( 12 / 7 ) * (100% / 12) - ( 1rem * 0.85714 ));
+  max-width: calc((100% - 16px * 6) / 7);
 }
 
 .gallery-columns-7 .gallery-item:nth-of-type(7n+7) {
@@ -4575,7 +4575,7 @@ svg {
 }
 
 .gallery-columns-8 .gallery-item {
-  max-width: calc( ( 12 / 8 ) * (100% / 12) - ( 1rem * 0.875 ));
+  max-width: calc((100% - 16px * 7) / 8);
 }
 
 .gallery-columns-8 .gallery-item:nth-of-type(8n+8) {
@@ -4583,7 +4583,7 @@ svg {
 }
 
 .gallery-columns-9 .gallery-item {
-  max-width: calc( ( 12 / 9 ) * (100% / 12) - ( 1rem * 0.88889 ));
+  max-width: calc((100% - 16px * 8) / 9);
 }
 
 .gallery-columns-9 .gallery-item:nth-of-type(9n+9) {

--- a/style.css
+++ b/style.css
@@ -4531,15 +4531,15 @@ svg {
 
 .gallery-item {
   display: inline-block;
-  margin-right: 1rem;
-  margin-bottom: 1rem;
+  margin-right: 16px;
+  margin-bottom: 16px;
   text-align: center;
   vertical-align: top;
   width: 100%;
 }
 
 .gallery-columns-2 .gallery-item {
-  max-width: calc( ( 12 / 2 ) * (100% / 12) - ( 1rem * 0.5 ));
+  max-width: calc((100% - 16px * 1) / 2);
 }
 
 .gallery-columns-2 .gallery-item:nth-of-type(2n+2) {
@@ -4547,7 +4547,7 @@ svg {
 }
 
 .gallery-columns-3 .gallery-item {
-  max-width: calc( ( 12 / 3 ) * (100% / 12) - ( 1rem * 0.66667 ));
+  max-width: calc((100% - 16px * 2) / 3);
 }
 
 .gallery-columns-3 .gallery-item:nth-of-type(3n+3) {
@@ -4555,7 +4555,7 @@ svg {
 }
 
 .gallery-columns-4 .gallery-item {
-  max-width: calc( ( 12 / 4 ) * (100% / 12) - ( 1rem * 0.75 ));
+  max-width: calc((100% - 16px * 3) / 4);
 }
 
 .gallery-columns-4 .gallery-item:nth-of-type(4n+4) {
@@ -4563,7 +4563,7 @@ svg {
 }
 
 .gallery-columns-5 .gallery-item {
-  max-width: calc( ( 12 / 5 ) * (100% / 12) - ( 1rem * 0.8 ));
+  max-width: calc((100% - 16px * 4) / 5);
 }
 
 .gallery-columns-5 .gallery-item:nth-of-type(5n+5) {
@@ -4571,7 +4571,7 @@ svg {
 }
 
 .gallery-columns-6 .gallery-item {
-  max-width: calc( ( 12 / 6 ) * (100% / 12) - ( 1rem * 0.83333 ));
+  max-width: calc((100% - 16px * 5) / 6);
 }
 
 .gallery-columns-6 .gallery-item:nth-of-type(6n+6) {
@@ -4579,7 +4579,7 @@ svg {
 }
 
 .gallery-columns-7 .gallery-item {
-  max-width: calc( ( 12 / 7 ) * (100% / 12) - ( 1rem * 0.85714 ));
+  max-width: calc((100% - 16px * 6) / 7);
 }
 
 .gallery-columns-7 .gallery-item:nth-of-type(7n+7) {
@@ -4587,7 +4587,7 @@ svg {
 }
 
 .gallery-columns-8 .gallery-item {
-  max-width: calc( ( 12 / 8 ) * (100% / 12) - ( 1rem * 0.875 ));
+  max-width: calc((100% - 16px * 7) / 8);
 }
 
 .gallery-columns-8 .gallery-item:nth-of-type(8n+8) {
@@ -4595,7 +4595,7 @@ svg {
 }
 
 .gallery-columns-9 .gallery-item {
-  max-width: calc( ( 12 / 9 ) * (100% / 12) - ( 1rem * 0.88889 ));
+  max-width: calc((100% - 16px * 8) / 9);
 }
 
 .gallery-columns-9 .gallery-item:nth-of-type(9n+9) {


### PR DESCRIPTION
Fixes #531 

Previously, we were providing our own frontend math for shortcode-based galleries. This included 22px margins, and was a little more complicated than was necessary. In addition, the math involving our 22px base spacing caused some breakage at certain breakpoints for 7-column galleries (due to partial pixels).

This new approach borrows the gallery math + spacing from Gutenberg, which syncs up gallery presentation between the two methods, simplifies the math, and fixes the 7-column issue. Checked with 1-column through 9-column gallery shortcodes. 👍 

**Before**
<img width="689" alt="screen shot 2018-11-18 at 7 52 49 am" src="https://user-images.githubusercontent.com/1202812/48672715-6238fb00-eb07-11e8-9520-82fda3589e23.png">

**After**
<img width="686" alt="screen shot 2018-11-18 at 7 52 30 am" src="https://user-images.githubusercontent.com/1202812/48672716-6533eb80-eb07-11e8-9e8f-d721b7136de4.png">
