### PR TITLE
Simplify selectors for dashes that appear in nested lists

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -90,7 +90,7 @@
 /* Fallback for non-latin fonts */
 
 @mixin non-latin-fonts( $wrapper_classname: '.site' ) {
-	
+
 	/* Arabic */
 	html[lang="ar"] #{$wrapper_classname} *,
 	html[lang="ary"] #{$wrapper_classname} *,
@@ -190,6 +190,22 @@
 /* Nested sub-menu padding: 10 levels deep */
 @mixin nestedSubMenuPadding() {
 
+ul {
+	counter-reset: section;          /* Creates a new instance of the
+                                        section counter with each ol
+                                        element */
+	list-style-type: none;
+}
+
+li::before {
+	counter-increment: section;      /* Increments only this instance
+                                        of the section counter */
+	content: counters(section, ".") " ";   /* Combines the values of all instances
+                                        of the section counter, separated
+                                        by a period */
+}
+
+/*
 	ul li > a:before {
 		font-family: $font__body;
 		font-weight: normal;
@@ -221,6 +237,7 @@
 	ul ul ul ul ul ul ul ul ul li > a:before {
 		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
 	}
+*/
 }
 
 @import "utilities";

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -200,7 +200,6 @@
 		content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
 		counter-increment: submenu
 	}
-
 }
 
 @import "utilities";

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -190,54 +190,17 @@
 /* Nested sub-menu padding: 10 levels deep */
 @mixin nestedSubMenuPadding() {
 
-ul {
-	counter-reset: section;          /* Creates a new instance of the
-                                        section counter with each ol
-                                        element */
-	list-style-type: none;
-}
+	ul {
+		counter-reset: submenu;
+	}
 
-li::before {
-	counter-increment: section;      /* Increments only this instance
-                                        of the section counter */
-	content: counters(section, ".") " ";   /* Combines the values of all instances
-                                        of the section counter, separated
-                                        by a period */
-}
-
-/*
-	ul li > a:before {
+	ul > li > a::before {
 		font-family: $font__body;
 		font-weight: normal;
+		content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
+		counter-increment: submenu
 	}
-	ul > li > a:before {
-		content: "\2013\00a0";
-	}
-	ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0";
-	}
-	ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-*/
+
 }
 
 @import "utilities";

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -267,37 +267,16 @@
 			}
 		}
 
-		/* Nested sub-menu padding: 10 levels deep */
-		.sub-menu li > a:before {
+		/* Nested sub-menu dashes */
+		.sub-menu {
+			counter-reset: submenu;
+		}
+
+		.sub-menu > li > a::before {
 			font-family: $font__body;
 			font-weight: normal;
-		}
-		.sub-menu > li > a:before {
-			content: "\2013\00a0";
-		}
-		.sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
+			counter-increment: submenu
 		}
 	}
 
@@ -364,37 +343,16 @@
 			}
 		}
 
-		/* Nested sub-menu padding: 10 levels deep */
-		.sub-menu li > a:before {
+		/* Nested sub-menu dashes */
+		.sub-menu {
+			counter-reset: submenu;
+		}
+
+		.sub-menu > li > a::before {
 			font-family: $font__body;
 			font-weight: normal;
-		}
-		.sub-menu > li > a:before {
-			content: "\2013\00a0";
-		}
-		.sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-		}
-		.sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-			content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
+			counter-increment: submenu
 		}
 	}
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -616,47 +616,57 @@ ul.wp-block-archives li ul,
 
 .wp-block-categories ul {
   padding-top: 0.75rem;
+  /*
+	ul li > a:before {
+		font-family: $font__body;
+		font-weight: normal;
+	}
+	ul > li > a:before {
+		content: "\2013\00a0";
+	}
+	ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0";
+	}
+	ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+*/
 }
 
-.wp-block-categories ul ul li > a:before {
-  font-family: "NonBreakingSpaceOverride", "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
+.wp-block-categories ul ul {
+  counter-reset: section;
+  /* Creates a new instance of the
+                                        section counter with each ol
+                                        element */
+  list-style-type: none;
 }
 
-.wp-block-categories ul ul > li > a:before {
-  content: "\2013\00a0";
-}
-
-.wp-block-categories ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.wp-block-categories ul ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+.wp-block-categories ul li::before {
+  counter-increment: section;
+  /* Increments only this instance
+                                        of the section counter */
+  content: counters(section, ".") " ";
+  /* Combines the values of all instances
+                                        of the section counter, separated
+                                        by a period */
 }
 
 .wp-block-categories li ul {

--- a/style-editor.css
+++ b/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*!
 Twenty Nineteen Editor Styles
 */
@@ -616,57 +617,17 @@ ul.wp-block-archives li ul,
 
 .wp-block-categories ul {
   padding-top: 0.75rem;
-  /*
-	ul li > a:before {
-		font-family: $font__body;
-		font-weight: normal;
-	}
-	ul > li > a:before {
-		content: "\2013\00a0";
-	}
-	ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0";
-	}
-	ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-*/
 }
 
 .wp-block-categories ul ul {
-  counter-reset: section;
-  /* Creates a new instance of the
-                                        section counter with each ol
-                                        element */
-  list-style-type: none;
+  counter-reset: submenu;
 }
 
-.wp-block-categories ul li::before {
-  counter-increment: section;
-  /* Increments only this instance
-                                        of the section counter */
-  content: counters(section, ".") " ";
-  /* Combines the values of all instances
-                                        of the section counter, separated
-                                        by a period */
+.wp-block-categories ul ul > li > a::before {
+  font-family: "NonBreakingSpaceOverride", "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .wp-block-categories li ul {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3401,39 +3401,6 @@ body.page .main-navigation {
 .widget_rss ul {
   padding: 0;
   list-style: none;
-  /*
-	ul li > a:before {
-		font-family: $font__body;
-		font-weight: normal;
-	}
-	ul > li > a:before {
-		content: "\2013\00a0";
-	}
-	ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0";
-	}
-	ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-*/
 }
 
 .widget_archive ul li,
@@ -3786,42 +3753,6 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-categories li a,
 .entry .entry-content .wp-block-latest-posts li a {
   text-decoration: none;
-}
-
-.entry .entry-content .wp-block-categories {
-  /*
-	ul li > a:before {
-		font-family: $font__body;
-		font-weight: normal;
-	}
-	ul > li > a:before {
-		content: "\2013\00a0";
-	}
-	ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0";
-	}
-	ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-*/
 }
 
 .entry .entry-content .wp-block-categories ul {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3461,28 +3461,21 @@ body.page .main-navigation {
 .widget_recent_comments ul ul,
 .widget_recent_entries ul ul,
 .widget_rss ul ul {
-  counter-reset: section;
-  /* Creates a new instance of the
-                                        section counter with each ol
-                                        element */
-  list-style-type: none;
+  counter-reset: submenu;
 }
 
-.widget_archive ul li::before,
-.widget_categories ul li::before,
-.widget_meta ul li::before,
-.widget_nav_menu ul li::before,
-.widget_pages ul li::before,
-.widget_recent_comments ul li::before,
-.widget_recent_entries ul li::before,
-.widget_rss ul li::before {
-  counter-increment: section;
-  /* Increments only this instance
-                                        of the section counter */
-  content: counters(section, ".") " ";
-  /* Combines the values of all instances
-                                        of the section counter, separated
-                                        by a period */
+.widget_archive ul ul > li > a::before,
+.widget_categories ul ul > li > a::before,
+.widget_meta ul ul > li > a::before,
+.widget_nav_menu ul ul > li > a::before,
+.widget_pages ul ul > li > a::before,
+.widget_recent_comments ul ul > li > a::before,
+.widget_recent_entries ul ul > li > a::before,
+.widget_rss ul ul > li > a::before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .widget_tag_cloud .tagcloud {
@@ -3841,21 +3834,14 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-categories ul {
-  counter-reset: section;
-  /* Creates a new instance of the
-                                        section counter with each ol
-                                        element */
-  list-style-type: none;
+  counter-reset: submenu;
 }
 
-.entry .entry-content .wp-block-categories li::before {
-  counter-increment: section;
-  /* Increments only this instance
-                                        of the section counter */
-  content: counters(section, ".") " ";
-  /* Combines the values of all instances
-                                        of the section counter, separated
-                                        by a period */
+.entry .entry-content .wp-block-categories ul > li > a::before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1218,7 +1218,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu padding: 10 levels deep */
+  /* Nested sub-menu dashes */
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
@@ -1229,7 +1229,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu padding: 10 levels deep */
+  /* Nested sub-menu dashes */
 }
 
 @media only screen and (min-width: 768px) {
@@ -1333,86 +1333,26 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu li > a:before {
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu li > a:before {
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a:before {
-  content: "\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a:before {
-  content: "\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
@@ -1425,7 +1365,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu padding: 10 levels deep */
+  /* Nested sub-menu dashes */
 }
 
 @media only screen and (min-width: 768px) {
@@ -1496,65 +1436,19 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu li > a:before {
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a:before {
-  content: "\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3401,6 +3401,39 @@ body.page .main-navigation {
 .widget_rss ul {
   padding: 0;
   list-style: none;
+  /*
+	ul li > a:before {
+		font-family: $font__body;
+		font-weight: normal;
+	}
+	ul > li > a:before {
+		content: "\2013\00a0";
+	}
+	ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0";
+	}
+	ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+*/
 }
 
 .widget_archive ul li,
@@ -3420,115 +3453,36 @@ body.page .main-navigation {
   margin-bottom: 0.5rem;
 }
 
-.widget_archive ul ul li > a:before,
-.widget_categories ul ul li > a:before,
-.widget_meta ul ul li > a:before,
-.widget_nav_menu ul ul li > a:before,
-.widget_pages ul ul li > a:before,
-.widget_recent_comments ul ul li > a:before,
-.widget_recent_entries ul ul li > a:before,
-.widget_rss ul ul li > a:before {
-  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
+.widget_archive ul ul,
+.widget_categories ul ul,
+.widget_meta ul ul,
+.widget_nav_menu ul ul,
+.widget_pages ul ul,
+.widget_recent_comments ul ul,
+.widget_recent_entries ul ul,
+.widget_rss ul ul {
+  counter-reset: section;
+  /* Creates a new instance of the
+                                        section counter with each ol
+                                        element */
+  list-style-type: none;
 }
 
-.widget_archive ul ul > li > a:before,
-.widget_categories ul ul > li > a:before,
-.widget_meta ul ul > li > a:before,
-.widget_nav_menu ul ul > li > a:before,
-.widget_pages ul ul > li > a:before,
-.widget_recent_comments ul ul > li > a:before,
-.widget_recent_entries ul ul > li > a:before,
-.widget_rss ul ul > li > a:before {
-  content: "\2013\00a0";
-}
-
-.widget_archive ul ul ul li > a:before,
-.widget_categories ul ul ul li > a:before,
-.widget_meta ul ul ul li > a:before,
-.widget_nav_menu ul ul ul li > a:before,
-.widget_pages ul ul ul li > a:before,
-.widget_recent_comments ul ul ul li > a:before,
-.widget_recent_entries ul ul ul li > a:before,
-.widget_rss ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+.widget_archive ul li::before,
+.widget_categories ul li::before,
+.widget_meta ul li::before,
+.widget_nav_menu ul li::before,
+.widget_pages ul li::before,
+.widget_recent_comments ul li::before,
+.widget_recent_entries ul li::before,
+.widget_rss ul li::before {
+  counter-increment: section;
+  /* Increments only this instance
+                                        of the section counter */
+  content: counters(section, ".") " ";
+  /* Combines the values of all instances
+                                        of the section counter, separated
+                                        by a period */
 }
 
 .widget_tag_cloud .tagcloud {
@@ -3841,6 +3795,42 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
+.entry .entry-content .wp-block-categories {
+  /*
+	ul li > a:before {
+		font-family: $font__body;
+		font-weight: normal;
+	}
+	ul > li > a:before {
+		content: "\2013\00a0";
+	}
+	ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0";
+	}
+	ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+*/
+}
+
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }
@@ -3850,45 +3840,22 @@ body.page .main-navigation {
   padding-right: 0;
 }
 
-.entry .entry-content .wp-block-categories ul li > a:before {
-  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
+.entry .entry-content .wp-block-categories ul {
+  counter-reset: section;
+  /* Creates a new instance of the
+                                        section counter with each ol
+                                        element */
+  list-style-type: none;
 }
 
-.entry .entry-content .wp-block-categories ul > li > a:before {
-  content: "\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+.entry .entry-content .wp-block-categories li::before {
+  counter-increment: section;
+  /* Increments only this instance
+                                        of the section counter */
+  content: counters(section, ".") " ";
+  /* Combines the values of all instances
+                                        of the section counter, separated
+                                        by a period */
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li {

--- a/style.css
+++ b/style.css
@@ -3407,6 +3407,39 @@ body.page .main-navigation {
 .widget_rss ul {
   padding: 0;
   list-style: none;
+  /*
+	ul li > a:before {
+		font-family: $font__body;
+		font-weight: normal;
+	}
+	ul > li > a:before {
+		content: "\2013\00a0";
+	}
+	ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0";
+	}
+	ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+*/
 }
 
 .widget_archive ul li,
@@ -3426,115 +3459,36 @@ body.page .main-navigation {
   margin-bottom: 0.5rem;
 }
 
-.widget_archive ul ul li > a:before,
-.widget_categories ul ul li > a:before,
-.widget_meta ul ul li > a:before,
-.widget_nav_menu ul ul li > a:before,
-.widget_pages ul ul li > a:before,
-.widget_recent_comments ul ul li > a:before,
-.widget_recent_entries ul ul li > a:before,
-.widget_rss ul ul li > a:before {
-  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
+.widget_archive ul ul,
+.widget_categories ul ul,
+.widget_meta ul ul,
+.widget_nav_menu ul ul,
+.widget_pages ul ul,
+.widget_recent_comments ul ul,
+.widget_recent_entries ul ul,
+.widget_rss ul ul {
+  counter-reset: section;
+  /* Creates a new instance of the
+                                        section counter with each ol
+                                        element */
+  list-style-type: none;
 }
 
-.widget_archive ul ul > li > a:before,
-.widget_categories ul ul > li > a:before,
-.widget_meta ul ul > li > a:before,
-.widget_nav_menu ul ul > li > a:before,
-.widget_pages ul ul > li > a:before,
-.widget_recent_comments ul ul > li > a:before,
-.widget_recent_entries ul ul > li > a:before,
-.widget_rss ul ul > li > a:before {
-  content: "\2013\00a0";
-}
-
-.widget_archive ul ul ul li > a:before,
-.widget_categories ul ul ul li > a:before,
-.widget_meta ul ul ul li > a:before,
-.widget_nav_menu ul ul ul li > a:before,
-.widget_pages ul ul ul li > a:before,
-.widget_recent_comments ul ul ul li > a:before,
-.widget_recent_entries ul ul ul li > a:before,
-.widget_rss ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.widget_archive ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_categories ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_meta ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_nav_menu ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_pages ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_comments ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_recent_entries ul ul ul ul ul ul ul ul ul ul li > a:before,
-.widget_rss ul ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+.widget_archive ul li::before,
+.widget_categories ul li::before,
+.widget_meta ul li::before,
+.widget_nav_menu ul li::before,
+.widget_pages ul li::before,
+.widget_recent_comments ul li::before,
+.widget_recent_entries ul li::before,
+.widget_rss ul li::before {
+  counter-increment: section;
+  /* Increments only this instance
+                                        of the section counter */
+  content: counters(section, ".") " ";
+  /* Combines the values of all instances
+                                        of the section counter, separated
+                                        by a period */
 }
 
 .widget_tag_cloud .tagcloud {
@@ -3853,6 +3807,42 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
+.entry .entry-content .wp-block-categories {
+  /*
+	ul li > a:before {
+		font-family: $font__body;
+		font-weight: normal;
+	}
+	ul > li > a:before {
+		content: "\2013\00a0";
+	}
+	ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0";
+	}
+	ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+	ul ul ul ul ul ul ul ul ul li > a:before {
+		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+	}
+*/
+}
+
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }
@@ -3862,45 +3852,22 @@ body.page .main-navigation {
   padding-left: 0;
 }
 
-.entry .entry-content .wp-block-categories ul li > a:before {
-  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
+.entry .entry-content .wp-block-categories ul {
+  counter-reset: section;
+  /* Creates a new instance of the
+                                        section counter with each ol
+                                        element */
+  list-style-type: none;
 }
 
-.entry .entry-content .wp-block-categories ul > li > a:before {
-  content: "\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.entry .entry-content .wp-block-categories ul ul ul ul ul ul ul ul ul li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+.entry .entry-content .wp-block-categories li::before {
+  counter-increment: section;
+  /* Increments only this instance
+                                        of the section counter */
+  content: counters(section, ".") " ";
+  /* Combines the values of all instances
+                                        of the section counter, separated
+                                        by a period */
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li {

--- a/style.css
+++ b/style.css
@@ -3407,39 +3407,6 @@ body.page .main-navigation {
 .widget_rss ul {
   padding: 0;
   list-style: none;
-  /*
-	ul li > a:before {
-		font-family: $font__body;
-		font-weight: normal;
-	}
-	ul > li > a:before {
-		content: "\2013\00a0";
-	}
-	ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0";
-	}
-	ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-*/
 }
 
 .widget_archive ul li,
@@ -3467,28 +3434,21 @@ body.page .main-navigation {
 .widget_recent_comments ul ul,
 .widget_recent_entries ul ul,
 .widget_rss ul ul {
-  counter-reset: section;
-  /* Creates a new instance of the
-                                        section counter with each ol
-                                        element */
-  list-style-type: none;
+  counter-reset: submenu;
 }
 
-.widget_archive ul li::before,
-.widget_categories ul li::before,
-.widget_meta ul li::before,
-.widget_nav_menu ul li::before,
-.widget_pages ul li::before,
-.widget_recent_comments ul li::before,
-.widget_recent_entries ul li::before,
-.widget_rss ul li::before {
-  counter-increment: section;
-  /* Increments only this instance
-                                        of the section counter */
-  content: counters(section, ".") " ";
-  /* Combines the values of all instances
-                                        of the section counter, separated
-                                        by a period */
+.widget_archive ul ul > li > a::before,
+.widget_categories ul ul > li > a::before,
+.widget_meta ul ul > li > a::before,
+.widget_nav_menu ul ul > li > a::before,
+.widget_pages ul ul > li > a::before,
+.widget_recent_comments ul ul > li > a::before,
+.widget_recent_entries ul ul > li > a::before,
+.widget_rss ul ul > li > a::before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .widget_tag_cloud .tagcloud {
@@ -3807,42 +3767,6 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
-.entry .entry-content .wp-block-categories {
-  /*
-	ul li > a:before {
-		font-family: $font__body;
-		font-weight: normal;
-	}
-	ul > li > a:before {
-		content: "\2013\00a0";
-	}
-	ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0";
-	}
-	ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-	ul ul ul ul ul ul ul ul ul li > a:before {
-		content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-	}
-*/
-}
-
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }
@@ -3853,21 +3777,14 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-categories ul {
-  counter-reset: section;
-  /* Creates a new instance of the
-                                        section counter with each ol
-                                        element */
-  list-style-type: none;
+  counter-reset: submenu;
 }
 
-.entry .entry-content .wp-block-categories li::before {
-  counter-increment: section;
-  /* Increments only this instance
-                                        of the section counter */
-  content: counters(section, ".") " ";
-  /* Combines the values of all instances
-                                        of the section counter, separated
-                                        by a period */
+.entry .entry-content .wp-block-categories ul > li > a::before {
+  font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li {

--- a/style.css
+++ b/style.css
@@ -1218,7 +1218,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu padding: 10 levels deep */
+  /* Nested sub-menu dashes */
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
@@ -1229,7 +1229,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu padding: 10 levels deep */
+  /* Nested sub-menu dashes */
 }
 
 @media only screen and (min-width: 768px) {
@@ -1333,86 +1333,26 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu li > a:before {
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu li > a:before {
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a:before {
-  content: "\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a:before {
-  content: "\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
@@ -1425,7 +1365,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu padding: 10 levels deep */
+  /* Nested sub-menu dashes */
 }
 
 @media only screen and (min-width: 768px) {
@@ -1496,65 +1436,19 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu li > a:before {
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
   font-family: "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
   font-weight: normal;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a:before {
-  content: "\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before,
-.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu .sub-menu li > a:before {
-  content: "\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0\2013\00a0";
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {


### PR DESCRIPTION
Instead of using really long selectors to add dashes to nested lists ( `ul ul ul > li a:before {}` ), this change uses CSS [`counters()`](https://caniuse.com/#feat=css-counters) to insert the dashes programatically. Doing it this way also comes with the benefit of supporting virtually infinite nested lists where as the previous CSS only supported 10 nested lists (and required far more CSS code).