### PR TITLE
Limit width of `wide` and `full` images to original image width

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -467,8 +467,18 @@
 			max-width: 100%;
 		}
 
+		&.alignwide img {
+			width: auto;
+
+			@include media(tablet) {
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
+
 		&.alignfull img {
-			width: 100vw;
+			width: auto;
+			max-width: 100vw;
 
 			@include media(tablet) {
 				margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -4116,8 +4116,20 @@ body.page .main-navigation {
   max-width: 100%;
 }
 
+.entry .entry-content .wp-block-image.alignwide img {
+	width: auto;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image.alignwide img {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 .entry .entry-content .wp-block-image.alignfull img {
-  width: 100vw;
+	width: auto;
+  max-width: 100vw;
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
Addresses #630.

Limit displayed with of `alignwide` and `alignfull` images to the original width of the uploaded image file to avoid stretching of images.