### PR TITLE
Fix site logo selective refresh issue

### DIFF
--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -147,15 +147,21 @@
 		var hasSelectiveRefresh = (
 			'undefined' !== typeof wp &&
 			wp.customize &&
-			wp.customize.selectiveRefresh
+			wp.customize.selectiveRefresh &&
+			wp.customize.navMenusPreview.NavMenuInstancePartial
 		);
 
 		if ( hasSelectiveRefresh ) {
-			// Re-run our priority+ function on partial content renders
+			// Re-run our priority+ function on Nav Menu partial refreshes
 			wp.customize.selectiveRefresh.bind('partial-content-rendered', function ( placement ) {
-				console.log( placement );
-				console.log( placement.partial.id );
-				if ( placement && placement.partial.id.includes( 'nav_menu_instance' ) ) {
+
+				var isNewNavMenu = (
+					placement &&
+					placement.partial.id.includes( 'nav_menu_instance' ) &&
+					placement.container[0].parentNode.classList.contains('main-navigation')
+				);
+
+				if ( isNewNavMenu ) {
 					updateNavigationMenu( placement.container[0].parentNode );
 				}
 			});

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -97,9 +97,23 @@
 	var breaks       = [];
 
 	/**
+	 * Let’s bail if we our menu doesn't exist
+	 */
+	if ( ! navContainer ) {
+		return;
+	}
+
+	/**
 	 * Refreshes the list item from the menu depending on the menu size
 	 */
 	function updateNavigationMenu( container ) {
+
+		/**
+		 * Let’s bail if our menu is empty
+		 */
+		if ( ! container.parentNode.querySelector('.main-menu[id]') ) {
+			return;
+		}
 
 		// Adds the necessary UI to operate the menu.
 		var visibleList  = container.parentNode.querySelector('.main-menu[id]');
@@ -158,6 +172,7 @@
 				var isNewNavMenu = (
 					placement &&
 					placement.partial.id.includes( 'nav_menu_instance' ) &&
+					'null' !== placement.container[0].parentNode &&
 					placement.container[0].parentNode.classList.contains( 'main-navigation' )
 				);
 

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -153,7 +153,9 @@
 		if ( hasSelectiveRefresh ) {
 			// Re-run our priority+ function on partial content renders
 			wp.customize.selectiveRefresh.bind('partial-content-rendered', function ( placement ) {
-				if ( placement ) {
+				console.log( placement );
+				console.log( placement.partial.id );
+				if ( placement && placement.partial.id.includes( 'nav_menu_instance' ) ) {
 					updateNavigationMenu( placement.container[0].parentNode );
 				}
 			});

--- a/js/priority-menu.js
+++ b/js/priority-menu.js
@@ -153,12 +153,12 @@
 
 		if ( hasSelectiveRefresh ) {
 			// Re-run our priority+ function on Nav Menu partial refreshes
-			wp.customize.selectiveRefresh.bind('partial-content-rendered', function ( placement ) {
+			wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function ( placement ) {
 
 				var isNewNavMenu = (
 					placement &&
 					placement.partial.id.includes( 'nav_menu_instance' ) &&
-					placement.container[0].parentNode.classList.contains('main-navigation')
+					placement.container[0].parentNode.classList.contains( 'main-navigation' )
 				);
 
 				if ( isNewNavMenu ) {
@@ -171,7 +171,7 @@
 	/**
 	 * Run our priority+ function on load
 	 */
-	window.addEventListener('load', function() {
+	window.addEventListener( 'load', function() {
 		updateNavigationMenu( navContainer );
 	});
 


### PR DESCRIPTION
Found a bug where the menu would break when updating the site-logo. This was happening because the conditional for re-running the priority+ function on selective refresh was happening on _every_ partial refresh. This fix makes the conditional more specific so that it only re-runs the priority+ function when the menu is refreshed. 

Before:
![site-logo-menu-error](https://user-images.githubusercontent.com/709581/48680265-83c9cf00-eb67-11e8-94f4-2e2ef93ca0e5.gif)

After: 
![site-logo-menu-fixed](https://user-images.githubusercontent.com/709581/48680230-1ae25700-eb67-11e8-85b7-fc7c02e009ed.gif)
