### PR TITLE
Minor: Add right padding to the privacy policy link

### DIFF
--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -10,7 +10,8 @@
 			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
 		}
 
-		.imprint {
+		.imprint, 
+		.privacy-policy-link {
 			margin-right: $size__spacing-unit;
 		}
 	}

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -9,20 +9,6 @@
 		@include media(tablet) {
 			margin: calc(3 * #{$size__spacing-unit}) $size__site-margins;
 		}
-
-		.imprint, 
-		.privacy-policy-link {
-			margin-right: $size__spacing-unit;
-		}
-	}
-
-	.site-info a {
-		color: inherit;
-
-		&:hover {
-			text-decoration: none;
-			color: $color__link;
-		}
 	}
 
 	.widget-column {
@@ -39,5 +25,19 @@
 
 	.site-info {
 		color: $color__text-light;
+
+		a {
+			color: inherit;
+
+			&:hover {
+				text-decoration: none;
+				color: $color__link;
+			}
+		}
+
+		.imprint,
+		.privacy-policy-link {
+			margin-right: $size__spacing-unit;
+		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3233,20 +3233,6 @@ body.page .main-navigation {
   }
 }
 
-#colophon .widget-area .imprint,
-#colophon .site-info .imprint {
-  margin-left: 1rem;
-}
-
-#colophon .site-info a {
-  color: inherit;
-}
-
-#colophon .site-info a:hover {
-  text-decoration: none;
-  color: #0073aa;
-}
-
 #colophon .widget-column {
   display: flex;
   flex-wrap: wrap;
@@ -3265,6 +3251,20 @@ body.page .main-navigation {
 
 #colophon .site-info {
   color: #767676;
+}
+
+#colophon .site-info a {
+  color: inherit;
+}
+
+#colophon .site-info a:hover {
+  text-decoration: none;
+  color: #0073aa;
+}
+
+#colophon .site-info .imprint,
+#colophon .site-info .privacy-policy-link {
+  margin-left: 1rem;
 }
 
 /* Widgets */

--- a/style.css
+++ b/style.css
@@ -3240,7 +3240,9 @@ body.page .main-navigation {
 }
 
 #colophon .widget-area .imprint,
-#colophon .site-info .imprint {
+#colophon .widget-area .privacy-policy-link,
+#colophon .site-info .imprint,
+#colophon .site-info .privacy-policy-link {
   margin-right: 1rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -3239,22 +3239,6 @@ body.page .main-navigation {
   }
 }
 
-#colophon .widget-area .imprint,
-#colophon .widget-area .privacy-policy-link,
-#colophon .site-info .imprint,
-#colophon .site-info .privacy-policy-link {
-  margin-right: 1rem;
-}
-
-#colophon .site-info a {
-  color: inherit;
-}
-
-#colophon .site-info a:hover {
-  text-decoration: none;
-  color: #0073aa;
-}
-
 #colophon .widget-column {
   display: flex;
   flex-wrap: wrap;
@@ -3273,6 +3257,20 @@ body.page .main-navigation {
 
 #colophon .site-info {
   color: #767676;
+}
+
+#colophon .site-info a {
+  color: inherit;
+}
+
+#colophon .site-info a:hover {
+  text-decoration: none;
+  color: #0073aa;
+}
+
+#colophon .site-info .imprint,
+#colophon .site-info .privacy-policy-link {
+  margin-right: 1rem;
 }
 
 /* Widgets */


### PR DESCRIPTION
Right now, the privacy policy link has no right padding. This becomes a problem when someone's added a footer menu:

<img width="872" alt="screen shot 2018-11-19 at 7 56 38 am" src="https://user-images.githubusercontent.com/1202812/48708641-19e60f80-ebd1-11e8-8b7d-1a0a3fba34e1.png">

This PR just adds some padding there:

<img width="895" alt="screen shot 2018-11-19 at 7 55 42 am" src="https://user-images.githubusercontent.com/1202812/48708655-24a0a480-ebd1-11e8-85d1-29630fa1c670.png">
