### PR TITLE
Expand color palette

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -143,9 +143,34 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 			'editor-color-palette',
 			array(
 				array(
-					'name'  => __( 'Primary Color', 'twentynineteen' ),
+					'name'  => __( 'Primary', 'twentynineteen' ),
 					'slug'  => 'primary',
 					'color' => twentynineteen_hsl_hex( 'default' === get_theme_mod( 'primary_color' ) ? 199 : get_theme_mod( 'primary_color_hue', 199 ), 100, 33 ),
+				),
+				array(
+					'name'  => __( 'Light Primary', 'twentynineteen' ),
+					'slug'  => 'primary-light',
+					'color' => twentynineteen_hsl_hex( 'default' === get_theme_mod( 'primary_color' ) ? 199 : get_theme_mod( 'primary_color_hue', 199 ), 100, 77 ),
+				),
+				array(
+					'name'  => __( 'Black', 'twentynineteen' ),
+					'slug'  => 'black',
+					'color' => '#000000',
+				),
+				array(
+					'name'  => __( 'Black', 'twentynineteen' ),
+					'slug'  => 'black',
+					'color' => '#000000',
+				),
+				array(
+					'name'  => __( 'White', 'twentynineteen' ),
+					'slug'  => 'black',
+					'color' => '#ffffff',
+				),
+				array(
+					'name'  => __( 'Jam', 'twentynineteen' ),
+					'slug'  => 'jam',
+					'color' => '#aa053f',
 				),
 			)
 		);


### PR DESCRIPTION
This PR takes a stab at improving the pullquote experience a little bit, by expanding the color palette.

Your thoughts are very much welcome on the colors I chose here, the important thing is we have more than 1, and ideally more than 3. 5 or more seems like a good number:

![screenshot 2018-11-19 at 14 02 27](https://user-images.githubusercontent.com/1204802/48709116-d1484980-ec04-11e8-9fa0-d0b81cf66386.png)

This partially addresses an issue where in the "Solid Color" variation, setting the Main Color _also_ sets the Text Color. See also https://github.com/WordPress/gutenberg/issues/12024#issuecomment-439877180.

The issue with that is that the mechanism that auto-sets colors picks from whatever colors are available in the palette registered by the theme. And in this case there was only one — Blue — so when you set a blue background, suddenly you also had blue text, completely invisible. 

We should fix this upstream, so you only ever set one color at a time, but in the mean time, this mitigates it. 

There's another issue — in the Regular variation, setting the "Main Color" does nothing:

![screenshot 2018-11-19 at 14 08 30](https://user-images.githubusercontent.com/1204802/48709227-2be1a580-ec05-11e8-88de-2f7d92894e10.png)

Well this is not actually true, because it does set a border-color. Here's the markup you get when you set the main color:

```
<figure class="wp-block-pullquote is-style-default" style="border-color: rgb(170, 5, 63);">
...
</figure>
```

The border-color is set by an inline style. This is not really ideal, as it dictates how the regular variation should look. Ideally it would, like for the Solid Color variation, simply set a CSS class such as "has-jam-color" or something like that, which could then be leveraged by the stylesheet to draw any kind of decoratives, like a fancy curly quote in the background or something. 

However that aspect is not fixable in the next few days — how about we do this:

A default pullquote looks like this:

![screenshot 2018-11-19 at 14 08 30](https://user-images.githubusercontent.com/1204802/48709381-98f53b00-ec05-11e8-9509-042e7e4cd75e.png)

But when the user explicitly sets a main color, you get this:

![screenshot 2018-11-19 at 14 16 35](https://user-images.githubusercontent.com/1204802/48709439-c80bac80-ec05-11e8-9ca0-b539e40d379c.png)

(in the above at least the border width is 2px which matches the separator width)