### PR TITLE
Update pullquote border color

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -290,7 +290,8 @@
 
 	//! Pullquote
 	.wp-block-pullquote {
-		border: none;
+		border-color: transparent;
+		border-width: 2px;
 		padding: $size__spacing-unit;
 
 		blockquote {

--- a/style-editor.css
+++ b/style-editor.css
@@ -394,7 +394,8 @@ figcaption,
 
 /** === Pullquote === */
 .wp-block-pullquote {
-  border: none;
+  border-color: transparent;
+  border-width: 2px;
   color: #000;
 }
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -423,7 +423,8 @@ figcaption,
 /** === Pullquote === */
 
 .wp-block-pullquote {
-	border: none;
+	border-color: transparent;
+	border-width: 2px;
 	color: #000;
 
 	blockquote {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3708,7 +3708,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote {
-  border: none;
+  border: transparent;
+  border-width: 2px;
   padding: 1rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -3720,7 +3720,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote {
-  border: none;
+  border-color: transparent;
+  border-width: 2px;
   padding: 1rem;
 }
 


### PR DESCRIPTION
As per @jasmussen's suggestion here:
WordPress/gutenberg#12024 (comment)

Currently, pullquotes do not have borders. Therefore, the block does not utilize the "Main" color option in the sidebar. 

This PR preserves the default appearance, but also allows users to activate a border color by using the "Main" color option in the sidebar.

**Before:**
![pullquote-before](https://user-images.githubusercontent.com/1202812/48717922-5709cc00-ebe8-11e8-8dd7-9ace0d7ba46e.gif)

**After:**
![pullquote-after](https://user-images.githubusercontent.com/1202812/48717925-596c2600-ebe8-11e8-9be0-17948af08f7d.gif)