### PR TITLE
Add async/defer capability to JS loading. Defer menu scripts.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -224,8 +224,10 @@ function twentynineteen_scripts() {
 	wp_enqueue_script( 'twentynineteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
 
 	if ( has_nav_menu( 'menu-1' ) ) {
-		wp_enqueue_script( 'twentynineteen-priority-menu', get_theme_file_uri( '/js/priority-menu.js' ), array(), '1.0', true );
-		wp_enqueue_script( 'twentynineteen-touch-navigation', get_theme_file_uri( '/js/touch-keyboard-navigation.js' ), array(), '1.0', true );
+		wp_enqueue_script( 'twentynineteen-priority-menu', get_theme_file_uri( '/js/priority-menu.js' ), array(), '1.0', false );
+		wp_script_add_data( 'twentynineteen-priority-menu', 'defer', true );
+		wp_enqueue_script( 'twentynineteen-touch-navigation', get_theme_file_uri( '/js/touch-keyboard-navigation.js' ), array(), '1.0', false );
+		wp_script_add_data( 'twentynineteen-touch-navigation', 'defer', true );
 	}
 
 	wp_enqueue_style( 'twentynineteen-print-style', get_template_directory_uri() . '/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -33,6 +33,32 @@ function twentynineteen_body_classes( $classes ) {
 add_filter( 'body_class', 'twentynineteen_body_classes' );
 
 /**
+ * Adds async/defer attributes to enqueued / registered scripts.
+ *
+ * If #12009 lands in WordPress, this function can no-op since it would be handled in core.
+ *
+ * @link https://core.trac.wordpress.org/ticket/12009
+ * @param string $tag    The script tag.
+ * @param string $handle The script handle.
+ * @return array
+ */
+function twentynineteen_filter_script_loader_tag( $tag, $handle ) {
+	foreach ( array( 'async', 'defer' ) as $attr ) {
+	   if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
+		   continue;
+	   }
+		// Prevent adding attribute when already added in #12009.
+	   if ( ! preg_match( ":\s$attr(=|>|\s):", $tag ) ) {
+		   $tag = preg_replace( ':(?=></script>):', " $attr", $tag, 1 );
+	   }
+		// Only allow async or defer, not both.
+	   break;
+   }
+	return $tag;
+}
+add_filter( 'script_loader_tag', 'twentynineteen_filter_script_loader_tag', 10, 2 );
+
+/**
  * Adds custom class to the array of posts classes.
  */
 function twentynineteen_post_classes( $classes, $class, $post_id ) {


### PR DESCRIPTION
- Adds async/defer capability to JavaScript loading.
- Defers loading of `twentynineteen-priority-menu` and `twentynineteen-touch-navigation` to improve performance.

[`async`/`defer`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) is new best practice for JS loading and should be used for all enqueued JS on the front end in place of loading in footer. This feature allows control of JS loading by adding the following code to any enqueued script:

`wp_script_add_data( '[label]', '[async/defer]', true );`

Corresponds with https://core.trac.wordpress.org/ticket/12009 and gracefully falls back if/when this feature is added to core.

Code by @westonruter, originally contributed to WP Rig

Replaces #39 