### PR TITLE
Adds default white color to link for Pullquote with solid background

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -468,6 +468,10 @@ figcaption,
   color: #fff;
 }
 
+.wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) a {
+  color: #fff;
+}
+
 @media only screen and (min-width: 768px) {
   .wp-block-pullquote.is-style-solid-color blockquote {
     max-width: 80%;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -470,6 +470,10 @@ figcaption,
 
 			&:not(.has-text-color) {
 				color: $color__background-body;
+
+				a {
+					color: #fff;
+				}
 			}
 
 			@include media(tablet) {


### PR DESCRIPTION
Adds default white color to link for Pullquote with solid background.

fixes #650 

( wp.org username: xkon )