### PR TITLE
Fix link color within solid-color pullquote blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -397,6 +397,7 @@
 				margin-left: $size__spacing-unit;
 
 				&.has-text-color p,
+				&.has-text-color a,
 				&.has-primary-color,
 				&.has-secondary-color,
 				&.has-dark-gray-color,

--- a/style-editor.css
+++ b/style-editor.css
@@ -460,7 +460,9 @@ figcaption,
   max-width: calc( 100% - (2 * 1rem));
 }
 
-.wp-block-pullquote.is-style-solid-color blockquote.has-text-color p {
+.wp-block-pullquote.is-style-solid-color blockquote a,
+.wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.wp-block-pullquote.is-style-solid-color blockquote.has-text-color a {
   color: inherit;
 }
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -464,7 +464,9 @@ figcaption,
 			width: calc(100% - (2 * #{ $size__spacing-unit}));
 			max-width: calc( 100% - (2 * #{ $size__spacing-unit}));
 
-			&.has-text-color p {
+			a,
+			&.has-text-color p,
+			&.has-text-color a {
 				color: inherit;
 			}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3634,7 +3634,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
-  color: #111;
+  color: white;
+  border-color: #111;
 }
 
 .entry .entry-content .wp-block-archives,
@@ -3825,7 +3826,8 @@ body.page .main-navigation {
   margin-right: 1rem;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 

--- a/style.css
+++ b/style.css
@@ -3646,6 +3646,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+  color: white;
   border-color: #111;
 }
 
@@ -3837,7 +3838,8 @@ body.page .main-navigation {
   margin-left: 1rem;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 


### PR DESCRIPTION
Fixes #650 

Makes sure that links within solid color pullquote blocks inherit the appropriate text color. Works with:

- Default primary color, set via the Customizer
- Colors applied via the theme color swatches
- Custom colors

### Before

_Editor:_
<img width="404" alt="screen shot 2018-11-21 at 9 54 11 am" src="https://user-images.githubusercontent.com/1202812/48849467-6fa6ed00-ed74-11e8-8b05-34d3488961c8.png">

_Front-end:_
<img width="419" alt="screen shot 2018-11-21 at 9 53 28 am" src="https://user-images.githubusercontent.com/1202812/48849482-79305500-ed74-11e8-8bd6-66917947f649.png">

### After

_Editor:_
<img width="402" alt="screen shot 2018-11-21 at 9 53 44 am" src="https://user-images.githubusercontent.com/1202812/48849503-82212680-ed74-11e8-9f7f-d9063bc5837b.png">

_Front-end:_
<img width="414" alt="screen shot 2018-11-21 at 9 53 03 am" src="https://user-images.githubusercontent.com/1202812/48849537-8c432500-ed74-11e8-917a-7f0239da99b3.png">

