### PR TITLE
Try fixing social icon jumping in Safari

### DIFF
--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -28,6 +28,9 @@
 				margin-bottom: -1px;
 				transition: opacity $link_transition ease-in-out;
 
+				// Prevent icons from jumping in Safari using hardware acceleration.
+				-webkit-transform: translate3d(0, 0, 0);
+
 				&:hover,
 				&:active {
 					color: $color__text-main;

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -28,9 +28,6 @@
 				margin-bottom: -1px;
 				transition: opacity $link_transition ease-in-out;
 
-				// Prevent icons from jumping in Safari using hardware acceleration.
-				-webkit-transform: translate3d(0, 0, 0);
-
 				&:hover,
 				&:active {
 					color: $color__text-main;
@@ -47,6 +44,9 @@
 					display: block;
 					width: 32px;
 					height: 32px;
+
+					// Prevent icons from jumping in Safari using hardware acceleration.
+					transform: translateZ(0);
 
 					&#ui-icon-link {
 						transform: rotate(-45deg);

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1575,6 +1575,7 @@ body.page .main-navigation {
   color: #111;
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
+  -webkit-transform: translate3d(0, 0, 0);
 }
 
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
@@ -3634,7 +3635,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
-  color: #111;
+  color: white;
+  border-color: #111;
 }
 
 .entry .entry-content .wp-block-archives,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1575,7 +1575,6 @@ body.page .main-navigation {
   color: #111;
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
-  -webkit-transform: translate3d(0, 0, 0);
 }
 
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
@@ -1593,6 +1592,7 @@ body.page .main-navigation {
   display: block;
   width: 32px;
   height: 32px;
+  transform: translateZ(0);
 }
 
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {

--- a/style.css
+++ b/style.css
@@ -1575,7 +1575,6 @@ body.page .main-navigation {
   color: #111;
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
-  -webkit-transform: translate3d(0, 0, 0);
 }
 
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
@@ -1593,6 +1592,7 @@ body.page .main-navigation {
   display: block;
   width: 32px;
   height: 32px;
+  transform: translateZ(0);
 }
 
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {

--- a/style.css
+++ b/style.css
@@ -1575,6 +1575,7 @@ body.page .main-navigation {
   color: #111;
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
+  -webkit-transform: translate3d(0, 0, 0);
 }
 
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
@@ -3646,6 +3647,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+  color: white;
   border-color: #111;
 }
 


### PR DESCRIPTION
Fixes #648 

This PR applies a [hack](https://dev.opera.com/articles/css-will-change-property/#the-old-the-translatez-or-translate3d-hack) to our social media icons to prevent them from bouncing around on hover in Safari. Setting `transform: translate3d(0, 0, 0);` asks the `transition` to use hardware acceleration, which solves the jumpiness in this case. This _is_ a hack though, so I'd love to find a  better way to solve this. I tried using the new `will-change`  property here, but it didn't seem to solve the problem for me. 😕

To reproduce/test: 
- Use Safari (I used v12.0.1).
- Use a retina screen (I was only able to reproduce this on a retina screen)
- Visit a Twenty Nineteen site that has a Social Menu
- Check whether or not the icons jump on hover

**Before:**
![icons-broken](https://user-images.githubusercontent.com/1202812/48852269-feb70380-ed7a-11e8-8a3c-4c1e1e027a99.gif)

**After:** 
![icons-fixed](https://user-images.githubusercontent.com/1202812/48852274-01195d80-ed7b-11e8-8fa0-d23bcdeca6ed.gif)

---

cc @jasmussen in case you have some insight here too.