### PR TITLE
Revert toolbar positioning.

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -59,12 +59,6 @@ body .wp-block[data-align="full"] {
   }
 }
 
-/** === Editor Block Toolbar Position === */
-.editor-block-list__block[data-align="wide"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar,
-.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
-  max-width: none;
-}
-
 /** === Content Width === */
 .wp-block {
   width: calc(100vw - (2 * 1rem));

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -71,14 +71,6 @@ body {
 	}
 }
 
-/** === Editor Block Toolbar Position === */
-
-// Since 2019 left-aligns wide and fullwide blocks, left align the toolbar too.
-.editor-block-list__block[data-align="wide"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar,
-.editor-block-list__block[data-align="full"] .editor-block-contextual-toolbar .editor-block-toolbar.editor-block-toolbar {
-		max-width: none;
-}
-
 /** === Content Width === */
 
 .wp-block {


### PR DESCRIPTION
Fixes #665.

This PR reverts the customization to the toolbar for wide and fullwide.

It doesn't look quite as good, but it makes the block mover usable again.

Let's look at some upstream improvements instead, I have a few ideas.