### PR TITLE
Try: Decreased font size for widget titles

### DIFF
--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -1,6 +1,10 @@
 .widget {
 	margin: 0 0 #{$size__spacing-unit};
 
+	.widget-title {
+		font-size: $font__size-lg;
+	}
+
 	/* Make sure select elements fit in widgets. */
 	select {
 		max-width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3281,6 +3281,10 @@ body.page .main-navigation {
   /* Make sure select elements fit in widgets. */
 }
 
+.widget h2.widget-title {
+  font-size: 1.6875em;
+}
+
 .widget select {
   max-width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -3287,6 +3287,10 @@ body.page .main-navigation {
   /* Make sure select elements fit in widgets. */
 }
 
+.widget .widget-title {
+  font-size: 1.6875em;
+}
+
 .widget select {
   max-width: 100%;
 }


### PR DESCRIPTION
As suggested in #658. I think this works, but it's more of an enhancement than a bug fix, so I'm not sure it fits in now that we have the release candidate.

Before:
<img width="833" alt="screen shot 2018-11-26 at 10 25 42 am" src="https://user-images.githubusercontent.com/1202812/49023715-d0179f00-f165-11e8-93ae-d4e74d1f0bb0.png">

After:
<img width="914" alt="screen shot 2018-11-26 at 10 24 47 am" src="https://user-images.githubusercontent.com/1202812/49023720-d1e16280-f165-11e8-893a-a6401774c603.png">