### PR TITLE
 Try: Add a full-screen featured image toggle to the customizer

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -54,8 +54,10 @@ function twentynineteen_custom_colors_css() {
 		 * - WP Block Button
 		 * - Blocks
 		 */
-		.image-filters-enabled .site-header.featured-image .site-featured-image:before,
-		.image-filters-enabled .site-header.featured-image .site-featured-image:after,
+		.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:before,
+		.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:after,
+		.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:before,
+		.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after,
 		.image-filters-enabled .entry .post-thumbnail:before,
 		.image-filters-enabled .entry .post-thumbnail:after,
 		.main-navigation .sub-menu,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -100,6 +100,25 @@ function twentynineteen_customize_register( $wp_customize ) {
 			'type'    => 'checkbox',
 		)
 	);
+
+	// Add image filter setting and control.
+	$wp_customize->add_setting(
+		'full_screen_image',
+		array(
+			'default'           => 1,
+			'sanitize_callback' => 'absint',
+			'transport'         => 'postMessage',
+		)
+	);
+
+	$wp_customize->add_control(
+		'full_screen_image',
+		array(
+			'label'   => __( 'Use a full screen featured image on individual pages', 'twentynineteen' ),
+			'section' => 'colors',
+			'type'    => 'checkbox',
+		)
+	);
 }
 add_action( 'customize_register', 'twentynineteen_customize_register' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -28,6 +28,11 @@ function twentynineteen_body_classes( $classes ) {
 		$classes[] = 'image-filters-enabled';
 	}
 
+	// Adds a class if image filters are enabled.
+	if ( is_single() && twentynineteen_full_screen_image_enabled() ) {
+		$classes[] = 'full-screen-image-enabled';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'twentynineteen_body_classes' );
@@ -107,6 +112,16 @@ function twentynineteen_can_show_post_thumbnail() {
  */
 function twentynineteen_image_filters_enabled() {
 	if ( get_theme_mod( 'image_filter', 1 ) ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Returns true if full-screen featured images are enabled in the theme options.
+ */
+function twentynineteen_full_screen_image_enabled() {
+	if ( get_theme_mod( 'full_screen_image', 1 ) ) {
 		return true;
 	}
 	return false;

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -57,4 +57,15 @@
 		} );
 	} );
 
+	// Image treatment.
+	wp.customize( 'full_screen_image', function( value ) {
+		value.bind( function( to ) {
+			if ( to ) {
+				$( 'body' ).addClass( 'full-screen-image-enabled' );
+			} else {
+				$( 'body' ).removeClass( 'full-screen-image-enabled' );
+			}
+		} );
+	} );
+
 })( jQuery );

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -2,6 +2,134 @@
 
 .site-header.featured-image {
 
+	/* Entry header */
+	.entry-header {
+		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
+		@include postContentMaxWidth();
+
+		@include media(tablet) {
+			margin-right: $size__site-margins;
+			margin-left: $size__site-margins;
+		}
+	}
+
+	.post-thumbnail {
+		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
+
+		@include media(tablet) {
+			margin-right: $size__site-margins;
+			margin-left: $size__site-margins;
+			max-width: 100%;
+		}
+	}
+
+	/* Entry meta */
+	.site-featured-image .entry-meta {
+		font-weight: 500;
+
+		> span {
+
+			margin-right: $size__spacing-unit;
+			display: inline-block;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+
+		a {
+
+			@include link-transition;
+			color: currentColor;
+
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.svg-icon {
+			position: relative;
+			display: inline-block;
+			vertical-align: middle;
+			margin-right: 0.5em;
+		}
+
+		.discussion-avatar-list {
+			display: none;
+		}
+	}
+
+	&.has-discussion {
+
+		@include media (tablet) {
+
+			.entry-meta {
+				display: flex;
+				position: relative;
+			}
+
+			.entry-title {
+				padding-right: calc(1 * (100vw / 12) + #{$size__spacing-unit});
+			}
+
+			.entry-meta .comment-count {
+				position: absolute;
+				right: 0;
+			}
+
+			.entry-meta .discussion-avatar-list {
+				display: block;
+				position: absolute;
+				bottom: 100%;
+			}
+		}
+	}
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image {
+
+	.post-thumbnail {
+		position: relative;
+		display: block;
+
+		.post-thumbnail-inner {
+			filter: grayscale(100%);
+
+			&:after {
+				background: rgba(0, 0, 0, 0.35);
+				content: "";
+				display: block;
+				height: 100%;
+				opacity: .5;
+				pointer-events: none;
+				position: absolute;
+				top: 0;
+				width: 100%;
+				z-index: 4;
+
+				@supports (mix-blend-mode: multiply) {
+					display: none;
+				}
+			}
+		}
+
+		&:before,
+		&:after, {
+			position: absolute;
+			display: block;
+			width: 100%;
+			height: 100%;
+			top: 0; left: 0;
+			content: "\020";
+			pointer-events: none;
+		}
+
+		@include filter-duotone;
+	}
+}
+
+.full-screen-image-enabled .site-header.featured-image {
+
 	/* Hide overflow for overflowing featured image */
 	overflow: hidden;
 
@@ -85,11 +213,6 @@
 				transform: none;
 				width: 100%;
 			}
-
-			/* When image filters are active, make it grayscale to colorize it blue. */
-			.image-filters-enabled & {
-				filter: grayscale(100%);
-			}
 		}
 
 		.entry-header {
@@ -109,70 +232,6 @@
 
 				&:before {
 					background: $color__background-body;
-				}
-			}
-
-			/* Entry meta */
-
-			.entry-meta {
-
-				font-weight: 500;
-
-				> span {
-
-					margin-right: $size__spacing-unit;
-					display: inline-block;
-
-					&:last-child {
-						margin-right: 0;
-					}
-				}
-
-				a {
-
-					@include link-transition;
-					color: currentColor;
-
-					&:hover {
-						text-decoration: none;
-					}
-				}
-
-				.svg-icon {
-					position: relative;
-					display: inline-block;
-					vertical-align: middle;
-					margin-right: 0.5em;
-				}
-
-				.discussion-avatar-list {
-					display: none;
-				}
-			}
-
-			&.has-discussion {
-
-				@include media (tablet) {
-
-					.entry-meta {
-						display: flex;
-						position: relative;
-					}
-
-					.entry-title {
-						padding-right: calc(1 * (100vw / 12) + #{$size__spacing-unit});
-					}
-
-					.entry-meta .comment-count {
-						position: absolute;
-						right: 0;
-					}
-
-					.entry-meta .discussion-avatar-list {
-						display: block;
-						position: absolute;
-						bottom: 100%;
-					}
 				}
 			}
 		}
@@ -224,35 +283,65 @@
 
 	/* The intensity of each blend mode is controlled via layer opacity. */
 
+	/* Multiply layer. */
+	/* When image filters are inactive, a black overlay is added. */
+	.site-featured-image:after {
+		background: #000;
+		mix-blend-mode: multiply;
+		opacity: .7;
+	}
+
+	/* Readability overlay */
+	&:after {
+		background: #000;
+		/**
+		 * Add a transition to the readability overlay, to add a subtle
+		 * but smooth effect when resizing the screen.
+		 */
+		transition: opacity 1200ms ease-in-out;
+		opacity: 0.7;
+		z-index: 5;
+	}
+
+
+	::-moz-selection {
+		background: rgba($color__background-body, 0.17);
+	}
+
+	::selection {
+		background: rgba($color__background-body, 0.17);
+	}
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image {
+
+	/* First layer: grayscale. */
+	.site-featured-image .post-thumbnail img {
+		filter: grayscale(100%);
+	}
+
 	/* Second layer: screen. */
-	.image-filters-enabled & .site-featured-image:before {
+	.site-featured-image:before {
 		background: $color__link;
 		mix-blend-mode: screen;
 		opacity: 0.1;
 	}
 
 	/* Third layer: multiply. */
-	/* When image filters are inactive, a black overlay is added. */
+	/* When image filters are active, a blue overlay is added. */
 	.site-featured-image:after {
-		background: #000;
-		mix-blend-mode: multiply;
-		opacity: .7;
+		background: $color__link;
+		opacity: .8;
+		z-index: 3;
 
-	  	/* When image filters are active, a blue overlay is added. */
-		.image-filters-enabled & {
-			background: $color__link;
-			opacity: .8;
-			z-index: 3;
-
-			/* Browsers supporting mix-blend-mode don't need opacity < 1 */
-			@supports (mix-blend-mode: multiply) {
-				opacity: 1;
-			}
+		/* Browsers supporting mix-blend-mode don't need opacity < 1 */
+		@supports (mix-blend-mode: multiply) {
+			opacity: 1;
 		}
 	}
 
 	/* Fourth layer: overlay. */
-  	.image-filters-enabled & .site-branding-container:after {
+	.site-branding-container:after {
 		background: rgba(0, 0, 0, 0.35);
 		mix-blend-mode: overlay;
 		opacity: 0.5;
@@ -266,32 +355,12 @@
 
 	/* Fifth layer: readability overlay */
 	&:after {
-		background: #000;
-		/**
-		 * Add a transition to the readability overlay, to add a subtle
-		 * but smooth effect when resizing the screen.
-		 */
-		transition: opacity 1200ms ease-in-out;
-		opacity: 0.7;
-		z-index: 5;
-
 		/* When image filters are active, a blue overlay is added. */
-		.image-filters-enabled & {
-			background: mix($color__link, black, 12%);
-			opacity: 0.38;
+		background: mix($color__link, black, 12%);
+		opacity: 0.38;
 
-			@include media(tablet) {
-				opacity: 0.18;
-			}
+		@include media(tablet) {
+			opacity: 0.18;
 		}
-	}
-
-
-	::-moz-selection {
-		background: rgba($color__background-body, 0.17);
-	}
-
-	::selection {
-		background: rgba($color__background-body, 0.17);
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2056,6 +2056,156 @@ body.page .main-navigation {
 }
 
 .site-header.featured-image {
+  /* Entry header */
+  /* Entry meta */
+}
+
+.site-header.featured-image .entry-header {
+  margin: calc(2 * 1rem) 1rem 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .entry-header {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .site-header.featured-image .entry-header {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .entry-header {
+    margin: 1rem calc(10% + 60px) calc(3 * 1rem);
+  }
+}
+
+.site-header.featured-image .post-thumbnail {
+  margin: calc(2 * 1rem) 1rem 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .post-thumbnail {
+    margin: 1rem calc(10% + 60px) calc(3 * 1rem);
+    max-width: 100%;
+  }
+}
+
+.site-header.featured-image .site-featured-image .entry-meta {
+  font-weight: 500;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta > span {
+  margin-left: 1rem;
+  display: inline-block;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta > span:last-child {
+  margin-left: 0;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta a {
+  transition: color 110ms ease-in-out;
+  color: currentColor;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta a:hover {
+  text-decoration: none;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta .svg-icon {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.5em;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta .discussion-avatar-list {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image.has-discussion .entry-meta {
+    display: flex;
+    position: relative;
+  }
+  .site-header.featured-image.has-discussion .entry-title {
+    padding-left: calc(1 * (100vw / 12) + 1rem);
+  }
+  .site-header.featured-image.has-discussion .entry-meta .comment-count {
+    position: absolute;
+    left: 0;
+  }
+  .site-header.featured-image.has-discussion .entry-meta .discussion-avatar-list {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+  }
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail {
+  position: relative;
+  display: block;
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail .post-thumbnail-inner {
+  filter: grayscale(100%);
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail .post-thumbnail-inner:after {
+  background: rgba(0, 0, 0, 0.35);
+  content: "";
+  display: block;
+  height: 100%;
+  opacity: .5;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 4;
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail .post-thumbnail-inner:after {
+    display: none;
+  }
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:before, .image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after {
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  content: "\020";
+  pointer-events: none;
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:before {
+  background: #0073aa;
+  mix-blend-mode: screen;
+  opacity: 0.1;
+  z-index: 2;
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after {
+  background: #0073aa;
+  mix-blend-mode: multiply;
+  opacity: .8;
+  z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after {
+    opacity: 1;
+  }
+}
+
+.full-screen-image-enabled .site-header.featured-image {
   /* Hide overflow for overflowing featured image */
   overflow: hidden;
   /* Need relative positioning to properly align layers. */
@@ -2074,87 +2224,85 @@ body.page .main-navigation {
   background-repeat: no-repeat;
   background-size: cover;
   /* The intensity of each blend mode is controlled via layer opacity. */
-  /* Second layer: screen. */
-  /* Third layer: multiply. */
+  /* Multiply layer. */
   /* When image filters are inactive, a black overlay is added. */
-  /* Fourth layer: overlay. */
-  /* Fifth layer: readability overlay */
+  /* Readability overlay */
 }
 
-.site-header.featured-image .site-branding .site-title,
-.site-header.featured-image .site-branding .site-description,
-.site-header.featured-image .main-navigation a:after,
-.site-header.featured-image .main-navigation .main-menu > li.menu-item-has-children:after,
-.site-header.featured-image .main-navigation li,
-.site-header.featured-image .social-navigation li,
-.site-header.featured-image .entry-meta,
-.site-header.featured-image .entry-title {
+.full-screen-image-enabled .site-header.featured-image .site-branding .site-title,
+.full-screen-image-enabled .site-header.featured-image .site-branding .site-description,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:after,
+.full-screen-image-enabled .site-header.featured-image .main-navigation .main-menu > li.menu-item-has-children:after,
+.full-screen-image-enabled .site-header.featured-image .main-navigation li,
+.full-screen-image-enabled .site-header.featured-image .social-navigation li,
+.full-screen-image-enabled .site-header.featured-image .entry-meta,
+.full-screen-image-enabled .site-header.featured-image .entry-title {
   color: #fff;
 }
 
-.site-header.featured-image .main-navigation a,
-.site-header.featured-image .main-navigation a + svg,
-.site-header.featured-image .social-navigation a,
-.site-header.featured-image .site-title a,
-.site-header.featured-image .site-featured-image a {
+.full-screen-image-enabled .site-header.featured-image .main-navigation a,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a,
+.full-screen-image-enabled .site-header.featured-image .site-title a,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a {
   color: #fff;
   transition: opacity 110ms ease-in-out;
 }
 
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active,
-.site-header.featured-image .main-navigation a:hover + svg,
-.site-header.featured-image .main-navigation a:active + svg,
-.site-header.featured-image .main-navigation a + svg:hover,
-.site-header.featured-image .main-navigation a + svg:active,
-.site-header.featured-image .main-navigation a + svg:hover + svg,
-.site-header.featured-image .main-navigation a + svg:active + svg,
-.site-header.featured-image .social-navigation a:hover,
-.site-header.featured-image .social-navigation a:active,
-.site-header.featured-image .social-navigation a:hover + svg,
-.site-header.featured-image .social-navigation a:active + svg,
-.site-header.featured-image .site-title a:hover,
-.site-header.featured-image .site-title a:active,
-.site-header.featured-image .site-title a:hover + svg,
-.site-header.featured-image .site-title a:active + svg,
-.site-header.featured-image .site-featured-image a:hover,
-.site-header.featured-image .site-featured-image a:active,
-.site-header.featured-image .site-featured-image a:hover + svg,
-.site-header.featured-image .site-featured-image a:active + svg {
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:hover, .full-screen-image-enabled .site-header.featured-image .main-navigation a:active,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:active + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:hover,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:active,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:active + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:hover,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:active,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:active + svg,
+.full-screen-image-enabled .site-header.featured-image .site-title a:hover,
+.full-screen-image-enabled .site-header.featured-image .site-title a:active,
+.full-screen-image-enabled .site-header.featured-image .site-title a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .site-title a:active + svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:hover,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:active,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:active + svg {
   color: #fff;
   opacity: 0.6;
 }
 
-.site-header.featured-image .main-navigation a:focus,
-.site-header.featured-image .main-navigation a:focus + svg,
-.site-header.featured-image .main-navigation a + svg:focus,
-.site-header.featured-image .main-navigation a + svg:focus + svg,
-.site-header.featured-image .social-navigation a:focus,
-.site-header.featured-image .social-navigation a:focus + svg,
-.site-header.featured-image .site-title a:focus,
-.site-header.featured-image .site-title a:focus + svg,
-.site-header.featured-image .site-featured-image a:focus,
-.site-header.featured-image .site-featured-image a:focus + svg {
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:focus,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:focus,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:focus,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .site-title a:focus,
+.full-screen-image-enabled .site-header.featured-image .site-title a:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:focus,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;
 }
 
-.site-header.featured-image .social-navigation a:focus {
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:focus {
   color: #fff;
   opacity: 1;
   border-bottom: 1px solid #fff;
 }
 
-.site-header.featured-image .social-navigation svg,
-.site-header.featured-image .site-featured-image svg {
+.full-screen-image-enabled .site-header.featured-image .social-navigation svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
   -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 
-.site-header.featured-image .site-featured-image {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image {
   /* First layer: grayscale. */
 }
 
-.site-header.featured-image .site-featured-image .post-thumbnail img {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
   height: auto;
   right: 50%;
   max-width: 1000%;
@@ -2165,11 +2313,10 @@ body.page .main-navigation {
   transform: translateX(50%) translateY(-50%);
   width: auto;
   z-index: 1;
-  /* When image filters are active, make it grayscale to colorize it blue. */
 }
 
 @supports (object-fit: cover) {
-  .site-header.featured-image .site-featured-image .post-thumbnail img {
+  .full-screen-image-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
     height: 100%;
     right: 0;
     object-fit: cover;
@@ -2179,103 +2326,46 @@ body.page .main-navigation {
   }
 }
 
-.image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
-  filter: grayscale(100%);
-}
-
-.site-header.featured-image .site-featured-image .entry-header {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header {
   margin-top: calc( 4 * 1rem);
   margin-bottom: 0;
   margin-right: 0;
   margin-left: 0;
-  /* Entry meta */
 }
 
 @media only screen and (min-width: 768px) {
-  .site-header.featured-image .site-featured-image .entry-header {
+  .full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header {
     margin-right: calc(10% + 60px);
     margin-left: calc(10% + 60px);
   }
 }
 
-.site-header.featured-image .site-featured-image .entry-header .entry-title:before {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: #fff;
 }
 
-.site-header.featured-image .site-featured-image .entry-header .entry-meta {
-  font-weight: 500;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta > span {
-  margin-left: 1rem;
-  display: inline-block;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta > span:last-child {
-  margin-left: 0;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta a {
-  transition: color 110ms ease-in-out;
-  color: currentColor;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta a:hover {
-  text-decoration: none;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta .svg-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin-left: 0.5em;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
-    display: flex;
-    position: relative;
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-title {
-    padding-left: calc(1 * (100vw / 12) + 1rem);
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
-    position: absolute;
-    left: 0;
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .discussion-avatar-list {
-    display: block;
-    position: absolute;
-    bottom: 100%;
-  }
-}
-
-.site-header.featured-image .custom-logo-link {
+.full-screen-image-enabled .site-header.featured-image .custom-logo-link {
   background: #fff;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
 
-.site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
+.full-screen-image-enabled .site-header.featured-image .custom-logo-link:hover, .full-screen-image-enabled .site-header.featured-image .custom-logo-link:active, .full-screen-image-enabled .site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
 
-.site-header.featured-image .site-branding {
+.full-screen-image-enabled .site-header.featured-image .site-branding {
   position: relative;
   z-index: 10;
 }
 
-.site-header.featured-image .site-featured-image .entry-header {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header {
   position: relative;
   z-index: 9;
 }
 
-.site-header.featured-image .site-branding-container:after,
-.site-header.featured-image .site-featured-image:before,
-.site-header.featured-image .site-featured-image:after, .site-header.featured-image:after {
+.full-screen-image-enabled .site-header.featured-image .site-branding-container:after,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image:before,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image:after, .full-screen-image-enabled .site-header.featured-image:after {
   display: block;
   position: absolute;
   top: 0;
@@ -2285,47 +2375,13 @@ body.page .main-navigation {
   height: 100%;
 }
 
-.image-filters-enabled .site-header.featured-image .site-featured-image:before {
-  background: #0073aa;
-  mix-blend-mode: screen;
-  opacity: 0.1;
-}
-
-.site-header.featured-image .site-featured-image:after {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image:after {
   background: #000;
   mix-blend-mode: multiply;
   opacity: .7;
-  /* When image filters are active, a blue overlay is added. */
 }
 
-.image-filters-enabled .site-header.featured-image .site-featured-image:after {
-  background: #0073aa;
-  opacity: .8;
-  z-index: 3;
-  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
-}
-
-@supports (mix-blend-mode: multiply) {
-  .image-filters-enabled .site-header.featured-image .site-featured-image:after {
-    opacity: 1;
-  }
-}
-
-.image-filters-enabled .site-header.featured-image .site-branding-container:after {
-  background: rgba(0, 0, 0, 0.35);
-  mix-blend-mode: overlay;
-  opacity: 0.5;
-  z-index: 4;
-  /* Browsers supporting mix-blend-mode can have a light overlay */
-}
-
-@supports (mix-blend-mode: overlay) {
-  .image-filters-enabled .site-header.featured-image .site-branding-container:after {
-    background: rgba(255, 255, 255, 0.35);
-  }
-}
-
-.site-header.featured-image:after {
+.full-screen-image-enabled .site-header.featured-image:after {
   background: #000;
   /**
 		 * Add a transition to the readability overlay, to add a subtle
@@ -2334,26 +2390,72 @@ body.page .main-navigation {
   transition: opacity 1200ms ease-in-out;
   opacity: 0.7;
   z-index: 5;
-  /* When image filters are active, a blue overlay is added. */
 }
 
-.image-filters-enabled .site-header.featured-image:after {
+.full-screen-image-enabled .site-header.featured-image ::-moz-selection {
+  background: rgba(255, 255, 255, 0.17);
+}
+
+.full-screen-image-enabled .site-header.featured-image ::selection {
+  background: rgba(255, 255, 255, 0.17);
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image {
+  /* First layer: grayscale. */
+  /* Second layer: screen. */
+  /* Third layer: multiply. */
+  /* When image filters are active, a blue overlay is added. */
+  /* Fourth layer: overlay. */
+  /* Fifth layer: readability overlay */
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
+  filter: grayscale(100%);
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:before {
+  background: #0073aa;
+  mix-blend-mode: screen;
+  opacity: 0.1;
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:after {
+  background: #0073aa;
+  opacity: .8;
+  z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:after {
+    opacity: 1;
+  }
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-branding-container:after {
+  background: rgba(0, 0, 0, 0.35);
+  mix-blend-mode: overlay;
+  opacity: 0.5;
+  z-index: 4;
+  /* Browsers supporting mix-blend-mode can have a light overlay */
+}
+
+@supports (mix-blend-mode: overlay) {
+  .full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-branding-container:after {
+    background: rgba(255, 255, 255, 0.35);
+  }
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image:after {
+  /* When image filters are active, a blue overlay is added. */
   background: #000e14;
   opacity: 0.38;
 }
 
 @media only screen and (min-width: 768px) {
-  .image-filters-enabled .site-header.featured-image:after {
+  .full-screen-image-enabled.image-filters-enabled .site-header.featured-image:after {
     opacity: 0.18;
   }
-}
-
-.site-header.featured-image ::-moz-selection {
-  background: rgba(255, 255, 255, 0.17);
-}
-
-.site-header.featured-image ::selection {
-  background: rgba(255, 255, 255, 0.17);
 }
 
 /*--------------------------------------------------------------

--- a/style.css
+++ b/style.css
@@ -2062,6 +2062,158 @@ body.page .main-navigation {
 }
 
 .site-header.featured-image {
+  /* Entry header */
+  /* Entry meta */
+}
+
+.site-header.featured-image .entry-header {
+  margin: calc(2 * 1rem) 1rem 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .entry-header {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .site-header.featured-image .entry-header {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .entry-header {
+    margin-right: calc(10% + 60px);
+    margin-left: calc(10% + 60px);
+  }
+}
+
+.site-header.featured-image .post-thumbnail {
+  margin: calc(2 * 1rem) 1rem 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image .post-thumbnail {
+    margin-right: calc(10% + 60px);
+    margin-left: calc(10% + 60px);
+    max-width: 100%;
+  }
+}
+
+.site-header.featured-image .site-featured-image .entry-meta {
+  font-weight: 500;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta > span {
+  margin-right: 1rem;
+  display: inline-block;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta > span:last-child {
+  margin-right: 0;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta a {
+  transition: color 110ms ease-in-out;
+  color: currentColor;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta a:hover {
+  text-decoration: none;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta .svg-icon {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.5em;
+}
+
+.site-header.featured-image .site-featured-image .entry-meta .discussion-avatar-list {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header.featured-image.has-discussion .entry-meta {
+    display: flex;
+    position: relative;
+  }
+  .site-header.featured-image.has-discussion .entry-title {
+    padding-right: calc(1 * (100vw / 12) + 1rem);
+  }
+  .site-header.featured-image.has-discussion .entry-meta .comment-count {
+    position: absolute;
+    right: 0;
+  }
+  .site-header.featured-image.has-discussion .entry-meta .discussion-avatar-list {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+  }
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail {
+  position: relative;
+  display: block;
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail .post-thumbnail-inner {
+  filter: grayscale(100%);
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail .post-thumbnail-inner:after {
+  background: rgba(0, 0, 0, 0.35);
+  content: "";
+  display: block;
+  height: 100%;
+  opacity: .5;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 4;
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail .post-thumbnail-inner:after {
+    display: none;
+  }
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:before, .image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after {
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  content: "\020";
+  pointer-events: none;
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:before {
+  background: #0073aa;
+  mix-blend-mode: screen;
+  opacity: 0.1;
+  z-index: 2;
+}
+
+.image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after {
+  background: #0073aa;
+  mix-blend-mode: multiply;
+  opacity: .8;
+  z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .image-filters-enabled:not(.full-screen-image-enabled) .site-header.featured-image .post-thumbnail:after {
+    opacity: 1;
+  }
+}
+
+.full-screen-image-enabled .site-header.featured-image {
   /* Hide overflow for overflowing featured image */
   overflow: hidden;
   /* Need relative positioning to properly align layers. */
@@ -2080,87 +2232,85 @@ body.page .main-navigation {
   background-repeat: no-repeat;
   background-size: cover;
   /* The intensity of each blend mode is controlled via layer opacity. */
-  /* Second layer: screen. */
-  /* Third layer: multiply. */
+  /* Multiply layer. */
   /* When image filters are inactive, a black overlay is added. */
-  /* Fourth layer: overlay. */
-  /* Fifth layer: readability overlay */
+  /* Readability overlay */
 }
 
-.site-header.featured-image .site-branding .site-title,
-.site-header.featured-image .site-branding .site-description,
-.site-header.featured-image .main-navigation a:after,
-.site-header.featured-image .main-navigation .main-menu > li.menu-item-has-children:after,
-.site-header.featured-image .main-navigation li,
-.site-header.featured-image .social-navigation li,
-.site-header.featured-image .entry-meta,
-.site-header.featured-image .entry-title {
+.full-screen-image-enabled .site-header.featured-image .site-branding .site-title,
+.full-screen-image-enabled .site-header.featured-image .site-branding .site-description,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:after,
+.full-screen-image-enabled .site-header.featured-image .main-navigation .main-menu > li.menu-item-has-children:after,
+.full-screen-image-enabled .site-header.featured-image .main-navigation li,
+.full-screen-image-enabled .site-header.featured-image .social-navigation li,
+.full-screen-image-enabled .site-header.featured-image .entry-meta,
+.full-screen-image-enabled .site-header.featured-image .entry-title {
   color: #fff;
 }
 
-.site-header.featured-image .main-navigation a,
-.site-header.featured-image .main-navigation a + svg,
-.site-header.featured-image .social-navigation a,
-.site-header.featured-image .site-title a,
-.site-header.featured-image .site-featured-image a {
+.full-screen-image-enabled .site-header.featured-image .main-navigation a,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a,
+.full-screen-image-enabled .site-header.featured-image .site-title a,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a {
   color: #fff;
   transition: opacity 110ms ease-in-out;
 }
 
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active,
-.site-header.featured-image .main-navigation a:hover + svg,
-.site-header.featured-image .main-navigation a:active + svg,
-.site-header.featured-image .main-navigation a + svg:hover,
-.site-header.featured-image .main-navigation a + svg:active,
-.site-header.featured-image .main-navigation a + svg:hover + svg,
-.site-header.featured-image .main-navigation a + svg:active + svg,
-.site-header.featured-image .social-navigation a:hover,
-.site-header.featured-image .social-navigation a:active,
-.site-header.featured-image .social-navigation a:hover + svg,
-.site-header.featured-image .social-navigation a:active + svg,
-.site-header.featured-image .site-title a:hover,
-.site-header.featured-image .site-title a:active,
-.site-header.featured-image .site-title a:hover + svg,
-.site-header.featured-image .site-title a:active + svg,
-.site-header.featured-image .site-featured-image a:hover,
-.site-header.featured-image .site-featured-image a:active,
-.site-header.featured-image .site-featured-image a:hover + svg,
-.site-header.featured-image .site-featured-image a:active + svg {
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:hover, .full-screen-image-enabled .site-header.featured-image .main-navigation a:active,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:active + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:hover,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:active,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:active + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:hover,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:active,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:active + svg,
+.full-screen-image-enabled .site-header.featured-image .site-title a:hover,
+.full-screen-image-enabled .site-header.featured-image .site-title a:active,
+.full-screen-image-enabled .site-header.featured-image .site-title a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .site-title a:active + svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:hover,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:active,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:hover + svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:active + svg {
   color: #fff;
   opacity: 0.6;
 }
 
-.site-header.featured-image .main-navigation a:focus,
-.site-header.featured-image .main-navigation a:focus + svg,
-.site-header.featured-image .main-navigation a + svg:focus,
-.site-header.featured-image .main-navigation a + svg:focus + svg,
-.site-header.featured-image .social-navigation a:focus,
-.site-header.featured-image .social-navigation a:focus + svg,
-.site-header.featured-image .site-title a:focus,
-.site-header.featured-image .site-title a:focus + svg,
-.site-header.featured-image .site-featured-image a:focus,
-.site-header.featured-image .site-featured-image a:focus + svg {
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:focus,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:focus,
+.full-screen-image-enabled .site-header.featured-image .main-navigation a + svg:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:focus,
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .site-title a:focus,
+.full-screen-image-enabled .site-header.featured-image .site-title a:focus + svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:focus,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;
 }
 
-.site-header.featured-image .social-navigation a:focus {
+.full-screen-image-enabled .site-header.featured-image .social-navigation a:focus {
   color: #fff;
   opacity: 1;
   border-bottom: 1px solid #fff;
 }
 
-.site-header.featured-image .social-navigation svg,
-.site-header.featured-image .site-featured-image svg {
+.full-screen-image-enabled .site-header.featured-image .social-navigation svg,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
   -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 
-.site-header.featured-image .site-featured-image {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image {
   /* First layer: grayscale. */
 }
 
-.site-header.featured-image .site-featured-image .post-thumbnail img {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
   height: auto;
   left: 50%;
   max-width: 1000%;
@@ -2171,11 +2321,10 @@ body.page .main-navigation {
   transform: translateX(-50%) translateY(-50%);
   width: auto;
   z-index: 1;
-  /* When image filters are active, make it grayscale to colorize it blue. */
 }
 
 @supports (object-fit: cover) {
-  .site-header.featured-image .site-featured-image .post-thumbnail img {
+  .full-screen-image-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
     height: 100%;
     left: 0;
     object-fit: cover;
@@ -2185,103 +2334,46 @@ body.page .main-navigation {
   }
 }
 
-.image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
-  filter: grayscale(100%);
-}
-
-.site-header.featured-image .site-featured-image .entry-header {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header {
   margin-top: calc( 4 * 1rem);
   margin-bottom: 0;
   margin-left: 0;
   margin-right: 0;
-  /* Entry meta */
 }
 
 @media only screen and (min-width: 768px) {
-  .site-header.featured-image .site-featured-image .entry-header {
+  .full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header {
     margin-left: calc(10% + 60px);
     margin-right: calc(10% + 60px);
   }
 }
 
-.site-header.featured-image .site-featured-image .entry-header .entry-title:before {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: #fff;
 }
 
-.site-header.featured-image .site-featured-image .entry-header .entry-meta {
-  font-weight: 500;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta > span {
-  margin-right: 1rem;
-  display: inline-block;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta > span:last-child {
-  margin-right: 0;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta a {
-  transition: color 110ms ease-in-out;
-  color: currentColor;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta a:hover {
-  text-decoration: none;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta .svg-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 0.5em;
-}
-
-.site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
-  display: none;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
-    display: flex;
-    position: relative;
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-title {
-    padding-right: calc(1 * (100vw / 12) + 1rem);
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
-    position: absolute;
-    right: 0;
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .discussion-avatar-list {
-    display: block;
-    position: absolute;
-    bottom: 100%;
-  }
-}
-
-.site-header.featured-image .custom-logo-link {
+.full-screen-image-enabled .site-header.featured-image .custom-logo-link {
   background: #fff;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
 
-.site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
+.full-screen-image-enabled .site-header.featured-image .custom-logo-link:hover, .full-screen-image-enabled .site-header.featured-image .custom-logo-link:active, .full-screen-image-enabled .site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
 
-.site-header.featured-image .site-branding {
+.full-screen-image-enabled .site-header.featured-image .site-branding {
   position: relative;
   z-index: 10;
 }
 
-.site-header.featured-image .site-featured-image .entry-header {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image .entry-header {
   position: relative;
   z-index: 9;
 }
 
-.site-header.featured-image .site-branding-container:after,
-.site-header.featured-image .site-featured-image:before,
-.site-header.featured-image .site-featured-image:after, .site-header.featured-image:after {
+.full-screen-image-enabled .site-header.featured-image .site-branding-container:after,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image:before,
+.full-screen-image-enabled .site-header.featured-image .site-featured-image:after, .full-screen-image-enabled .site-header.featured-image:after {
   display: block;
   position: absolute;
   top: 0;
@@ -2291,47 +2383,13 @@ body.page .main-navigation {
   height: 100%;
 }
 
-.image-filters-enabled .site-header.featured-image .site-featured-image:before {
-  background: #0073aa;
-  mix-blend-mode: screen;
-  opacity: 0.1;
-}
-
-.site-header.featured-image .site-featured-image:after {
+.full-screen-image-enabled .site-header.featured-image .site-featured-image:after {
   background: #000;
   mix-blend-mode: multiply;
   opacity: .7;
-  /* When image filters are active, a blue overlay is added. */
 }
 
-.image-filters-enabled .site-header.featured-image .site-featured-image:after {
-  background: #0073aa;
-  opacity: .8;
-  z-index: 3;
-  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
-}
-
-@supports (mix-blend-mode: multiply) {
-  .image-filters-enabled .site-header.featured-image .site-featured-image:after {
-    opacity: 1;
-  }
-}
-
-.image-filters-enabled .site-header.featured-image .site-branding-container:after {
-  background: rgba(0, 0, 0, 0.35);
-  mix-blend-mode: overlay;
-  opacity: 0.5;
-  z-index: 4;
-  /* Browsers supporting mix-blend-mode can have a light overlay */
-}
-
-@supports (mix-blend-mode: overlay) {
-  .image-filters-enabled .site-header.featured-image .site-branding-container:after {
-    background: rgba(255, 255, 255, 0.35);
-  }
-}
-
-.site-header.featured-image:after {
+.full-screen-image-enabled .site-header.featured-image:after {
   background: #000;
   /**
 		 * Add a transition to the readability overlay, to add a subtle
@@ -2340,26 +2398,72 @@ body.page .main-navigation {
   transition: opacity 1200ms ease-in-out;
   opacity: 0.7;
   z-index: 5;
-  /* When image filters are active, a blue overlay is added. */
 }
 
-.image-filters-enabled .site-header.featured-image:after {
+.full-screen-image-enabled .site-header.featured-image ::-moz-selection {
+  background: rgba(255, 255, 255, 0.17);
+}
+
+.full-screen-image-enabled .site-header.featured-image ::selection {
+  background: rgba(255, 255, 255, 0.17);
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image {
+  /* First layer: grayscale. */
+  /* Second layer: screen. */
+  /* Third layer: multiply. */
+  /* When image filters are active, a blue overlay is added. */
+  /* Fourth layer: overlay. */
+  /* Fifth layer: readability overlay */
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
+  filter: grayscale(100%);
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:before {
+  background: #0073aa;
+  mix-blend-mode: screen;
+  opacity: 0.1;
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:after {
+  background: #0073aa;
+  opacity: .8;
+  z-index: 3;
+  /* Browsers supporting mix-blend-mode don't need opacity < 1 */
+}
+
+@supports (mix-blend-mode: multiply) {
+  .full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-featured-image:after {
+    opacity: 1;
+  }
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-branding-container:after {
+  background: rgba(0, 0, 0, 0.35);
+  mix-blend-mode: overlay;
+  opacity: 0.5;
+  z-index: 4;
+  /* Browsers supporting mix-blend-mode can have a light overlay */
+}
+
+@supports (mix-blend-mode: overlay) {
+  .full-screen-image-enabled.image-filters-enabled .site-header.featured-image .site-branding-container:after {
+    background: rgba(255, 255, 255, 0.35);
+  }
+}
+
+.full-screen-image-enabled.image-filters-enabled .site-header.featured-image:after {
+  /* When image filters are active, a blue overlay is added. */
   background: #000e14;
   opacity: 0.38;
 }
 
 @media only screen and (min-width: 768px) {
-  .image-filters-enabled .site-header.featured-image:after {
+  .full-screen-image-enabled.image-filters-enabled .site-header.featured-image:after {
     opacity: 0.18;
   }
-}
-
-.site-header.featured-image ::-moz-selection {
-  background: rgba(255, 255, 255, 0.17);
-}
-
-.site-header.featured-image ::selection {
-  background: rgba(255, 255, 255, 0.17);
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
> ⚠️ Note: This is mostly just a proof of concept, and since there's a feature-freeze on the current Release Client, this isn't going to make it into 5.0. Even so, I wanted to share this branch as a starting point in case it becomes helpful in the future, or for anyone who may want to emulate this in a child theme or plugin. 

Currently, Twenty Nineteen displays featured images as  full-screen backgrounds on single pages:

<img width="1440" alt="screen shot 2018-11-26 at 12 22 06 pm" src="https://user-images.githubusercontent.com/1202812/49030643-e88fb580-f175-11e8-8984-0266c2a17e47.png">

This often looks great, but can be problematic with smaller images (as noted in #208), or when images incorporate text:

<img width="1440" alt="screen shot 2018-11-26 at 12 23 40 pm" src="https://user-images.githubusercontent.com/1202812/49030897-91d6ab80-f176-11e8-84d3-4b2abbef7abf.png">

<img width="1429" alt="screen shot 2018-11-26 at 12 26 41 pm" src="https://user-images.githubusercontent.com/1202812/49030878-8d11f780-f176-11e8-90b3-aea8ba3848b8.png">

This PR helps theme authors deal with that by offering a theme option to opt-out of the full-screen image treatment:

![full-screen-image](https://user-images.githubusercontent.com/1202812/49030925-a5821200-f176-11e8-92d0-bbb574c968d7.gif)

This has only been lightly tested, but there are a few known issues:  

- The toggle lives within the Colors panel for now, so it can be tested alongside the custom colors implementation. It should likely move into a separate "Theme Options" panel.
- When the full-size image is turned off  (and color overlays are turned on), there's a slim color bar underneath the image. 
- The stylesheet updates are fairly messy. There's a lot of duplicated code for the color filters, and in general, this could use a refactor and cleanup. 