### PR TITLE
Add nowrap to the columns block at breakpoints above 600px

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -700,6 +700,10 @@
 			padding-right: $size__spacing-unit;
 		}
 
+		@include media(mobile) {
+			flex-wrap: nowrap;
+		}
+
 		@include media(tablet) {
 			.wp-block-column > * {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4176,6 +4176,12 @@ body.page .main-navigation {
   padding-left: 1rem;
 }
 
+@media only screen and (min-width: 600px) {
+  .entry .entry-content .wp-block-columns {
+    flex-wrap: nowrap;
+  }
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;

--- a/style.css
+++ b/style.css
@@ -4188,6 +4188,12 @@ body.page .main-navigation {
   padding-right: 1rem;
 }
 
+@media only screen and (min-width: 600px) {
+  .entry .entry-content .wp-block-columns {
+    flex-wrap: nowrap;
+  }
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;


### PR DESCRIPTION
Fixes #673 (and also [45369 on Trac](https://core.trac.wordpress.org/ticket/45369))

Gutenberg's default front-end styles use `flex-wrap: wrap` on screens narrower than `782px`, and `flex-wrap: nowrap;` on screens above `782px`. On the frontend of Twenty Nineteen, this leads to columns wrapping earlier than we intend for them to:

![columns-broken](https://user-images.githubusercontent.com/1202812/49053434-1dbff600-f1be-11e8-8f5e-5d2226efd5b8.gif)

In our case, we want to use use `flex-wrap: nowrap` on all screens above 600px wide:

![columns-fixed](https://user-images.githubusercontent.com/1202812/49053509-624b9180-f1be-11e8-8ef7-05ac37979788.gif)
