### PR TITLE
Update logic to hide comment meta when comments_open is false

### DIFF
--- a/header.php
+++ b/header.php
@@ -37,7 +37,7 @@
 						$discussion = ! is_page() && twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null;
 
 						$classes = 'entry-header';
-						if ( ! empty( $discussion ) && count( $discussion->responses ) > 0 ) {
+						if ( comments_open() && ! empty( $discussion ) && count( $discussion->responses ) > 0 ) {
 							$classes = 'entry-header has-discussion';
 						}
 					?>

--- a/image.php
+++ b/image.php
@@ -88,8 +88,8 @@ get_header();
 						)
 					);
 
-					// If comments are open or we have at least one comment, load up the comment template.
-					if ( comments_open() || get_comments_number() ) {
+					// If comments are open load up the comment template.
+					if ( comments_open() ) {
 						comments_template();
 					}
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -55,7 +55,7 @@ if ( ! function_exists( 'twentynineteen_comment_count' ) ) :
 	 * Prints HTML with the comment count for the current post.
 	 */
 	function twentynineteen_comment_count() {
-		if ( ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
+		if ( ! post_password_required() && comments_open() ) {
 			echo '<span class="comments-link">';
 			echo twentynineteen_get_icon_svg( 'comment', 16 );
 

--- a/page.php
+++ b/page.php
@@ -23,8 +23,8 @@ get_header();
 
 				get_template_part( 'template-parts/content/content', 'page' );
 
-				// If comments are open or we have at least one comment, load up the comment template.
-				if ( comments_open() || get_comments_number() ) {
+				// If comments are open load up the comment template.
+				if ( comments_open() ) {
 					comments_template();
 				}
 

--- a/single.php
+++ b/single.php
@@ -44,8 +44,8 @@ get_header();
 					);
 				}
 
-				// If comments are open or we have at least one comment, load up the comment template.
-				if ( comments_open() || get_comments_number() ) {
+				// If comments are open load up the comment template.
+				if ( comments_open() ) {
 					comments_template();
 				}
 


### PR DESCRIPTION
Switched to use comments_open() only instead of or checking get_comments_number() to avoid displaying comment meta when commenting is disabled

Fixes #676