### PR TITLE
Fix image_filter conditional function

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -13,6 +13,7 @@
  * @param array $classes Classes for the body element.
  * @return array
  */
+
 function twentynineteen_body_classes( $classes ) {
 
 	if ( is_singular() ) {
@@ -106,7 +107,7 @@ function twentynineteen_can_show_post_thumbnail() {
  * Returns true if image filters are enabled on the theme options.
  */
 function twentynineteen_image_filters_enabled() {
-	return 'inactive' !== get_theme_mod( 'image_filter', 1 );
+	return 0 !== get_theme_mod( 'image_filter', 1 );
 }
 
 /**

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -13,7 +13,6 @@
  * @param array $classes Classes for the body element.
  * @return array
  */
-
 function twentynineteen_body_classes( $classes ) {
 
 	if ( is_singular() ) {


### PR DESCRIPTION
The `image_filter` theme option conditional was mistakenly returning a string which prevented the `body_class` filter from adding the right class. This fix reverts it back to boolean so that the filter settings works properly on the frontend and in the customizer.