### PR TITLE
Add proper frontend styles for center aligned archive and category blocks 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,3 +74,4 @@ Version 1.0:
 | @mikeyarce | @mikeyarce |
 | @dingo-d | @dingo_bastard |
 | @mrxkon | @xkon |
+| @richtabor | @richtabor |

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -198,9 +198,9 @@
 		&.is-style-outline .wp-block-button__link,
 		&.is-style-outline .wp-block-button__link:focus,
 		&.is-style-outline .wp-block-button__link:active {
-			@include button-all-transition;	
+			@include button-all-transition;
 			border-width: 2px;
-			border-style: solid;		
+			border-style: solid;
 
 			&:not(.has-background) {
 				background: transparent;
@@ -784,7 +784,7 @@
 	.has-secondary-background-color,
 	.has-dark-gray-background-color,
 	.has-light-gray-background-color {
-		
+
 		// Use white text against these backgrounds by default.
 		color: $color__background-body;
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -244,6 +244,14 @@
 		}
 	}
 
+	.wp-block-archives,
+	.wp-block-categories {
+
+		&.aligncenter {
+			text-align: center;
+		}
+	}
+
 	//! Latest categories
 	.wp-block-categories {
 

--- a/style.css
+++ b/style.css
@@ -3690,6 +3690,11 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
+.entry .entry-content .wp-block-archives.aligncenter,
+.entry .entry-content .wp-block-categories.aligncenter {
+  text-align: center;
+}
+
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }


### PR DESCRIPTION
Editor on the left, Frontend on the right. <img width="2540" alt="screenshot 2018-11-28 12 26 48" src="https://user-images.githubusercontent.com/1813435/49169894-e316a480-f308-11e8-8d3e-010571185c1b.png">

Fixes #644 