### PR TITLE
Ensure the icons in the classic block toolbar always use dashicons

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -757,3 +757,8 @@ ul.wp-block-archives li ul,
   line-height: 1.6;
   color: #767676;
 }
+
+/* Make sure our non-latin font overrides don't overwrite icons in the classic editor toolbar */
+.wp-block[data-type="core/freeform"] .mce-btn i {
+  font-family: dashicons !important;
+}

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -753,3 +753,8 @@ ul.wp-block-archives,
 		}
 	}
 }
+
+/* Make sure our non-latin font overrides don't overwrite the iconfont used in the classic editor toolbar */
+.wp-block[data-type="core/freeform"] .mce-btn i {
+	font-family: dashicons !important;
+}


### PR DESCRIPTION
As per #383, our non-latin font family overrides use `!important` rules to swap in more langauge-appropriate fonts. This generally works in the editor, but [as noted here](
https://github.com/WordPress/twentynineteen/issues/602#issuecomment-439407971), it does write over the `dashicons` font family used in the toolbar of the Classic block:

![screen shot 2018-11-28 at 12 22 58 pm](https://user-images.githubusercontent.com/1202812/49169899-e742c200-f308-11e8-80ac-e0ba3afdfac1.png)

This PR applies a quick editor styles rule to ensure that these toolbar icons always use `dashicons`:

![screen shot 2018-11-28 at 12 22 29 pm](https://user-images.githubusercontent.com/1202812/49169912-ee69d000-f308-11e8-924c-c549e2bdff2a.png)

To test: 

1. Add a classic editor block
2. Change the `lang` attribute in the page's `html` tag to specify [a non-latin language](https://github.com/nielslange/twentynineteen/blob/873aaf90daf53a0d6dd57684a90502c54215d469/sass/mixins/_mixins-master.scss#L94-L175). 
3. Verify that the classic block's toolbar icons appear correct. 

---

⚠️ This fix replaces https://github.com/WordPress/twentynineteen/pull/621, and should really just be a short-term fix until we come up with a more comprehensive, better solution for swapping out font families. Using `!important` like we do is bound to break other areas as well. 