### PR TITLE
Remove duplicate rule-line when a separator block is followed by H1/H2 in the editor

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -621,6 +621,13 @@ figcaption,
   padding-left: calc(2 * 1rem);
 }
 
+/* Remove duplicate rule-line when a separator
+ * is followed by an H1, or H2 */
+.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] h1:before,
+.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] h2:before {
+  display: none;
+}
+
 /** === Latest Posts, Archives, Categories === */
 ul.wp-block-archives,
 .wp-block-categories,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -625,6 +625,21 @@ figcaption,
 	}
 }
 
+/* Remove duplicate rule-line when a separator
+ * is followed by an H1, or H2 */
+.wp-block[data-type="core/separator"] {
+
+	+ .wp-block[data-type="core/heading"] {
+
+		h1,
+		h2 {
+			&:before {
+				display: none;
+			}
+		}
+	}
+}
+
 /** === Latest Posts, Archives, Categories === */
 
 ul.wp-block-archives,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -627,15 +627,12 @@ figcaption,
 
 /* Remove duplicate rule-line when a separator
  * is followed by an H1, or H2 */
-.wp-block[data-type="core/separator"] {
+.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] {
 
-	+ .wp-block[data-type="core/heading"] {
-
-		h1,
-		h2 {
-			&:before {
-				display: none;
-			}
+	h1,
+	h2 {
+		&:before {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #660

Here's a screen recording of me adding a separator block followed by a heading block (H2). The rule-line from the H2 is removed now. No more duplicate rule-lines! 👌

## Before:
![image](https://user-images.githubusercontent.com/1813435/49172948-57a11180-f310-11e8-8d95-e93c207d6941.png)

## After:
![screenflick movie 108](https://user-images.githubusercontent.com/1813435/49172778-efeac680-f30f-11e8-8bf9-568fe4ae2d99.gif)