### PR TITLE
Fix gallery caption link color, Recompile CSS

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -578,6 +578,10 @@
 		.blocks-gallery-item:last-child {
 			margin-bottom: 16px;
 		}
+
+		figcaption a {
+			color: #fff;
+		}
 	}
 
 	//! Captions

--- a/style-editor.css
+++ b/style-editor.css
@@ -758,7 +758,7 @@ ul.wp-block-archives li ul,
   color: #767676;
 }
 
-/* Make sure our non-latin font overrides don't overwrite icons in the classic editor toolbar */
+/* Make sure our non-latin font overrides don't overwrite the iconfont used in the classic editor toolbar */
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3690,6 +3690,11 @@ body.page .main-navigation {
   text-decoration: none;
 }
 
+.entry .entry-content .wp-block-archives.aligncenter,
+.entry .entry-content .wp-block-categories.aligncenter {
+  text-align: center;
+}
+
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }
@@ -4040,6 +4045,10 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
 .entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
+}
+
+.entry .entry-content .wp-block-gallery figcaption a {
+  color: #fff;
 }
 
 .entry .entry-content .wp-block-audio figcaption,

--- a/style.css
+++ b/style.css
@@ -4059,6 +4059,10 @@ body.page .main-navigation {
   margin-bottom: 16px;
 }
 
+.entry .entry-content .wp-block-gallery figcaption a {
+  color: #fff;
+}
+
 .entry .entry-content .wp-block-audio figcaption,
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,


### PR DESCRIPTION
Links within gallery captions are currently blue: 
![screen shot 2018-11-28 at 2 39 56 pm](https://user-images.githubusercontent.com/1202812/49177776-10208280-f31c-11e8-990a-cb009f52321e.png)

This PR makes them white to match the back-end: 
![screen shot 2018-11-28 at 2 41 08 pm](https://user-images.githubusercontent.com/1202812/49177781-11ea4600-f31c-11e8-969f-209dc9918e25.png)

In addition, this PR re-compiles our CSS. It appears to be a little out of date following recent commits. 