### PR TITLE
Remove hyphens rule for cover image text

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -528,10 +528,6 @@
 			line-height: 1.25;
 			padding: 0;
 			color: #fff;
-			-ms-hyphens: auto;
-			-moz-hyphens: auto;
-			-webkit-hyphens: auto;
-			hyphens: auto;
 
 			@include media(tablet) {
 				font-size: $font__size-xl;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3967,10 +3967,6 @@ body.page .main-navigation {
   line-height: 1.25;
   padding: 0;
   color: #fff;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
 }
 
 @media only screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -3979,10 +3979,6 @@ body.page .main-navigation {
   line-height: 1.25;
   padding: 0;
   color: #fff;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
On the front-end, we add hyphens to  broken lines via `hyphens: auto`. This was intended to provide more natural line breaks, but I've found that it actually  makes the browser a little over-eager to add hyphens. In this example case, the browser is adding a hyphen in a case that would actually be better handled with a line break:

<img width="1440" alt="screen shot 2018-11-29 at 10 48 46 am" src="https://user-images.githubusercontent.com/1202812/49234110-6eee0680-f3c5-11e8-8627-d8d7701d55d4.png">

Removing the `hyphens` rule results in more readable text there: 

<img width="1440" alt="screen shot 2018-11-29 at 10 58 38 am" src="https://user-images.githubusercontent.com/1202812/49234276-bd9ba080-f3c5-11e8-91ef-3479426eda1d.png">

When removing this rule, the text still uses `word-wrap: break-word;` to prevent extremely long words from breaking the layout: 

**Before:** 

<img width="1440" alt="screen shot 2018-11-29 at 10 50 46 am" src="https://user-images.githubusercontent.com/1202812/49234387-f76ca700-f3c5-11e8-95f8-105b8e9f85d0.png">

**After:**

<img width="1440" alt="screen shot 2018-11-29 at 10 51 10 am" src="https://user-images.githubusercontent.com/1202812/49234409-fe93b500-f3c5-11e8-870e-dc8db592ca77.png">

In this use case, it'd be a little nice to include a  hyphen there, but I don't think the tradeoff is worth it because of its effect on words that don't actually need hyphens. In addition, the editor does not use hyphens for line breaks such as those, so this more closely mimics what users will see in the back-end. 