### PR TITLE
Fix `sizes` attribute for regular aligned body images. 

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -132,6 +132,27 @@ function twentynineteen_post_thumbnail_sizes_attr( $attr ) {
 add_filter( 'wp_get_attachment_image_attributes', 'twentynineteen_post_thumbnail_sizes_attr', 10, 1 );
 
 /**
+ * Add custom `sizes` attribute to responsive image functionality for post content images.
+ *
+ * @since Twenty Nineteen 1.0
+ *
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
+ *                      values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
+ */
+function twentynineteen_calculate_image_sizes_attr( $sizes ) {
+	if ( is_admin() ) {
+		return $sizes;
+	}
+
+	$sizes = '(min-width: 768px) calc(8 * (100vw / 12) - 28px), (min-width: 1168) calc(6 * 100vw/12) - 28px), calc(100% - (2 * 1rem))';
+
+	return $sizes;
+}
+add_filter( 'wp_calculate_image_sizes', 'twentynineteen_calculate_image_sizes_attr', 10, 1 );
+
+/**
  * Returns the size for avatars used in the theme.
  */
 function twentynineteen_get_avatar_size() {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -141,16 +141,20 @@ add_filter( 'wp_get_attachment_image_attributes', 'twentynineteen_post_thumbnail
  *                      values in pixels (in that order).
  * @return string A source size value for use in a content image 'sizes' attribute.
  */
-function twentynineteen_calculate_image_sizes_attr( $sizes ) {
+function twentynineteen_calculate_image_sizes_attr( $sizes, $size ) {
 	if ( is_admin() ) {
 		return $sizes;
 	}
 
-	$sizes = '(min-width: 768px) calc(8 * (100vw / 12) - 28px), (min-width: 1168) calc(6 * 100vw/12) - 28px), calc(100% - (2 * 1rem))';
+	$width = $size[0];
+
+	if ( 767 <= $width ) {
+		$sizes = '(min-width: 768px) calc(8 * (100vw / 12) - 28px), (min-width: 1168) calc(6 * 100vw/12) - 28px), calc(100% - (2 * 1rem))';
+	}
 
 	return $sizes;
 }
-add_filter( 'wp_calculate_image_sizes', 'twentynineteen_calculate_image_sizes_attr', 10, 1 );
+add_filter( 'wp_calculate_image_sizes', 'twentynineteen_calculate_image_sizes_attr', 10, 2 );
 
 /**
  * Returns the size for avatars used in the theme.


### PR DESCRIPTION
This PR fixes the incorrect `sizes` attribute for regular aligned body images. It does not solve for `alignwide` and `alignfull` images, but is an improvement over core. While we wait for the `wp_calculate_image_sizes` filter to be updated at some later date, this PR should be merged with core before 5.0 release to avoid even regularly aligned images receiving an incorrect `sizes` attribute.

This PR follows the same pattern as what is already in previous default themes including Twenty Seventeen: https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentyseventeen/functions.php#L491-L517

@kjellr I strongly recommend this be merged before 5.0 release.