### PR TITLE
Try pushing right-aligned images outside of the text column

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -509,15 +509,24 @@
 		}
 
 		.aligncenter {
+			
+			@include postContentMaxWidth();
 
 			@include media(tablet) {
-				position: relative;
-				right: calc( #{$size__site-tablet-content} / 2 );
-				transform: translateX( 50% );
+				margin: 0;
+				width: $size__site-tablet-content;
+
+				img {
+					margin: 0 auto;
+				}
 			}
 
 			@include media(desktop) {
-				right: calc( #{$size__site-desktop-content} / 2 );
+				width: $size__site-desktop-content;
+
+				img {
+					margin: 0 auto;
+				}
 			}
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -502,20 +502,31 @@
 
 	//! Image
 	.wp-block-image {
+		max-width: 100%;
 
 		img {
 			display: block;
 		}
 
-		&.alignleft,
-		&.alignright {
-			max-width: 100%;
+		.aligncenter {
+
+			@include media(tablet) {
+				position: relative;
+				right: calc( #{$size__site-tablet-content} / 2 );
+				transform: translateX( 50% );
+			}
+
+			@include media(desktop) {
+				right: calc( #{$size__site-desktop-content} / 2 );
+			}
 		}
 
 		&.alignfull img {
 			width: 100vw;
+			max-width: calc( 100% + (2 * #{$size__spacing-unit}));
 
 			@include media(tablet) {
+				max-width: calc( 125% + 150px );
 				margin-left: auto;
 				margin-right: auto;
 			}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3942,17 +3942,37 @@ body.page .main-navigation {
   display: block;
 }
 
+.entry .entry-content .wp-block-image .aligncenter {
+  margin: 0;
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    position: relative;
-    left: calc( calc(8 * (100vw / 12) - 28px) / 2);
-    transform: translateX(-50%);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    left: calc( calc(6 * (100vw / 12) - 28px) / 2);
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    width: calc(8 * (100vw / 12) - 28px);
+  }
+  .entry .entry-content .wp-block-image .aligncenter img {
+    margin: 0 auto;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    width: calc(6 * (100vw / 12) - 28px);
+  }
+  .entry .entry-content .wp-block-image .aligncenter img {
+    margin: 0 auto;
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3934,20 +3934,36 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content .wp-block-image {
+  max-width: 100%;
+}
+
 .entry .entry-content .wp-block-image img {
   display: block;
 }
 
-.entry .entry-content .wp-block-image.alignleft, .entry .entry-content .wp-block-image.alignright {
-  max-width: 100%;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    position: relative;
+    left: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    transform: translateX(-50%);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    left: calc( calc(6 * (100vw / 12) - 28px) / 2);
+  }
 }
 
 .entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
+  max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image.alignfull img {
+    max-width: calc( 125% + 150px);
     margin-right: auto;
     margin-left: auto;
   }

--- a/style.css
+++ b/style.css
@@ -3956,15 +3956,32 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    position: relative;
-    right: calc( calc(8 * (100vw / 12) - 28px) / 2);
-    transform: translateX(50%);
+    max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    right: calc( calc(6 * (100vw / 12) - 28px) / 2);
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    margin: 0;
+    width: calc(8 * (100vw / 12) - 28px);
+  }
+  .entry .entry-content .wp-block-image .aligncenter img {
+    margin: 0 auto;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    width: calc(6 * (100vw / 12) - 28px);
+  }
+  .entry .entry-content .wp-block-image .aligncenter img {
+    margin: 0 auto;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3946,20 +3946,36 @@ body.page .main-navigation {
   }
 }
 
+.entry .entry-content .wp-block-image {
+  max-width: 100%;
+}
+
 .entry .entry-content .wp-block-image img {
   display: block;
 }
 
-.entry .entry-content .wp-block-image.alignleft, .entry .entry-content .wp-block-image.alignright {
-  max-width: 100%;
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    position: relative;
+    right: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    transform: translateX(50%);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    right: calc( calc(6 * (100vw / 12) - 28px) / 2);
+  }
 }
 
 .entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
+  max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image.alignfull img {
+    max-width: calc( 125% + 150px);
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
As noted in #696, right-aligned images are supposed to float outside of the text column in both the front and back end. Currently, they're not behaving as designed on the front end. 

This PR sets the `max-width` for `wp-block-image` to 100%, allowing us push right-floated images outside the content area. It required a little adjustment to get center-aligned images to work correctly, but it seems to be pretty solid in my testing. 

When testing this PR, please be sure to test all image alignments just in case. 🤞 

**Before**
![screen shot 2018-12-03 at 10 14 54 am](https://user-images.githubusercontent.com/1202812/49382385-4c6d2d80-f6e4-11e8-9372-33cc747a11e9.png)

**After**
![screen shot 2018-12-03 at 10 14 05 am](https://user-images.githubusercontent.com/1202812/49382356-3b242100-f6e4-11e8-92f2-a09db8c4c398.png)