### PR TITLE
Ensure default outline style button has legible text on hover

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -215,6 +215,9 @@
 		&.is-style-outline .wp-block-button__link:hover {
 			color: white;
 			border-color: $color__background-button-hover;
+			&:not(.has-background) {
+				color: $color__background-button-hover;
+			}
 		}
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3658,6 +3658,10 @@ body.page .main-navigation {
   border-color: #111;
 }
 
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-text-color) {
+  color: #111;
+}
+
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3658,7 +3658,7 @@ body.page .main-navigation {
   border-color: #111;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #111;
 }
 

--- a/style.css
+++ b/style.css
@@ -3670,6 +3670,10 @@ body.page .main-navigation {
   border-color: #111;
 }
 
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+  color: #111;
+}
+
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {


### PR DESCRIPTION
Currently on hover .is-style-outline the button text is white on white. This checks that if no background color is set that it uses same hover color as border. 

Before & After:
![outline_button-hover](https://user-images.githubusercontent.com/2164566/49475781-c6351200-f7dd-11e8-9b64-feb0dc9a33dd.jpg)
