### PR TITLE
#717: Removed redundant link behaviour in touchevents js

### DIFF
--- a/js/touch-keyboard-navigation.js
+++ b/js/touch-keyboard-navigation.js
@@ -219,19 +219,9 @@
 
 				var url = event.target.getAttribute( 'href' ) ? event.target.getAttribute( 'href' ) : '';
 
-				// If there’s a link, go to it on touchend
-				if ( '#' !== url && '' !== url ) {
-					window.location = url;
-
 				// Open submenu if url is #
-				} else if ( '#' === url && event.target.nextSibling.matches('.submenu-expand') ) {
-
+				if ( '#' === url && event.target.nextSibling.matches('.submenu-expand') ) {
 					openSubMenu( event.target );
-
-				// Prevent default touch events
-				} else {
-
-					event.preventDefault();
 				}
 			}
 


### PR DESCRIPTION
AFAIK there's no need to say "If link, send the user off to the link location", because that's default behaviour of a link. Likewise there's no need to prevent that behaviour, and adding this preventdefault actually causes a console error momentarily.