### PR TITLE
Remove hidden overflow from site-header

### DIFF
--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -2,9 +2,6 @@
 
 .site-header.featured-image {
 
-	/* Hide overflow for overflowing featured image */
-	overflow: hidden;
-
 	/* Need relative positioning to properly align layers. */
 	position: relative;
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2076,8 +2076,6 @@ body.page .main-navigation {
 }
 
 .site-header.featured-image {
-  /* Hide overflow for overflowing featured image */
-  overflow: hidden;
   /* Need relative positioning to properly align layers. */
   position: relative;
   /* Add text shadow to text, to increase readability. */

--- a/style.css
+++ b/style.css
@@ -2082,8 +2082,6 @@ body.page .main-navigation {
 }
 
 .site-header.featured-image {
-  /* Hide overflow for overflowing featured image */
-  overflow: hidden;
   /* Need relative positioning to properly align layers. */
   position: relative;
   /* Add text shadow to text, to increase readability. */


### PR DESCRIPTION
- Prevents long sub-menus from getting truncated by the header height
- Fixes: #720 

Before: 
<img width="755" alt="screen shot 2018-12-09 at 2 49 32 pm" src="https://user-images.githubusercontent.com/1202812/49702864-48994980-fbc3-11e8-8752-6ca7e86e2c80.png">

After: 
![image](https://user-images.githubusercontent.com/709581/49763038-8f597300-fc99-11e8-9e76-707f741c147b.png)
