### PR TITLE
Use a button (instead of span) for the back button in the touch menu

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -211,10 +211,10 @@ function twentynineteen_add_ellipses_to_nav( $nav_menu, $args ) {
 		$nav_menu .= '</span>';
 		$nav_menu .= '<ul class="sub-menu hidden-links">';
 		$nav_menu .= '<li id="menu-item--1" class="mobile-parent-nav-menu-item menu-item--1">';
-		$nav_menu .= '<span class="menu-item-link-return">';
+		$nav_menu .= '<button class="menu-item-link-return">';
 		$nav_menu .= twentynineteen_get_icon_svg( 'chevron_left' );
 		$nav_menu .= esc_html__( 'Back', 'twentynineteen' );
-		$nav_menu .= '</span>';
+		$nav_menu .= '</button>';
 		$nav_menu .= '</li>';
 		$nav_menu .= '</ul>';
 		$nav_menu .= '</li>';
@@ -269,7 +269,7 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 		// Inject the keyboard_arrow_left SVG inside the parent nav menu item, and let the item link to the parent item.
 		// @todo Only do this for nested submenus? If on a first-level submenu, then really the link could be "#" since the desire is to remove the target entirely.
 		$link = sprintf(
-			'<span class="menu-item-link-return" tabindex="-1">%s',
+			'<button class="menu-item-link-return" tabindex="-1">%s',
 			twentynineteen_get_icon_svg( 'chevron_left', 24 )
 		);
 
@@ -284,7 +284,7 @@ function twentynineteen_add_dropdown_icons( $output, $item, $depth, $args ) {
 		// replace closing </a> with </span>
 		$output = preg_replace(
 			'#</a>#i',
-			'</span>',
+			'</button>',
 			$output,
 			1 // Limit.
 		);

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -184,7 +184,7 @@
 
 			> .menu-item-link-return {
 				width: 100%;
-				font-size: $font__size-md;
+				font-size: $font__size_base;
 				font-weight: normal;
 				text-align: left;
 			}

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -182,6 +182,13 @@
 				}
 			}
 
+			> .menu-item-link-return {
+				width: 100%;
+				font-size: $font__size-md;
+				font-weight: normal;
+				text-align: left;
+			}
+
 			> a:empty {
 				display: none;
 			}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1206,6 +1206,13 @@ body.page .main-navigation {
   background: #005177;
 }
 
+.main-navigation .sub-menu > li > .menu-item-link-return {
+  width: 100%;
+  font-size: 1.125em;
+  font-weight: normal;
+  text-align: right;
+}
+
 .main-navigation .sub-menu > li > a:empty {
   display: none;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1208,7 +1208,7 @@ body.page .main-navigation {
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
-  font-size: 1.125em;
+  font-size: 22px;
   font-weight: normal;
   text-align: right;
 }

--- a/style.css
+++ b/style.css
@@ -1208,7 +1208,7 @@ body.page .main-navigation {
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
-  font-size: 1.125em;
+  font-size: 22px;
   font-weight: normal;
   text-align: left;
 }

--- a/style.css
+++ b/style.css
@@ -1206,6 +1206,13 @@ body.page .main-navigation {
   background: #005177;
 }
 
+.main-navigation .sub-menu > li > .menu-item-link-return {
+  width: 100%;
+  font-size: 1.125em;
+  font-weight: normal;
+  text-align: left;
+}
+
 .main-navigation .sub-menu > li > a:empty {
   display: none;
 }


### PR DESCRIPTION
In the touch menu, the back button is currently a `span` tag. This PR changes it to a `button` for better semantics. 

Resolves #714.