### PR TITLE
Clean up opacity and text shadow on submenus when there's a featured image

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -169,6 +169,7 @@
 				color: $color__background-body;
 				display: block;
 				line-height: $font__line-height-heading;
+				text-shadow: none;
 				padding: calc( .5 * #{$size__spacing-unit} ) calc( 24px + #{$size__spacing-unit} ) calc( .5 * #{$size__spacing-unit} ) $size__spacing-unit;
 				white-space: nowrap;
 

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -45,6 +45,10 @@
 		}
 	}
 
+	.main-navigation .sub-menu a {
+		opacity: inherit;
+	}
+
 	/* add focus state to social media icons */
 	.social-navigation a {
 		&:focus {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1190,6 +1190,7 @@ body.page .main-navigation {
   color: #fff;
   display: block;
   line-height: 1.2;
+  text-shadow: none;
   padding: calc( .5 * 1rem) 1rem calc( .5 * 1rem) calc( 24px + 1rem);
   white-space: nowrap;
 }
@@ -2155,6 +2156,10 @@ body.page .main-navigation {
 .site-header.featured-image .site-featured-image a:focus,
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;
+}
+
+.site-header.featured-image .main-navigation .sub-menu a {
+  opacity: inherit;
 }
 
 .site-header.featured-image .social-navigation a:focus {

--- a/style.css
+++ b/style.css
@@ -1190,6 +1190,7 @@ body.page .main-navigation {
   color: #fff;
   display: block;
   line-height: 1.2;
+  text-shadow: none;
   padding: calc( .5 * 1rem) calc( 24px + 1rem) calc( .5 * 1rem) 1rem;
   white-space: nowrap;
 }
@@ -2161,6 +2162,10 @@ body.page .main-navigation {
 .site-header.featured-image .site-featured-image a:focus,
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;
+}
+
+.site-header.featured-image .main-navigation .sub-menu a {
+  opacity: inherit;
 }
 
 .site-header.featured-image .social-navigation a:focus {


### PR DESCRIPTION
On pages that have a featured image, submenu item labels were incorrectly inheriting some styles from the top-level menu text:

- The text had a small text-shadow
- The text was 0.6 opacity on hover

This unnecessarily gave the menu items a different treatment than their counterparts on pages with no featured image.

**Before:** 

<img width="599" alt="screen shot 2018-12-12 at 3 10 43 pm" src="https://user-images.githubusercontent.com/1202812/49896064-44b63300-fe20-11e8-877d-b07dea6ed666.png">

**After:**

<img width="598" alt="screen shot 2018-12-12 at 3 11 02 pm" src="https://user-images.githubusercontent.com/1202812/49896071-47188d00-fe20-11e8-966d-920edd01942f.png">
