### PR TITLE
Remove HTML from translation strings

### DIFF
--- a/image.php
+++ b/image.php
@@ -84,8 +84,7 @@ get_header();
 					// Parent post navigation.
 					the_post_navigation(
 						array(
-							'prev_text' => '<span class="meta-nav">' . __( 'Published in', 'twentynineteen' ) . '</span> ' .
-								'<span class="post-title">%title</span>',
+							'prev_text' => sprintf( '<span class="meta-nav">%s</span><br><span class="post-title">%s</span>', __( 'Published in', 'twentynineteen' ), '%title' ),
 						)
 					);
 

--- a/image.php
+++ b/image.php
@@ -84,7 +84,8 @@ get_header();
 					// Parent post navigation.
 					the_post_navigation(
 						array(
-							'prev_text' => _x( '<span class="meta-nav">Published in</span><br><span class="post-title">%title</span>', 'Parent post link', 'twentynineteen' ),
+							'prev_text' => '<span class="meta-nav">' . __( 'Published in', 'twentynineteen' ) . '</span> ' .
+								'<span class="post-title">%title</span>',
 						)
 					);
 

--- a/single.php
+++ b/single.php
@@ -27,8 +27,7 @@ get_header();
 					// Parent post navigation.
 					the_post_navigation(
 						array(
-							'prev_text' => '<span class="meta-nav">' . __( 'Published in', 'twentynineteen' ) . '</span> ' .
-								'<span class="post-title">%title</span>',
+							'prev_text' => sprintf( '<span class="meta-nav">%s</span><br><span class="post-title">%s</span>', __( 'Published in', 'twentynineteen' ), '%title' ),
 						)
 					);
 				} elseif ( is_singular( 'post' ) ) {

--- a/single.php
+++ b/single.php
@@ -27,8 +27,8 @@ get_header();
 					// Parent post navigation.
 					the_post_navigation(
 						array(
-							/* translators: %s: parent post link */
-							'prev_text' => sprintf( __( '<span class="meta-nav">Published in</span><span class="post-title">%s</span>', 'twentynineteen' ), '%title' ),
+							'prev_text' => '<span class="meta-nav">' . __( 'Published in', 'twentynineteen' ) . '</span> ' .
+								'<span class="post-title">%title</span>',
 						)
 					);
 				} elseif ( is_singular( 'post' ) ) {


### PR DESCRIPTION
Resolves #725 (and [45473](https://core.trac.wordpress.org/ticket/45473) on Trac).

We can't actually remove the HTML from here completely because we want to maintain the visual appearance: 

<img width="348" alt="screen shot 2018-12-13 at 10 05 26 am" src="https://user-images.githubusercontent.com/1202812/49947306-eb511100-febe-11e8-8b85-df361966a91e.png">

This uses the same approach proposed by `mukesh27` on Trac: https://core.trac.wordpress.org/attachment/ticket/45473/45473.patch

I'm not sure this needs inline translator comments or not. 