### PR TITLE
Remove unnecessary HTML from translation string

### DIFF
--- a/image.php
+++ b/image.php
@@ -84,7 +84,8 @@ get_header();
 					// Parent post navigation.
 					the_post_navigation(
 						array(
-							'prev_text' => _x( '<span class="meta-nav">Published in</span><br><span class="post-title">%title</span>', 'Parent post link', 'twentynineteen' ),
+							/* translators: parent post link */
+							'prev_text' => '<span class="meta-nav">' . esc_html__( 'Published in', 'twentynineteen' ) . '</span><br><span class="post-title">%title</span>',
 						)
 					);
 

--- a/single.php
+++ b/single.php
@@ -27,8 +27,8 @@ get_header();
 					// Parent post navigation.
 					the_post_navigation(
 						array(
-							/* translators: %s: parent post link */
-							'prev_text' => sprintf( __( '<span class="meta-nav">Published in</span><span class="post-title">%s</span>', 'twentynineteen' ), '%title' ),
+							/* translators: parent post link */
+							'prev_text' => '<span class="meta-nav">' . esc_html__( 'Published in', 'twentynineteen' ) . '</span><span class="post-title">%title</span>',
 						)
 					);
 				} elseif ( is_singular( 'post' ) ) {


### PR DESCRIPTION
Remove unnecessary HTML from translation string: `<span class="meta-nav">Published in</span><br><span class="post-title">%title</span>`

Closes: #725 