### PR TITLE
Bump version number to match files in Core repo.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: the WordPress team
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
 Requires at least: 4.9.6
-Tested up to: 5.0
-Stable tag: 1.0
+Tested up to: WordPress 5.0-trunk
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,8 +14,15 @@ Our 2019 default theme is designed to show off the power of the block editor. It
 
 == Changelog ==
 
+= 1.1 =
+* Released: December 19, 2018
+
+https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.1
+
 = 1.0 =
-* Initial Release
+* Released: December 6, 2018
+
+Initial Release
 
 == Resources ==
 * normalize.css, © 2012-2018 Nicolas Gallagher and Jonathan Neal, MIT

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: the WordPress team
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
 Requires at least: 4.9.6
-Tested up to: WordPress 5.0-trunk
+Tested up to: WordPress 5.0
 Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A new Gutenberg-ready theme.
 Requires at least: WordPress 4.9.6
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen

--- a/style.scss
+++ b/style.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A new Gutenberg-ready theme.
 Requires at least: WordPress 4.9.6
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen


### PR DESCRIPTION
This PR bumps the version numbers in the style.css, style.scss, and readme.txt to match what is currently in the patch for Twenty Nineteenn in this ticket:

https://core.trac.wordpress.org/ticket/45681

Fixes #744.