### PR TITLE
Add notices about the transition to Trac

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,9 @@
+Hi there! Thanks for contributing. In case you missed it in the main README, this repository will soon be archived.
+
+Moving forward, issues should be posted to Trac instead:
+
+https://core.trac.wordpress.org/newticket
+
+When you open an issue there, please begin your issue's title with "Twenty Nineteen: ", and select the "Bundled Theme" component.
+
+If you have any questions, feel free to ask in the #core-themes channel on WordPress.org slack. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Hi there! Thanks for contributing. In case you missed it in the main README, this repository will soon be archived.
+
+Moving forward, PRs should be posted as patches to Trac:
+
+1. Create an issue on Trac if one doesn't already exist there. Begin your issue's title with "Twenty Nineteen: ", and select the "Bundled Theme" component. You can create a new issue here:
+
+https://core.trac.wordpress.org/newticket
+
+2. Submit your changes as a patch to Twenty Nineteen in WordPress core, and attach it to your issue. Instructions for making a patch are here:
+
+https://make.wordpress.org/core/handbook/tutorials/working-with-patches/
+
+If you have any questions, feel free to ask in the #core-themes channel on WordPress.org slack. 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Twenty Nineteen
 
-> :warning: This repository will be archived in early 2019. All new issues and PRs should be submitted to Trac instead: 
-> 
-> https://core.trac.wordpress.org/newticket
-> 
-> Twenty Nineteen issues appear under the "Bundled Theme" component on Trac:
-> 
-> https://core.trac.wordpress.org/query?status=!closed&component=Bundled+Theme
->
-> New PRs should be submitted as patches to Twenty Nineteen in WordPress core. Instructions for making a patch are here:
->
-> https://make.wordpress.org/core/handbook/tutorials/working-with-patches/
-> 
-> When this GitHub repository is archived, unresolved issues will be moved over to Trac. If you have any questions, feel free to ask in the `#core-themes` channel on WordPress.org slack. 
+:warning: This repository will be archived in early 2019. All new issues and PRs should be submitted to Trac instead: 
+
+https://core.trac.wordpress.org/newticket
+
+Twenty Nineteen issues appear under the "Bundled Theme" component on Trac:
+
+https://core.trac.wordpress.org/query?status=!closed&component=Bundled+Theme
+
+New PRs should be submitted as patches to Twenty Nineteen in WordPress core. Instructions for making a patch are here:
+
+https://make.wordpress.org/core/handbook/tutorials/working-with-patches/
+
+When this GitHub repository is archived, unresolved issues will be moved over to Trac. If you have any questions, feel free to ask in the `#core-themes` channel on WordPress.org slack.
+
+--- 
 
 [![Build Status](https://travis-ci.org/WordPress/twentynineteen.svg?branch=master)](https://travis-ci.org/WordPress/twentynineteen)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Twenty Nineteen
 
+> :warning: This repository will be archived in early 2019. All new issues and PRs should be submitted to Trac instead: 
+> 
+> https://core.trac.wordpress.org/newticket
+> 
+> Twenty Nineteen issues appear under the "Bundled Theme" component on Trac:
+> 
+> https://core.trac.wordpress.org/query?status=!closed&component=Bundled+Theme
+>
+> New PRs should be submitted as patches to Twenty Nineteen in WordPress core. Instructions for making a patch are here:
+>
+> https://make.wordpress.org/core/handbook/tutorials/working-with-patches/
+> 
+> When this GitHub repository is archived, unresolved issues will be moved over to Trac. If you have any questions, feel free to ask in the `#core-themes` channel on WordPress.org slack. 
+
 [![Build Status](https://travis-ci.org/WordPress/twentynineteen.svg?branch=master)](https://travis-ci.org/WordPress/twentynineteen)
 
 **Contributors:** the WordPress team  


### PR DESCRIPTION
Issues and PRs in this repository are currently in the process of being transitioned to Trac. To make sure that's clear to contributors, it'd be helpful to include notices here to let them know where new issues and patches should go.

This commit adds a note to the main `README.md`, as well new [issue](https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/) & [pull request](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) templates to explain this to transition before issues/PRs are opened.