### PR TITLE
Change default link SVG icon size to 26

### DIFF
--- a/inc/icon-functions.php
+++ b/inc/icon-functions.php
@@ -42,7 +42,7 @@ function twentynineteen_nav_menu_social_icons( $item_output, $item, $depth, $arg
 	if ( 'social' === $args->theme_location ) {
 		$svg = twentynineteen_get_social_link_svg( $item->url, 26 );
 		if ( empty( $svg ) ) {
-			$svg = twentynineteen_get_icon_svg( 'link' );
+			$svg = twentynineteen_get_icon_svg( 'link', 26 );
 		}
 		$item_output = str_replace( $args->link_after, '</span>' . $svg, $item_output );
 	}


### PR DESCRIPTION
In Social Menu Walker system use SVG icon size with 26 but in default link SVG icon it will use font size 24  instead of 26 that needs to update to 26.